### PR TITLE
Flexible batch p-value threshold and gene-set resource selection

### DIFF
--- a/KE-MAPPING-API-REFERENCE.md
+++ b/KE-MAPPING-API-REFERENCE.md
@@ -200,18 +200,38 @@ These are on the main app (not under `/api/v1`), no auth required.
 
 ### GET /exports/gmt/ke-wp
 
-Download KE-WP mappings as a GMT (Gene Matrix Transposed) file.
+Download KE-WP mappings as a GMT (Gene Matrix Transposed) file. The Builder
+resolves each mapped pathway/term to its **member genes**, so the GMT contains
+gene symbols (not pathway IDs) — ready for `fgsea` / `clusterProfiler`.
 
 **Query params:** `?min_confidence=High|Medium|Low` (optional filter)
 
-**Response:** `text/plain` GMT file. Format:
+**Response:** `text/plain` GMT file. One gene set per line, tab-separated:
 ```
-KE_ID\tKE_Title\tWP_ID_1\tWP_ID_2\t...
+<KE_id>_<KE_name>_<pathway_id>\t<pathway_title>\t<gene_1>\t<gene_2>\t...
 ```
+e.g. `KE177_Increase_Mitochondrial_dysfunction_WP5241\tMitochondrial beta-oxidation\tECHS1\tACSL3\t...`.
+A single KE typically spans several lines (one per mapped pathway/term); union
+the gene columns across lines that share the same `KE<id>` token to obtain the
+KE's full gene set.
 
 ### GET /exports/gmt/ke-go
 
-Download KE-GO mappings as GMT. Same params as above.
+Download KE-GO (GO Biological Process) mappings as GMT. Same params and
+gene-level format as `ke-wp` (the descriptor column carries the `GO:nnnnnnn`
+term id in place of the WP id).
+
+### GET /exports/gmt/ke-reactome
+
+Download KE-Reactome mappings as GMT. Same params and gene-level format as
+`ke-wp` (descriptor column carries the `R-HSA-nnnnnn` pathway id).
+
+**Analyser consumption:** the Molecular AOP Analyser builds its KE→gene
+reference sets per resource. WikiPathways keeps its dedicated CSV-backed
+pipeline; **GO BP and Reactome gene sets are sourced from `/exports/gmt/ke-go`
+and `/exports/gmt/ke-reactome`** respectively (issue #55), parsed by
+`services/api_service.py::fetch_gmt_reference_sets`. Users pick which
+resource(s) feed enrichment in the single and batch analysis forms.
 
 ### GET /exports/rdf/ke-wp
 

--- a/app.py
+++ b/app.py
@@ -21,7 +21,12 @@ from config import Config, ExperimentMetadata
 from validation import validate_form_data, validate_file_upload, log_validation_error
 from helpers import load_reference_sets
 from cache_manager import cache, cached_data_loader, get_reference_cache
-from services.api_service import fetch_reference_sets_from_api, fetch_ke_wp_records, load_ke_wp_records_csv
+from services.api_service import (
+    fetch_reference_sets_from_api,
+    fetch_ke_wp_records,
+    load_ke_wp_records_csv,
+    fetch_gmt_reference_sets,
+)
 from exceptions import AOPAnalysisError, format_error_response
 from utils import cleanup_file, validate_file_path
 from services.data_service import load_and_validate_data, process_gene_expression, guess_id_type, load_aop_data
@@ -632,6 +637,9 @@ def preview():
         # Phase 14: preserve user's method and pval_threshold across HTMX re-renders
         pval_threshold=pval_threshold,
         method=request.form.get('method', 'ora'),
+        # Issue #55: preserve the gene-set resource selection across HTMX re-renders
+        # (e.g. "Update Plot"). Defaults to WikiPathways before any choice is made.
+        selected_resources=[r for r in request.form.getlist('resources') if r in VALID_RESOURCES] or list(DEFAULT_RESOURCES),
     )
 
     # HTMX swaps in just the partial — no full-page reload, no scroll-to-top.
@@ -682,6 +690,12 @@ def analyze():
             pval_threshold = None
         if pval_threshold is not None and not (0 < pval_threshold <= 1):
             return f"P-value threshold must be between 0 (exclusive) and 1 (inclusive). Got: {pval_threshold}.", 400
+
+        # Issue #55: gene-set resource selection. Unknown values are ignored and
+        # an empty selection falls back to WikiPathways (backward compatible).
+        resources = [r for r in request.form.getlist('resources') if r in VALID_RESOURCES]
+        if not resources:
+            resources = list(DEFAULT_RESOURCES)
 
         method = form_data['method']
         
@@ -734,7 +748,7 @@ def analyze():
         ke_list, edges, ke_type_map, ke_title_map = load_aop_data(aop_id)
         
         # Get cached reference sets and run enrichment analysis
-        current_reference_sets, data_source = load_cached_reference_sets()
+        current_reference_sets, data_source = load_cached_reference_sets(resources)
 
         # Pre-build gene_logfc_map so the enrichment service can derive the
         # observed Direction column ("N↑ / M↓") for each KE alongside the
@@ -922,6 +936,7 @@ def analyze():
         stored_metadata['pval_adj_column'] = pval_adj_col
         stored_metadata['significant_genes'] = len(df_processed[df_processed['significant'] == True])
         stored_metadata['data_source'] = data_source
