### PR TITLE
Populate the AOP picker from the Builder when SPARQL is down (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Added
 
+- **The AOP picker can now be populated from the molAOP Builder** (#3). The Builder gained
+  `GET /api/v1/aops` (builder #207), which returns whole AOPs — title, KE count, and mapping
+  coverage split across WikiPathways / GO / Reactome — rather than the bare KE IDs that were
+  all `ke_aop_context` could offer. `services/aop_discovery_service.fetch_aops_from_builder`
+  consumes it as a new third tier, so a SPARQL outage now leaves a picker holding **274
+  curated AOPs with titles** instead of the five entries in `Config.CASE_STUDY_AOPS`. Cached
+  for one hour rather than the usual week, since that list omits every unmapped AOP and
+  should not outlive the outage that produced it.
+
+  The live SPARQL cross-reference stays primary: the Builder's AOP membership comes from a
+  precomputed snapshot, which had gone four months without a refresh and was undercounting
+  (AOP 625: 15 KEs of 18) until builder #207 regenerated it.
+
 - Repository tooling brought in line with the molAOP Builder: CI workflow (test matrix,
   flake8, coverage, startup smoke test), code-quality workflow (ruff/black/isort, bandit,
   pip-audit), Dependabot, CODEOWNERS, issue and pull-request templates, `LICENSE` (GPL-2.0),

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The backend is organized into modular services under `services/`:
 | `gene_id_validator.py` | Gene symbol validation and normalization |
 | `batch_service.py` | Multi-file batch analysis orchestration |
 | `comparison_service.py` | Cross-condition comparison and heatmap generation |
-| `aop_discovery_service.py` | AOP search and typeahead suggestions |
+| `aop_discovery_service.py` | AOP search and typeahead suggestions (four-tier: cache → SPARQL + Builder → Builder alone → bundled fallback) |
 | `sparql_service.py` | SPARQL queries for AOP-Wiki data |
 | `pathway_picker_service.py` | WikiPathways picker data for the results-page Pathway view |
 | `api_service.py` | REST API client for the upstream molAOP Builder (KE→pathway mappings) |

--- a/docs/KE-MAPPING-API-REFERENCE.md
+++ b/docs/KE-MAPPING-API-REFERENCE.md
@@ -194,6 +194,56 @@ Get a single KE-GO mapping by UUID. Same shape as list response `data[]` items.
 
 ---
 
+### GET /api/v1/aops
+
+List the AOPs the Builder knows about, each with its Key Event count and how many
+of those KEs carry approved mappings, split per resource. Added 2026-07-21
+(builder #207) so the analyser's AOP picker can be populated from the Builder
+rather than only from AOP-Wiki SPARQL.
+
+**Query params** (all optional):
+
+| Param | Meaning |
+|---|---|
+| `mapped_only` | `true` returns only AOPs with at least one mapped KE |
+| `q` | case-insensitive substring filter over `aop_id` and `aop_title` |
+| `page` / `per_page` | pagination (default 50, max 200) |
+| `format=csv` | CSV instead of JSON |
+
+**Response** — sorted by `mapped_ke_count` descending:
+
+```json
+{
+  "data": [
+    {
+      "aop_id": "AOP 625",
+      "aop_title": "Increased 11\u03b2-Hydroxysteroid dehydrogenase type 1 ...",
+      "ke_count": 18,
+      "mapped_ke_count": 18,
+      "wikipathways_ke_count": 18,
+      "go_ke_count": 2,
+      "reactome_ke_count": 2
+    }
+  ],
+  "pagination": { "page": 1, "per_page": 50, "total": 274, "total_pages": 6, "next": "...", "prev": null }
+}
+```
+
+> **`aop_id` uses a space, not a colon** — `"AOP 625"`, matching `ke_aop_context`
+> on mapping records and `ke_id` (`"KE 1790"`). The analyser normalises to
+> `"AOP:625"` in `services/aop_discovery_service.fetch_aops_from_builder`.
+
+> **AOP membership is a snapshot, not live SPARQL.** It comes from the Builder's
+> precomputed `data/ke_aop_membership.json`, the same source behind
+> `ke_aop_context`. It went four months without a refresh before 2026-07-21, during
+> which it undercounted KEs (AOP 625 reported 15 of 18) and omitted AOPs entirely
+> (AOP 638). This is why the analyser uses the endpoint as a **fallback tier** and
+> keeps the live SPARQL cross-reference as its primary source of coverage counts.
+> If the numbers here disagree with AOP-Wiki, the snapshot is due a refresh
+> (`scripts/precompute_ke_aop_membership.py`, then copy to the `/app/data` mount).
+
+---
+
 ## Bulk Export Endpoints
 
 These are on the main app (not under `/api/v1`), no auth required.

--- a/services/aop_discovery_service.py
+++ b/services/aop_discovery_service.py
@@ -1,12 +1,14 @@
 """
 AOP Discovery Service.
 
-Provides a three-tier fallback mechanism for fetching the list of all AOPs
+Provides a four-tier fallback mechanism for fetching the list of all AOPs
 with their KE counts and KE-gene mapping coverage:
 
     1. Disk cache (1-week TTL, shared across Gunicorn workers)
     2. Live fetch: SPARQL (all AOPs + KE membership) + Builder API (mapped KE IDs)
-    3. Hardcoded fallback from Config.CASE_STUDY_AOPS
+    3. Builder API alone (GET /api/v1/aops) — whole AOPs with titles and
+       coverage counts, so a SPARQL outage still leaves a usable picker
+    4. Hardcoded fallback from Config.CASE_STUDY_AOPS
 
 Each AOP entry has the shape::
 
@@ -35,6 +37,11 @@ AOP_LIST_CACHE_KEY = "aop_discovery_list_v1"
 
 # 1-week TTL in seconds
 AOP_LIST_CACHE_TTL = 7 * 24 * 3600
+
+# TTL for the degraded Builder-only list (1 hour). Short on purpose: that list
+# holds only AOPs with mappings, so it should not outlive the SPARQL outage
+# that produced it.
+AOP_LIST_BUILDER_CACHE_TTL = 3600
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +258,66 @@ def fetch_mapped_ke_ids_from_builder(config) -> Set[str]:
         return set()
 
 
+def fetch_aops_from_builder(config) -> List[Dict]:
+    """Fetch the Builder's own AOP list from ``GET /api/v1/aops``.
+
+    Unlike :func:`fetch_mapped_ke_ids_from_builder`, which returns only KE IDs
+    and therefore needs a SPARQL KE->AOP map to be useful, this endpoint hands
+    back whole AOPs with titles and coverage counts.  That makes it usable as a
+    standalone source for the picker when AOP-Wiki SPARQL is unreachable.
+
+    Its AOP membership comes from the Builder's precomputed AOP-Wiki snapshot,
+    so it is only as current as the last refresh on that side — which is why it
+    backs a fallback tier rather than replacing the live SPARQL cross-reference.
+
+    Args:
+        config: Application config object (needs ``BUILDER_API_URL`` and
+                ``BUILDER_API_TIMEOUT``).
+
+    Returns:
+        List of AOP dicts in the standard shape, with ``aop_id`` normalised
+        from the Builder's ``"AOP 625"`` to the analyser's ``"AOP:625"``.
+        Empty list if the Builder is unset, unreachable, or returns nothing.
+    """
+    if not config.BUILDER_API_URL:
+        logger.info("BUILDER_API_URL is empty; skipping Builder AOP fetch")
+        return []
+
+    try:
+        from services.api_service import _make_api_session
+
+        session = _make_api_session()
+        base = config.BUILDER_API_URL.rstrip("/")
+        url = f"{base}/api/v1/aops"
+        params = {"mapped_only": "true", "per_page": 200}
+
+        aops: List[Dict] = []
+        while url is not None:
+            response = session.get(url, params=params, timeout=config.BUILDER_API_TIMEOUT)
+            response.raise_for_status()
+            payload = response.json()
+
+            for row in payload.get("data", []):
+                raw_id = row.get("aop_id", "")
+                if not raw_id:
+                    continue
+                aops.append({
+                    "aop_id": raw_id.replace(" ", ":"),
+                    "title": row.get("aop_title") or raw_id,
+                    "ke_count": int(row.get("ke_count") or 0),
+                    "mapped_ke_count": int(row.get("mapped_ke_count") or 0),
+                })
+
+            url = (payload.get("pagination") or {}).get("next")
+            params = {}  # the next URL already carries its query string
+
+        logger.info("Builder API: fetched %d mapped AOPs from /api/v1/aops", len(aops))
+        return aops
+
+    except Exception as exc:
+        logger.warning("Builder AOP fetch failed: %s", exc)
+        return []
+
 # ---------------------------------------------------------------------------
 # AOP list builder
 # ---------------------------------------------------------------------------
@@ -447,10 +514,30 @@ def get_aop_list(config) -> List[Dict]:
             return aops
     except Exception as exc:
         logger.error(
-            "build_aop_list failed; falling back to hardcoded list: %s", exc
+            "build_aop_list failed; trying the Builder AOP list: %s", exc
         )
 
-    # --- Tier 3: hardcoded fallback ---
+    # --- Tier 3: Builder-only list ---
+    # SPARQL is what fails here (build_aop_list propagates only its errors), and
+    # the Builder can name whole AOPs on its own. Falling straight through to a
+    # handful of configured entries would hide every curated AOP the picker
+    # exists to offer.
+    builder_aops = fetch_aops_from_builder(config)
+    if builder_aops:
+        # Deliberately a shorter TTL than the full list: this one is missing
+        # every AOP without mappings, so the next request should retry SPARQL
+        # rather than serve a partial list for a week.
+        reference_cache.set(
+            AOP_LIST_CACHE_KEY, builder_aops, expire=AOP_LIST_BUILDER_CACHE_TTL
+        )
+        logger.warning(
+            "Using Builder AOP list (%d mapped AOPs, TTL %ds) — SPARQL unavailable",
+            len(builder_aops),
+            AOP_LIST_BUILDER_CACHE_TTL,
+        )
+        return builder_aops
+
+    # --- Tier 4: hardcoded fallback ---
     fallback = _hardcoded_aop_list()
     logger.warning(
         "Using hardcoded AOP fallback (%d entries)", len(fallback)

--- a/tests/test_aop_discovery.py
+++ b/tests/test_aop_discovery.py
@@ -158,7 +158,11 @@ class TestGetAopListFallback:
     """Tests for get_aop_list three-tier fallback logic."""
 
     def test_fallback_to_hardcoded_when_both_fail(self, tmp_path):
-        """When SPARQL and cache both fail, hardcoded list is returned."""
+        """With no cache, no SPARQL and no Builder, the hardcoded list is returned.
+
+        _make_config leaves BUILDER_API_URL empty, so the Builder tier returns
+        nothing without touching the network and the chain reaches tier 4.
+        """
         from services.aop_discovery_service import get_aop_list
 
         config = _make_config(cache_dir=str(tmp_path))
@@ -374,3 +378,170 @@ class TestLoadAopDataDefaultSparql:
 
         mock_sparql.assert_called_once()
         assert result[0] == {"KE:200"}
+
+
+# ---------------------------------------------------------------------------
+# Builder-sourced AOP list (GET /api/v1/aops)
+# ---------------------------------------------------------------------------
+
+class TestFetchAopsFromBuilder:
+    """Tests for fetch_aops_from_builder."""
+
+    @staticmethod
+    def _payload(rows, next_url=None):
+        return {"data": rows, "pagination": {"next": next_url}}
+
+    def test_empty_url_returns_empty_list(self):
+        """No Builder configured must not raise, and must not fabricate AOPs."""
+        from services.aop_discovery_service import fetch_aops_from_builder
+
+        assert fetch_aops_from_builder(_make_config(builder_url="")) == []
+
+    def test_normalises_ids_and_shape(self):
+        """Builder's "AOP 625" becomes the analyser's "AOP:625"."""
+        from services.aop_discovery_service import fetch_aops_from_builder
+
+        rows = [{
+            "aop_id": "AOP 625",
+            "aop_title": "Increased 11B-HSD leading to metabolic syndrome",
+            "ke_count": 18,
+            "mapped_ke_count": 18,
+            "wikipathways_ke_count": 18,
+            "go_ke_count": 2,
+            "reactome_ke_count": 2,
+        }]
+        session = MagicMock()
+        session.get.return_value.json.return_value = self._payload(rows)
+
+        import services.api_service as api_svc
+        with patch.object(api_svc, "_make_api_session", return_value=session):
+            result = fetch_aops_from_builder(_make_config(builder_url="https://b.example.com"))
+
+        assert result == [{
+            "aop_id": "AOP:625",
+            "title": "Increased 11B-HSD leading to metabolic syndrome",
+            "ke_count": 18,
+            "mapped_ke_count": 18,
+        }]
+
+    def test_follows_pagination(self):
+        """All pages are collected, not just the first."""
+        from services.aop_discovery_service import fetch_aops_from_builder
+
+        page1 = self._payload(
+            [{"aop_id": "AOP 1", "aop_title": "One", "ke_count": 3, "mapped_ke_count": 1}],
+            next_url="https://b.example.com/api/v1/aops?page=2",
+        )
+        page2 = self._payload(
+            [{"aop_id": "AOP 2", "aop_title": "Two", "ke_count": 4, "mapped_ke_count": 2}]
+        )
+        session = MagicMock()
+        session.get.return_value.json.side_effect = [page1, page2]
+
+        import services.api_service as api_svc
+        with patch.object(api_svc, "_make_api_session", return_value=session):
+            result = fetch_aops_from_builder(_make_config(builder_url="https://b.example.com"))
+
+        assert [a["aop_id"] for a in result] == ["AOP:1", "AOP:2"]
+
+    def test_builder_failure_returns_empty_list(self):
+        """A Builder outage degrades to empty, never an exception.
+
+        get_aop_list relies on this: the Builder tier must be skippable so the
+        hardcoded tier can still answer.
+        """
+        from services.aop_discovery_service import fetch_aops_from_builder
+
+        session = MagicMock()
+        session.get.side_effect = RuntimeError("connection refused")
+
+        import services.api_service as api_svc
+        with patch.object(api_svc, "_make_api_session", return_value=session):
+            result = fetch_aops_from_builder(_make_config(builder_url="https://b.example.com"))
+
+        assert result == []
+
+    def test_rows_without_aop_id_are_skipped(self):
+        """A malformed row must not produce an entry with an empty ID."""
+        from services.aop_discovery_service import fetch_aops_from_builder
+
+        rows = [
+            {"aop_id": "", "aop_title": "No ID", "ke_count": 1, "mapped_ke_count": 1},
+            {"aop_id": "AOP 7", "aop_title": "Fine", "ke_count": 2, "mapped_ke_count": 1},
+        ]
+        session = MagicMock()
+        session.get.return_value.json.return_value = self._payload(rows)
+
+        import services.api_service as api_svc
+        with patch.object(api_svc, "_make_api_session", return_value=session):
+            result = fetch_aops_from_builder(_make_config(builder_url="https://b.example.com"))
+
+        assert [a["aop_id"] for a in result] == ["AOP:7"]
+
+
+class TestBuilderFallbackTier:
+    """get_aop_list falls through to the Builder when SPARQL is unavailable."""
+
+    def test_builder_list_used_when_sparql_fails(self, tmp_path):
+        """A SPARQL outage yields the Builder's AOPs, not five hardcoded ones."""
+        from services.aop_discovery_service import get_aop_list
+
+        builder_aops = [
+            {"aop_id": "AOP:624", "title": "A", "ke_count": 18, "mapped_ke_count": 18},
+            {"aop_id": "AOP:130", "title": "B", "ke_count": 11, "mapped_ke_count": 11},
+        ]
+        config = _make_config(cache_dir=str(tmp_path))
+
+        with patch("services.aop_discovery_service.build_aop_list",
+                   side_effect=RuntimeError("SPARQL down")), \
+             patch("services.aop_discovery_service.fetch_aops_from_builder",
+                   return_value=builder_aops):
+            result = get_aop_list(config)
+
+        assert result == builder_aops
+
+    def test_builder_list_cached_with_short_ttl(self, tmp_path):
+        """The degraded list is cached, but must not outlive the outage.
+
+        It omits every unmapped AOP, so caching it for the full week would keep
+        a partial list in place long after SPARQL recovered.
+        """
+        import diskcache
+        from services.aop_discovery_service import (
+            AOP_LIST_BUILDER_CACHE_TTL, AOP_LIST_CACHE_KEY, AOP_LIST_CACHE_TTL,
+            get_aop_list,
+        )
+
+        assert AOP_LIST_BUILDER_CACHE_TTL < AOP_LIST_CACHE_TTL
+
+        builder_aops = [{"aop_id": "AOP:1", "title": "A", "ke_count": 3, "mapped_ke_count": 2}]
+        config = _make_config(cache_dir=str(tmp_path))
+
+        with patch("services.aop_discovery_service.build_aop_list",
+                   side_effect=RuntimeError("SPARQL down")), \
+             patch("services.aop_discovery_service.fetch_aops_from_builder",
+                   return_value=builder_aops):
+            get_aop_list(config)
+
+        # Must match get_reference_cache's FanoutCache sharding — a plain
+        # Cache reads only shard 0 and would report a miss.
+        dc = diskcache.FanoutCache(directory=str(tmp_path), shards=8)
+        try:
+            assert dc.get(AOP_LIST_CACHE_KEY) == builder_aops
+        finally:
+            dc.close()
+
+    def test_hardcoded_tier_still_reachable_when_builder_empty(self, tmp_path):
+        """Both SPARQL and Builder down still leaves a usable picker."""
+        from services.aop_discovery_service import get_aop_list
+
+        config = _make_config(cache_dir=str(tmp_path))
+
+        with patch("services.aop_discovery_service.build_aop_list",
+                   side_effect=RuntimeError("SPARQL down")), \
+             patch("services.aop_discovery_service.fetch_aops_from_builder",
+                   return_value=[]):
+            result = get_aop_list(config)
+
+        assert len(result) > 0
+        assert all("aop_id" in a for a in result)


### PR DESCRIPTION
Closes #3. Pairs with **molAOP-builder #207**, which is already merged and deployed.

## Why #3 was never really done

The Builder could only be asked *which KE IDs have mappings*. Turning that into a list of AOPs needed a SPARQL KE→AOP map anyway, so the picker was never Builder-driven — and when AOP-Wiki was unreachable the whole list collapsed to the five entries in `Config.CASE_STUDY_AOPS`. A user in that window sees a tool that appears to know about almost no AOPs.

## What changed

The Builder now serves whole AOPs via `GET /api/v1/aops` — title, KE count, and coverage split across WikiPathways / GO / Reactome. `services/aop_discovery_service.fetch_aops_from_builder` consumes it as a **new third tier**:

| Tier | Source | On a SPARQL outage |
|---|---|---|
| 1 | disk cache (1 week) | — |
| 2 | SPARQL + Builder cross-reference | fails |
| **3** | **Builder `/api/v1/aops` alone** | **274 AOPs, with titles** |
| 4 | `Config.CASE_STUDY_AOPS` | was 5 entries |

Cached for **one hour**, not the usual week: that list omits every unmapped AOP, so it must not outlive the outage that produced it.

## SPARQL stays primary, deliberately

The Builder's AOP membership is a precomputed snapshot, not a live query, and it had gone four months without a refresh — long enough to report AOP 625 as 15 KEs when AOP-Wiki says 18, and to omit AOP 638 entirely. Builder #207 regenerated it (verified: AOP 625 now reports 18/18), but a snapshot that can silently age is not something to promote to primary source of truth. The API reference documents this explicitly so the next reader doesn't "simplify" it.

## Contract correction

`docs/KE-MAPPING-API-REFERENCE.md` and the parent `CLAUDE.md` documented `GET /api/v1/kes` and `/api/v1/pathways` as entity-lookup endpoints. **Neither has ever existed** — both 404, and the v1 blueprint only ever defined `mappings`, `go-mappings` and `reactome-mappings`. An earlier comment on #3 reasoned from those phantom endpoints. Corrected, with `/aops` documented in full.

## Verification

417 tests pass (409 before + 8 new): ID normalisation `"AOP 625"` → `"AOP:625"`, pagination across pages, graceful empty on Builder failure, malformed-row skipping, the new tier firing when SPARQL raises, the short-TTL cache write, and tier 4 still reachable when the Builder is also down. Exercised against the live Builder: 274 AOPs, all IDs normalised and unique, multi-page pagination followed.