### PR TITLE
Stop Dependabot managing the pip lockfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 version: 2
+
+# No "pip" ecosystem here, deliberately. requirements.txt / requirements-dev.txt are
+# pip-compile locks that must be regenerated inside python:3.11-bookworm so the pins match
+# the image (see CLAUDE.md). Dependabot edits the lock in place on whatever it resolves on,
+# which is exactly what that workflow forbids. Bump the loose specs in requirements.in and
+# recompile instead.
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Removes the `pip` ecosystem from `.github/dependabot.yml`, keeping `github-actions` and `docker`.

`requirements.txt` / `requirements-dev.txt` are pip-compile locks that must be regenerated inside `python:3.11-bookworm` or the pins stop matching the deployed image (see `CLAUDE.md`). Dependabot edits the lock in place, resolving on whatever interpreter it happens to run on — precisely what that workflow forbids. Enabling the ecosystem yesterday produced four such PRs within minutes (#91–#94), each proposing a hand-edit to a generated file.

Python dependency bumps go through `requirements.in` + a recompile instead. Actions and Docker updates are genuinely useful and stay enabled.