+        stored_metadata['selected_resources'] = ", ".join(resources)
         stored_metadata['analysis_date'] = datetime.datetime.now().strftime('%Y-%m-%d %H:%M')
 
         # Save experiment metadata and results to database
@@ -935,6 +950,7 @@ def analyze():
                     'id_column': id_col,
                     'fc_column': fc_col,
                     'pval_column': pval_col,
+                    'selected_resources': ", ".join(resources),
                 }
                 
                 results_summary = {
@@ -1121,6 +1137,7 @@ def generate_report():
             network_png=network_png_data,
             software_versions=get_software_versions(),
             method=request.form.get('method') or metadata.get('method', 'ora'),  # Phase 14: forward method to report (Plan 04 consumption)
+            selected_resources=request.form.get('selected_resources') or metadata.get('selected_resources', 'WikiPathways'),  # #55: forward resources to report
         )
         
         # Generate report based on format
@@ -1169,25 +1186,30 @@ def generate_report():
 _reference_cache = get_reference_cache(Config.CACHE_DIR)
 REFERENCE_CACHE_KEY = "reference_sets_v1"
 
+# Selectable gene-set resources (issue #55). WikiPathways keeps its existing
+# CSV-backed pipeline; GO_BP and Reactome are sourced from the Builder GMT
+# exports. Each resource is cached independently so different selections don't
+# collide, then merged (union per KE) for enrichment.
+VALID_RESOURCES = ("WikiPathways", "GO_BP", "Reactome")
+DEFAULT_RESOURCES = ("WikiPathways",)
+_GMT_RESOURCE_CACHE_KEYS = {
+    "GO_BP": "reference_sets_go_v1",
+    "Reactome": "reference_sets_reactome_v1",
+}
 
-def load_cached_reference_sets():
-    """Load AOP reference gene sets with API-first strategy and disk caching.
 
-    Loading order:
-    1. Check diskcache (shared across Gunicorn workers)
-    2. Fetch from Builder API (with retry)
-    3. Fall back to local CSV files
+def _load_wikipathways_reference_sets():
+    """Load WikiPathways KE->gene sets (disk cache -> Builder API -> local CSV).
 
     Returns:
-        tuple: (reference_sets dict, data_source string)
-        data_source is one of: 'api', 'cache', 'csv'
+        tuple: (reference_sets dict, source string) where source is one of
+        'api', 'cache', 'csv'.
     """
-    # Check disk cache first
     cached = _reference_cache.get(REFERENCE_CACHE_KEY)
     if cached is not None:
         reference_sets, original_source = cached
         logger.info(
-            f"Loaded {len(reference_sets)} KE sets from disk cache "
+            f"Loaded {len(reference_sets)} WikiPathways KE sets from disk cache "
             f"(originally from {original_source})"
         )
         return reference_sets, "cache"
@@ -1201,7 +1223,7 @@ def load_cached_reference_sets():
             expire=Config.CACHE_TTL,
         )
         logger.info(
-            f"Loaded {len(reference_sets)} KE sets from Builder API, "
+            f"Loaded {len(reference_sets)} WikiPathways KE sets from Builder API, "
             f"cached for {Config.CACHE_TTL}s"
         )
         return reference_sets, "api"
@@ -1222,10 +1244,99 @@ def load_cached_reference_sets():
         expire=Config.CACHE_TTL,
     )
     logger.info(
-        f"Loaded {len(reference_sets)} KE sets from local CSV files, "
+        f"Loaded {len(reference_sets)} WikiPathways KE sets from local CSV files, "
         f"cached for {Config.CACHE_TTL}s"
     )
     return reference_sets, "csv"
+
+
+def _load_gmt_resource_reference_sets(resource):
+    """Load a GMT-backed resource (GO_BP/Reactome): disk cache -> Builder GMT export.
+
+    Unlike WikiPathways there is no local CSV fallback for these resources, so a
+    Builder outage makes the resource temporarily unavailable; the caller skips
+    it rather than failing the whole analysis.
+
+    Returns:
+        tuple: (reference_sets dict, source string) where source is 'cache' or 'api'.
+    """
+    cache_key = _GMT_RESOURCE_CACHE_KEYS[resource]
+    cached = _reference_cache.get(cache_key)
+    if cached is not None:
+        reference_sets, _ = cached
+        logger.info(
+            f"Loaded {len(reference_sets)} {resource} KE sets from disk cache"
+        )
+        return reference_sets, "cache"
+
+    reference_sets = fetch_gmt_reference_sets(Config, resource)
+    _reference_cache.set(
+        cache_key,
+        (reference_sets, "api"),
+        expire=Config.CACHE_TTL,
+    )
+    logger.info(
+        f"Loaded {len(reference_sets)} {resource} KE sets from Builder GMT export, "
+        f"cached for {Config.CACHE_TTL}s"
+    )
+    return reference_sets, "api"
+
+
+def load_cached_reference_sets(resources=DEFAULT_RESOURCES):
+    """Load and merge KE->gene reference sets for the selected resources.
+
+    Each resource is loaded (and disk-cached) independently, then the per-KE
+    gene sets are unioned across the selection. WikiPathways always resolves
+    (Builder API with a local CSV fallback); GO_BP/Reactome are skipped with a
+    warning if the Builder GMT export is unavailable, so a partial outage
+    degrades gracefully rather than failing the analysis.
+
+    Args:
+        resources: iterable of resource keys from VALID_RESOURCES. Unknown
+            values are ignored; an empty/invalid selection falls back to
+            WikiPathways.
+
+    Returns:
+        tuple: (merged reference_sets dict, data_source string). For backward
+        compatibility data_source reflects the WikiPathways component's source
+        ('api'/'cache'/'csv') when WikiPathways is selected — this drives the
+        WikiPathways pathway picker. When WikiPathways is not selected it is
+        'gmt'. A fully empty result yields 'none'.
+    """
+    selected = [r for r in resources if r in VALID_RESOURCES]
+    if not selected:
+        selected = list(DEFAULT_RESOURCES)
+
+    merged = {}
+    wp_source = None
+    loaded = []
+    for resource in selected:
+        try:
+            if resource == "WikiPathways":
+                sets, source = _load_wikipathways_reference_sets()
+                wp_source = source
+            else:
+                sets, source = _load_gmt_resource_reference_sets(resource)
+        except Exception as exc:
+            logger.warning("Resource %s unavailable (%s); skipping", resource, exc)
+            continue
+        # Build fresh sets so cached resource sets are never mutated.
+        for ke_id, genes in sets.items():
+            merged.setdefault(ke_id, set()).update(genes)
+        loaded.append(f"{resource}:{source}")
+
+    if not loaded:
+        data_source = "none"
+    elif wp_source is not None:
+        data_source = wp_source
+    else:
+        data_source = "gmt"
+
+    logger.info(
+        "Merged %d KE sets across resources [%s] (data_source=%s)",
+        len(merged), ", ".join(loaded) or "-", data_source,
+    )
+    return merged, data_source
 
 
 # Load initial reference sets
@@ -1395,6 +1506,23 @@ def batch_analyze():
     except ValueError:
         logfc_threshold = 0.0
 
+    # Parse p-value threshold (optional; blank falls back to the legacy default).
+    pval_raw = request.form.get('pval_threshold', '').strip()
+    if pval_raw:
+        try:
+            pval_threshold = float(pval_raw)
+        except ValueError:
+            return jsonify({'error': f'P-value threshold must be a number. Got: {pval_raw}.'}), 400
+        if not (0 < pval_threshold <= 1):
+            return jsonify({'error': f'P-value threshold must be between 0 (exclusive) and 1 (inclusive). Got: {pval_threshold}.'}), 400
+    else:
+        pval_threshold = Config.PVAL_CUTOFF
+
+    # Issue #55: gene-set resource selection (unknown values ignored; empty -> WikiPathways).
+    resources = [r for r in request.form.getlist('resources') if r in VALID_RESOURCES]
+    if not resources:
+        resources = list(DEFAULT_RESOURCES)
+
     filenames = request.form.getlist('filenames[]')
     condition_labels = request.form.getlist('condition_labels[]')
     doses = request.form.getlist('doses[]')
@@ -1471,7 +1599,8 @@ def batch_analyze():
             aop_id=aop_id,
             aop_label=aop_label,
             logfc_threshold=logfc_threshold,
-            pval_cutoff=Config.PVAL_CUTOFF,
+            pval_cutoff=pval_threshold,
+            selected_resources=", ".join(resources),
             id_column=id_col,
             fc_column=fc_col,
             pval_column=pval_col,
@@ -1512,7 +1641,7 @@ def batch_analyze():
         session_db.close()
 
     # Launch analysis in a background thread (returns immediately to client)
-    current_reference_sets, _ = load_cached_reference_sets()
+    current_reference_sets, _ = load_cached_reference_sets(resources)
     db_url = db_manager.db_url
     thread = threading.Thread(
         target=run_batch,

--- a/database.py
+++ b/database.py
@@ -42,7 +42,10 @@ class ExperimentRecord(Base):
     id_column = Column(String(100))
     fc_column = Column(String(100))
     pval_column = Column(String(100))
-    
+    # Issue #55: comma-separated gene-set resources used (e.g. "WikiPathways, GO_BP").
+    # NULL for pre-#55 rows (coerced to WikiPathways on read).
+    selected_resources = Column(String(255))
+
     # Analysis results summary (JSON)
     enrichment_results = Column(Text)  # JSON string of enrichment results
     gene_count = Column(Integer)
@@ -69,6 +72,7 @@ class ExperimentRecord(Base):
             'id_column': self.id_column,
             'fc_column': self.fc_column,
             'pval_column': self.pval_column,
+            'selected_resources': self.selected_resources or 'WikiPathways',  # coerce NULL (pre-#55 rows)
             'enrichment_results': json.loads(self.enrichment_results) if self.enrichment_results else None,
             'gene_count': self.gene_count,
             'significant_genes': self.significant_genes,
@@ -181,6 +185,8 @@ class BatchRecord(Base):
     # Shared analysis parameters
     logfc_threshold = Column(Float)
     pval_cutoff = Column(Float)
+    # Issue #55: comma-separated gene-set resources used (e.g. "WikiPathways, GO_BP").
+    selected_resources = Column(String(255))
 
     # Shared column mapping (same for all files in the batch)
     id_column = Column(String(100))
@@ -309,6 +315,33 @@ def _ensure_method_column(engine) -> None:
                 logger.info(f"Added 'method' column to '{table}' table (D-04 migration)")
 
 
+def _ensure_selected_resources_column(engine) -> None:
+    """Idempotent PRAGMA-then-ALTER migration for the 'selected_resources' column.
+
+    Adds ``selected_resources TEXT`` to the ``experiments`` and ``batches``
+    tables when absent (issue #55). Safe to run on every startup — the PRAGMA
+    check makes the ALTER a no-op on databases that already have the column.
+
+    Security note: the table names and column literal are module-internal
+    constants — no user-supplied input is interpolated into the SQL statements.
+
+    Args:
+        engine: SQLAlchemy engine bound to the target database.
+    """
+    for table in ('experiments', 'batches'):
+        with engine.connect() as conn:
+            result = conn.execute(text(f"PRAGMA table_info({table})"))
+            existing_cols = {row[1] for row in result}
+            if 'selected_resources' not in existing_cols:
+                conn.execute(
+                    text(f"ALTER TABLE {table} ADD COLUMN selected_resources TEXT")
+                )
+                conn.commit()
+                logger.info(
+                    f"Added 'selected_resources' column to '{table}' table (#55 migration)"
+                )
+
+
 class DatabaseManager:
     """Manager class for database operations."""
     
@@ -349,6 +382,10 @@ class DatabaseManager:
             # databases that lack it (D-04, D-06). No-op on fresh databases where
             # the column is already present from the model definition above.
             _ensure_method_column(self.engine)
+
+            # Idempotent additive migration: add 'selected_resources' column to
+            # pre-existing databases that lack it (#55). No-op on fresh databases.
+            _ensure_selected_resources_column(self.engine)
 
             # Create session factory
             self.SessionLocal = sessionmaker(
@@ -405,6 +442,7 @@ class DatabaseManager:
                 record.id_column = analysis_params.get('id_column')
                 record.fc_column = analysis_params.get('fc_column')
                 record.pval_column = analysis_params.get('pval_column')
+                record.selected_resources = analysis_params.get('selected_resources')
                 record.analysis_timestamp = datetime.now(timezone.utc).replace(tzinfo=None)
             
             # Add results summary if provided

--- a/services/api_service.py
+++ b/services/api_service.py
@@ -5,6 +5,8 @@ Provides paginated fetching with retry logic, KE ID normalisation,
 and integration with the local reference set loading pipeline.
 """
 import logging
+import re
+
 import pandas as pd
 import requests
 from requests.adapters import HTTPAdapter
@@ -13,6 +15,18 @@ from urllib3.util.retry import Retry
 from helpers import load_reference_sets
 
 logger = logging.getLogger(__name__)
+
+# Builder GMT export paths that already resolve pathways/terms to genes.
+# WikiPathways is intentionally omitted here — it keeps its existing
+# CSV-backed pipeline (see fetch_reference_sets_from_api / load_reference_sets).
+GMT_RESOURCE_PATHS = {
+    "GO_BP": "exports/gmt/ke-go",
+    "Reactome": "exports/gmt/ke-reactome",
+}
+
+# Matches the leading "KE<number>" token of a GMT descriptor column, e.g.
+# "KE177_Increase_Mitochondrial_dysfunction_WP5241" -> "177".
+_KE_ID_RE = re.compile(r"^KE\s?(\d+)_")
 
 
 def _make_api_session(retries=3, backoff_factor=1.0):
@@ -225,5 +239,95 @@ def fetch_reference_sets_from_api(config):
     logger.info(
         "Reference sets loaded: %d KE gene sets produced from API data",
         len(reference_sets),
+    )
+    return reference_sets
+
+
+def parse_gmt_reference_sets(gmt_text):
+    """Parse a Builder GMT export into KE-to-gene reference sets.
+
+    The Builder GMT format is one gene set per line, tab-separated::
+
+        KE<id>_<KE_name>_<pathway_id>\\t<pathway_title>\\t<gene>\\t<gene>...
+
+    A single KE typically spans several rows (one per mapped pathway/term);
+    genes are unioned across all rows that share the same KE.  KE IDs are
+    normalised from the ``KE<id>`` token to ``"KE:<id>"`` so they match the
+    convention used elsewhere (see :func:`fetch_reference_sets_from_api` and
+    the AOP ``ke_list`` keys consumed by enrichment).
+
+    Parameters
+    ----------
+    gmt_text : str
+        Raw GMT file contents (``text/plain``).
+
+    Returns
+    -------
+    dict[str, set[str]]
+        Mapping of KE ID (``"KE:177"``) -> set of uppercase gene symbols.
+    """
+    reference_sets = {}
+    for line in gmt_text.splitlines():
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        if len(fields) < 3:
+            continue  # descriptor + title but no genes -> nothing to add
+        match = _KE_ID_RE.match(fields[0])
+        if not match:
+            continue
+        ke_id = f"KE:{match.group(1)}"
+        genes = {g.strip().upper() for g in fields[2:] if g.strip()}
+        if not genes:
+            continue
+        reference_sets.setdefault(ke_id, set()).update(genes)
+    return reference_sets
+
+
+def fetch_gmt_reference_sets(config, resource):
+    """Fetch KE-to-gene reference sets for a resource from the Builder GMT export.
+
+    Used for resources whose genes are resolved Builder-side and exposed via the
+    GMT export endpoints (GO Biological Process and Reactome).  WikiPathways is
+    not handled here — it retains its dedicated CSV-backed pipeline.
+
+    Parameters
+    ----------
+    config : Config
+        Application config providing ``BUILDER_API_URL`` and
+        ``BUILDER_API_TIMEOUT``.
+    resource : str
+        Resource key, one of :data:`GMT_RESOURCE_PATHS` (``"GO_BP"`` or
+        ``"Reactome"``).
+
+    Returns
+    -------
+    dict[str, set[str]]
+        Mapping of KE ID -> set of gene symbols, identical in shape to the
+        WikiPathways reference sets.
+
+    Raises
+    ------
+    ValueError
+        If ``config.BUILDER_API_URL`` is unset, or ``resource`` is unknown.
+    requests.HTTPError
+        On non-2xx responses after all retries are exhausted.
+    """
+    if not config.BUILDER_API_URL:
+        raise ValueError("BUILDER_API_URL not configured; API integration is disabled")
+    if resource not in GMT_RESOURCE_PATHS:
+        raise ValueError(f"Unknown GMT resource: {resource!r}")
+
+    url = f"{config.BUILDER_API_URL.rstrip('/')}/{GMT_RESOURCE_PATHS[resource]}"
+    session = _make_api_session()
+    response = session.get(url, timeout=config.BUILDER_API_TIMEOUT)
+    response.raise_for_status()
+
+    reference_sets = parse_gmt_reference_sets(response.text)
+    logger.info(
+        "Loaded %d KE gene sets for resource %s from GMT export %s",
+        len(reference_sets),
+        resource,
+        url,
     )
     return reference_sets

--- a/services/batch_service.py
+++ b/services/batch_service.py
@@ -296,7 +296,9 @@ def _run_condition(
     )
 
     # Process gene expression (applies significance flags)
-    df_processed, _ = process_gene_expression(df_raw, batch.logfc_threshold or 0.0)
+    df_processed, _ = process_gene_expression(
+        df_raw, batch.logfc_threshold or 0.0, pval_threshold=batch.pval_cutoff
+    )
 
     # Apply harmonisation: restrict to genes present in all batch files
     df_filtered = df_processed[df_processed['ID'].isin(harmonised_genes)].copy()

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -93,6 +93,11 @@ class ReportData:
     # compatible. Plan 04 reads this field to branch report header and table columns.
     method: str = 'ora'
 
+    # Issue #55: gene-set resources used for enrichment (display string, e.g.
+    # "WikiPathways, GO_BP"). Defaulted so existing ReportData(...) constructions
+    # remain compatible.
+    selected_resources: str = 'WikiPathways'
+
     # System information
     analysis_timestamp: datetime = None
     software_versions: Optional[Dict[str, str]] = None
@@ -324,6 +329,10 @@ class ReportGenerator:
                 <div class="param-item">
                     <label>Method:</label>
                     <span>{report_data.method_label}</span>
+                </div>
+                <div class="param-item">
+                    <label>Gene Set Resources:</label>
+                    <span>{report_data.selected_resources}</span>
                 </div>
                 <div class="param-item">
                     <label>Selected AOP:</label>
@@ -899,6 +908,7 @@ class ReportGenerator:
         summary_data = [
             ['Metric', 'Value'],
             ['Method', report_data.method_label],
+            ['Gene Set Resources', report_data.selected_resources],
             ['Filename', report_data.filename],
             ['Total Genes', f"{report_data.gene_count:,}"],
             ['Significant Genes', f"{report_data.significant_genes:,}"],

--- a/templates/_batch_analysis.html
+++ b/templates/_batch_analysis.html
@@ -180,6 +180,41 @@
             </div>
         </div>
 
+        <h3>P-value Threshold</h3>
+        <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
+            Genes with a raw p-value below this threshold are flagged as significant for
+            Fisher's exact test. Applied equally to all conditions. Default 0.05.
+        </p>
+        <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 24px;">
+            <label for="pval-threshold" style="font-weight: 600; color: #29235C; font-size: 14px;">
+                p-value threshold:
+            </label>
+            <input type="number" id="pval-threshold" name="pval_threshold"
+                   value="0.05" step="0.001" min="0.001" max="1"
+                   title="Genes with raw p-value below this threshold are flagged as significant for Fisher's exact. Default 0.05."
+                   style="width: 80px; display: inline-block; margin: 0; padding: 6px 8px;">
+        </div>
+
+        <h3>Gene Set Resources</h3>
+        <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
+            Curated KE gene-set resources to enrich against. Genes are pooled across the
+            selected resources. Applied equally to all conditions.
+        </p>
+        <div style="display: flex; flex-direction: column; gap: 6px; margin-bottom: 24px;">
+            <label style="font-size: 14px; color: #29235C;">
+                <input type="checkbox" class="batch-resource" value="WikiPathways" checked>
+                WikiPathways
+            </label>
+            <label style="font-size: 14px; color: #29235C;">
+                <input type="checkbox" class="batch-resource" value="GO_BP">
+                Gene Ontology (Biological Process)
+            </label>
+            <label style="font-size: 14px; color: #29235C;">
+                <input type="checkbox" class="batch-resource" value="Reactome">
+                Reactome
+            </label>
+        </div>
+
         <div class="wizard-nav">
             <button id="btn-back-tag" class="btn btn--secondary">Back</button>
             <button id="btn-analyze" class="btn btn--primary">Start Batch Analysis</button>

--- a/templates/_batch_analysis_scripts.html
+++ b/templates/_batch_analysis_scripts.html
@@ -558,6 +558,10 @@ document.getElementById('btn-analyze').addEventListener('click', function() {
     payload.append('batch_uuid', batchUuid);
     payload.append('aop_selection', aopId);
     payload.append('logfc_threshold', document.getElementById('logfc-threshold').value);
+    payload.append('pval_threshold', document.getElementById('pval-threshold').value);
+    document.querySelectorAll('.batch-resource:checked').forEach(function(cb) {
+        payload.append('resources', cb.value);
+    });
     payload.append('batch_name', document.getElementById('batch-name').value.trim());
     payload.append('owner', document.getElementById('batch-owner').value.trim());
     payload.append('description', document.getElementById('batch-desc').value.trim());

--- a/templates/_single_analysis.html
+++ b/templates/_single_analysis.html
@@ -424,6 +424,31 @@
                 <ul id="aop_suggestions" class="typeahead-dropdown" hidden></ul>
             </div>
         </div>
+
+        <fieldset style="margin: 0 auto 20px; max-width: 600px; border: 1px solid #ddd; padding: 12px;">
+            <legend style="color: #29235C; font-weight: 700; padding: 0 8px;">Gene set resources</legend>
+            <p style="font-size: 13px; color: #666; margin: 0 0 10px;">
+                Choose which curated KE gene-set resources to enrich against. Genes are pooled
+                across the selected resources.
+            </p>
+            {% set sel_resources = selected_resources or ['WikiPathways'] %}
+            <label style="display: block; margin-bottom: 6px;">
+                <input type="checkbox" name="resources" value="WikiPathways"
+                       {% if 'WikiPathways' in sel_resources %}checked{% endif %}>
+                WikiPathways
+            </label>
+            <label style="display: block; margin-bottom: 6px;">
+                <input type="checkbox" name="resources" value="GO_BP"
+                       {% if 'GO_BP' in sel_resources %}checked{% endif %}>
+                Gene Ontology (Biological Process)
+            </label>
+            <label style="display: block;">
+                <input type="checkbox" name="resources" value="Reactome"
+                       {% if 'Reactome' in sel_resources %}checked{% endif %}>
+                Reactome
+            </label>
+        </fieldset>
+
         <button type="submit" title="Run enrichment analysis based on selected threshold and genes.">
             Run Enrichment Analysis
         </button>

--- a/templates/_single_analysis_scripts.html
+++ b/templates/_single_analysis_scripts.html
@@ -228,6 +228,34 @@
     applyMethod();
 })();
 
+// IIFE: keep the gene-set resource selection alive across "Update Plot" (#55).
+// The resource checkboxes live in #enrichmentForm, but Update Plot submits
+// #volcanoForm, so mirror the checked resources into hidden inputs on
+// #volcanoForm. /preview echoes them back via selected_resources, so the boxes
+// stay checked after the HTMX swap. Re-runs on every partial swap.
+(function () {
+    const volcanoForm = document.getElementById('volcanoForm');
+    const checkboxes = document.querySelectorAll('input[name="resources"]');
+    if (!volcanoForm || !checkboxes.length) return;
+
+    function syncResources() {
+        volcanoForm.querySelectorAll('input[data-resource-mirror]').forEach(el => el.remove());
+        checkboxes.forEach(cb => {
+            if (cb.checked) {
+                const hidden = document.createElement('input');
+                hidden.type = 'hidden';
+                hidden.name = 'resources';
+                hidden.value = cb.value;
+                hidden.setAttribute('data-resource-mirror', '');
+                volcanoForm.appendChild(hidden);
+            }
+        });
+    }
+
+    checkboxes.forEach(cb => cb.addEventListener('change', syncResources));
+    syncResources();
+})();
+
 // Globals exposed for inline onclick handlers in _single_analysis.html.
 function setThreshold(value) {
     document.getElementById('logfc_threshold').value = value;

--- a/templates/results.html
+++ b/templates/results.html
@@ -310,6 +310,10 @@
                 <span class="metadata-summary__label">Significant Genes</span>
                 <span class="metadata-summary__value">{{ metadata.get('significant_genes', 0) }}</span>
             </div>
+            <div class="metadata-summary__item">
+                <span class="metadata-summary__label">Gene Set Resources</span>
+                <span class="metadata-summary__value">{{ metadata.get('selected_resources', 'WikiPathways') }}</span>
+            </div>
             {% if metadata.get('analysis_date') %}
             <div class="metadata-summary__item">
                 <span class="metadata-summary__label">Analysed</span>

--- a/tests/test_api_service.py
+++ b/tests/test_api_service.py
@@ -1,0 +1,85 @@
+"""Tests for the Builder API client service (issue #55 GMT resource loading)."""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from services.api_service import (
+    parse_gmt_reference_sets,
+    fetch_gmt_reference_sets,
+    GMT_RESOURCE_PATHS,
+)
+
+
+# A small GMT fixture mirroring the live Builder exports: one gene set per line,
+# tab-separated, with the descriptor column encoding "KE<id>_<name>_<pathway_id>".
+SAMPLE_GMT = (
+    "KE177_Increase_Mitochondrial_dysfunction_WP5241\tMito beta-oxidation\tECHS1\tACSL3\tACADL\n"
+    "KE177_Increase_Mitochondrial_dysfunction_WP78\tTCA cycle\tDLD\tECHS1\n"  # ECHS1 repeats
+    "KE55_Increase_Cell_injury_R-HSA-5357769\tCaspase activation\tCASP3\tCASP8\n"
+    "\n"  # blank line -> skipped
+    "KE999_No_genes_WP1\tEmpty set\n"  # descriptor + title only, no genes -> skipped
+    "malformed_line_without_ke_token\tTitle\tGENEX\n"  # no KE token -> skipped
+)
+
+
+class TestParseGmtReferenceSets:
+    """Tests for GMT text parsing into KE->gene reference sets."""
+
+    def test_unions_genes_across_pathways_per_ke(self):
+        result = parse_gmt_reference_sets(SAMPLE_GMT)
+        # KE:177 unions WP5241 + WP78 genes, de-duplicating ECHS1.
+        assert result["KE:177"] == {"ECHS1", "ACSL3", "ACADL", "DLD"}
+
+    def test_separate_kes_kept_apart(self):
+        result = parse_gmt_reference_sets(SAMPLE_GMT)
+        assert result["KE:55"] == {"CASP3", "CASP8"}
+
+    def test_ke_id_normalised_with_colon(self):
+        result = parse_gmt_reference_sets(SAMPLE_GMT)
+        assert all(k.startswith("KE:") for k in result)
+
+    def test_blank_geneless_and_malformed_lines_skipped(self):
+        result = parse_gmt_reference_sets(SAMPLE_GMT)
+        # KE:999 had no genes; malformed line had no KE token.
+        assert "KE:999" not in result
+        assert all("GENEX" not in genes for genes in result.values())
+
+    def test_genes_uppercased(self):
+        result = parse_gmt_reference_sets("KE1_x_WP1\tTitle\tabc\tDef\n")
+        assert result["KE:1"] == {"ABC", "DEF"}
+
+    def test_empty_input_returns_empty_dict(self):
+        assert parse_gmt_reference_sets("") == {}
+
+
+class TestFetchGmtReferenceSets:
+    """Tests for fetching + parsing a resource GMT export from the Builder."""
+
+    def _config(self, url="https://builder.example.com"):
+        cfg = MagicMock()
+        cfg.BUILDER_API_URL = url
+        cfg.BUILDER_API_TIMEOUT = 10
+        return cfg
+
+    def test_fetches_and_parses(self):
+        mock_resp = MagicMock()
+        mock_resp.text = SAMPLE_GMT
+        mock_resp.raise_for_status = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+
+        import services.api_service as api_svc
+        with patch.object(api_svc, "_make_api_session", return_value=mock_session):
+            result = fetch_gmt_reference_sets(self._config(), "GO_BP")
+
+        # Correct endpoint hit for the resource.
+        called_url = mock_session.get.call_args[0][0]
+        assert called_url.endswith(GMT_RESOURCE_PATHS["GO_BP"])
+        assert result["KE:177"] == {"ECHS1", "ACSL3", "ACADL", "DLD"}
+
+    def test_unknown_resource_raises(self):
+        with pytest.raises(ValueError):
+            fetch_gmt_reference_sets(self._config(), "NotAResource")
+
+    def test_unset_builder_url_raises(self):
+        with pytest.raises(ValueError):
+            fetch_gmt_reference_sets(self._config(url=""), "Reactome")

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -80,6 +80,25 @@ class TestProcessGeneExpression:
         # Only B (1.5) and C (2.0) have |logFC| >= 1.0
         assert stats['significant_genes'] == 2
 
+    def test_pval_threshold_honoured(self):
+        """A custom p-value threshold controls which genes are flagged significant."""
+        df = self._make_df(['A', 'B', 'C'], [2.0, 2.0, 2.0], [0.03, 0.07, 0.2])
+        # Stricter than default 0.05: only A (0.03) qualifies.
+        strict, strict_stats = process_gene_expression(df, logfc_threshold=0.0, pval_threshold=0.05)
+        assert strict_stats['significant_genes'] == 1
+        assert bool(strict[strict['ID'] == 'A']['significant'].iloc[0]) is True
+        assert bool(strict[strict['ID'] == 'B']['significant'].iloc[0]) is False
+        # Looser threshold lets B (0.07) through too.
+        loose, loose_stats = process_gene_expression(df, logfc_threshold=0.0, pval_threshold=0.1)
+        assert loose_stats['significant_genes'] == 2
+
+    def test_pval_threshold_none_uses_default(self):
+        """When pval_threshold is None, the legacy Config.PVAL_CUTOFF (0.05) applies."""
+        df = self._make_df(['A', 'B'], [2.0, 2.0], [0.04, 0.06])
+        result, stats = process_gene_expression(df, logfc_threshold=0.0, pval_threshold=None)
+        assert stats['significant_genes'] == 1
+        assert bool(result[result['ID'] == 'A']['significant'].iloc[0]) is True
+
     def test_duplicate_genes_combined(self):
         """Duplicate gene IDs should be combined via Fisher's method."""
         df = self._make_df(['BRCA1', 'BRCA1', 'TP53'],

--- a/tests/test_reference_resources.py
+++ b/tests/test_reference_resources.py
@@ -1,0 +1,66 @@
+"""Tests for multi-resource reference-set merging in app.load_cached_reference_sets (#55)."""
+from unittest.mock import patch
+
+import app
+
+
+class TestLoadCachedReferenceSets:
+    """Merge + graceful-degradation behaviour across gene-set resources."""
+
+    def test_default_is_wikipathways_only(self):
+        wp = {"KE:1": {"A", "B"}}
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")) as wp_loader, \
+             patch.object(app, "_load_gmt_resource_reference_sets") as gmt_loader:
+            sets, source = app.load_cached_reference_sets()
+        wp_loader.assert_called_once()
+        gmt_loader.assert_not_called()
+        assert sets == {"KE:1": {"A", "B"}}
+        # data_source reflects the WikiPathways component for picker compatibility.
+        assert source == "csv"
+
+    def test_unions_genes_across_resources(self):
+        wp = {"KE:1": {"A", "B"}}
+        go = {"KE:1": {"B", "C"}, "KE:2": {"D"}}
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+             patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
+            sets, source = app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
+        assert sets == {"KE:1": {"A", "B", "C"}, "KE:2": {"D"}}
+        assert source == "api"  # WikiPathways source still drives data_source
+
+    def test_does_not_mutate_source_sets(self):
+        wp = {"KE:1": {"A"}}
+        go = {"KE:1": {"B"}}
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+             patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
+            app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
+        # Cached per-resource sets are untouched by the merge.
+        assert wp == {"KE:1": {"A"}}
+        assert go == {"KE:1": {"B"}}
+
+    def test_gmt_failure_degrades_to_working_resources(self):
+        wp = {"KE:1": {"A"}}
+
+        def _boom(resource):
+            raise RuntimeError("builder GMT export unavailable")
+
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+             patch.object(app, "_load_gmt_resource_reference_sets", side_effect=_boom):
+            sets, source = app.load_cached_reference_sets(["WikiPathways", "Reactome"])
+        # Reactome skipped; WikiPathways retained -> analysis still runs.
+        assert sets == {"KE:1": {"A"}}
+        assert source == "api"
+
+    def test_unknown_resource_falls_back_to_default(self):
+        wp = {"KE:1": {"A"}}
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")) as wp_loader:
+            sets, source = app.load_cached_reference_sets(["bogus"])
+        wp_loader.assert_called_once()
+        assert sets == {"KE:1": {"A"}}
+
+    def test_gmt_only_selection_sets_gmt_source(self):
+        go = {"KE:1": {"X"}}
+        with patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
+            sets, source = app.load_cached_reference_sets(["GO_BP"])
+        assert sets == {"KE:1": {"X"}}
+        # No WikiPathways component -> data_source is 'gmt' (picker falls back to CSV).
+        assert source == "gmt"


### PR DESCRIPTION
Implements #54 and #55.

## #54 — Flexible p-value threshold in batch analysis
Single analysis already exposed a validated p-value threshold; batch hardcoded `Config.PVAL_CUTOFF` (0.05). This adds a p-value input to the batch wizard, validates it in `batch_analyze()` (blank → default), stores it on `BatchRecord.pval_cutoff`, and passes it through `process_gene_expression` per condition.

## #55 — Select gene sets by resource (WikiPathways / GO BP / Reactome)
Previously the analyser built KE→gene sets from WikiPathways only. GO BP and Reactome gene sets are now sourced from the Builder GMT exports (`/exports/gmt/ke-go`, `/exports/gmt/ke-reactome`), which already resolve terms/pathways to genes.

- `fetch_gmt_reference_sets` parses the GMT and unions genes per KE; WikiPathways keeps its existing CSV-backed pipeline.
- `load_cached_reference_sets(resources)` loads each resource with its own cache key, merges (union per KE), and **degrades gracefully** if a GMT resource is unavailable (keeps the working resources).
- Resource selector added to single and batch analysis (default WikiPathways), **sticky** across single-analysis "Update Plot" re-renders.
- Choice persisted on `ExperimentRecord`/`BatchRecord` (additive SQLite migration) and surfaced on the results page and in HTML/PDF reports.
- `KE-MAPPING-API-REFERENCE.md` GMT section corrected (exports return genes) and analyser consumption documented.

## Testing
- `pytest`: 213 passing, incl. new tests for GMT parsing/fetch, multi-resource merge + graceful degradation, and batch p-value behaviour.
- Headless-browser UAT on the PXR demo: resource selector renders + stays sticky across re-render; live GO BP/Reactome GMT fetch and merge; AOP:2 enrichment with WikiPathways + Reactome; results page shows "Gene Set Resources: WikiPathways, Reactome".

## Notes
- GO BP / Reactome currently have approved Builder mappings for only a few KEs (GO BP: KE:214/55/57; Reactome: KE:177/55). The feature works; broader coverage is a Builder-side curation task.
- Deploy is analyser-only (Builder unchanged).

Closes #54
Closes #55
