### PR TITLE
Resolve WikiPathways gene membership from the Builder, not a snapshot (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,29 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 - Design-token layer in `static/css/main.css` mirroring the Builder's `:root` block —
   VHP4Safety palette, spacing, radius, shadow and z-index scales as CSS custom properties.
 
+### Fixed
+
+- **WikiPathways gene membership no longer comes only from a bundled snapshot** (#79).
+  KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was
+  resolved against `data/edges_wpid_to_gene.csv` — a snapshot topping out at `WP5452`. Any
+  pathway curated since resolved to **no genes at all**, silently, because the merge is an
+  inner join. 8 of the 79 live-mapped pathways were affected; 8 Key Events lost every gene
+  they had and were reported as *"no gene set mapped"*, which is the opposite of what
+  happened — they are curated, and the tool could not resolve them. It also quietly deflated
+  the WikiPathways coverage that a resource comparison reports, while the run advertised its
+  provenance as `WikiPathways (Builder API, live)`: the *mappings* were live, the gene
+  membership behind them was not.
+
+  Membership now comes from the Builder's own KE-WP GMT export, per pathway, with the
+  bundled CSV still covering anything the Builder does not answer for. Concretely: KE 1115
+  (Reactive oxygen species) goes from excluded-entirely to 49 genes, KE 1392 from 33 to 73,
+  KE 177 from 109 to 115, and the reference sets grow from 87 to 90 Key Events.
+
+  Three pathways (`WP1234`, `WP3980`, `WP4010`) resolve in neither source — `WP1234` is a
+  404 upstream. Those are now **named in a warning** on the results page and in the run's
+  provenance rather than disappearing, so a Key Event that looks uncovered can be told apart
+  from one that genuinely is.
+
 ### Changed
 
 - Page-specific CSS moved out of the templates into `static/css/pages/`.

--- a/app.py
+++ b/app.py
@@ -1468,26 +1468,34 @@ def _load_wikipathways_reference_sets(min_confidence=DEFAULT_MIN_CONFIDENCE):
     cache_key = _confidence_cache_key(REFERENCE_CACHE_KEY, min_confidence)
     cached = _reference_cache.get(cache_key)
     if cached is not None:
-        reference_sets, original_source = cached
+        # Entries written before #79 are 2-tuples; treat them as "nothing known
+        # to be unresolved" rather than invalidating a warm cache on deploy.
+        if len(cached) == 3:
+            reference_sets, original_source, unresolved = cached
+        else:
+            reference_sets, original_source = cached
+            unresolved = []
         logger.info(
             f"Loaded {len(reference_sets)} WikiPathways KE sets from disk cache "
             f"(originally from {original_source}, min_confidence={min_confidence})"
         )
-        return reference_sets, f"cache({original_source})"
+        return reference_sets, f"cache({original_source})", unresolved
 
     # Try API
     try:
-        reference_sets = fetch_reference_sets_from_api(Config, min_confidence=min_confidence)
+        reference_sets, unresolved = fetch_reference_sets_from_api(
+            Config, min_confidence=min_confidence
+        )
         _reference_cache.set(
             cache_key,
-            (reference_sets, "api"),
+            (reference_sets, "api", unresolved),
             expire=Config.CACHE_TTL,
         )
         logger.info(
             f"Loaded {len(reference_sets)} WikiPathways KE sets from Builder API, "
             f"cached for {Config.CACHE_TTL}s"
         )
-        return reference_sets, "api"
+        return reference_sets, "api", unresolved
     except Exception as exc:
         logger.warning(
             f"Builder API unavailable ({exc}); falling back to local CSV files"
@@ -1495,22 +1503,24 @@ def _load_wikipathways_reference_sets(min_confidence=DEFAULT_MIN_CONFIDENCE):
 
     # Fall back to CSV. The local KE-WP.csv carries no confidence column, so
     # min_confidence is a documented no-op here (#60 graceful degradation).
+    unresolved = []
     reference_sets = load_reference_sets(
         ke_wp_path='data/KE-WP.csv',
         wp_gene_path='data/edges_wpid_to_gene.csv',
         node_path='data/node_attributes.csv',
         min_confidence=min_confidence,
+        unresolved_out=unresolved,
     )
     _reference_cache.set(
         cache_key,
-        (reference_sets, "csv"),
+        (reference_sets, "csv", unresolved),
         expire=Config.CACHE_TTL,
     )
     logger.info(
         f"Loaded {len(reference_sets)} WikiPathways KE sets from local CSV files, "
         f"cached for {Config.CACHE_TTL}s"
     )
-    return reference_sets, "csv"
+    return reference_sets, "csv", sorted(set(unresolved))
 
 
 def _load_gmt_resource_reference_sets(resource, min_confidence=DEFAULT_MIN_CONFIDENCE):
@@ -1654,8 +1664,11 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
     resolution = []
     for resource in selected:
         try:
+            unresolved_pathways = []
             if resource == "WikiPathways":
-                sets, source = _load_wikipathways_reference_sets(min_confidence)
+                sets, source, unresolved_pathways = _load_wikipathways_reference_sets(
+                    min_confidence
+                )
                 wp_source = source
             else:
                 sets, source = _load_gmt_resource_reference_sets(resource, min_confidence)
@@ -1669,6 +1682,7 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
                 'source': None,
                 'ke_count': 0,
                 'confidence_applied': False,
+                'unresolved_pathways': [],
                 'error': str(exc),
             })
             continue
@@ -1685,6 +1699,10 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
             # honour the threshold. Recorded per resource so a "high only" run
             # cannot be mistaken for one where every gene set was filtered.
             'confidence_applied': _confidence_was_applicable(resource, source),
+            # Issue #79: pathways that are curated and mapped but whose gene
+            # membership no source could resolve. Their KEs silently lose those
+            # genes, and a KE that loses all of them looks unmapped.
+            'unresolved_pathways': unresolved_pathways,
             'error': None,
         })
 
@@ -1790,6 +1808,26 @@ def resource_resolution_warnings(resolution, min_confidence=DEFAULT_MIN_CONFIDEN
                 f"files, which carry no confidence column, so the minimum mapping "
                 f"confidence could not be applied to it either."
             )
+
+    # Issue #79: a mapped pathway whose genes cannot be resolved removes real
+    # coverage. Left unsaid, its Key Events read as "no gene set mapped" — the
+    # opposite of what happened, and it quietly deflates the coverage numbers a
+    # resource comparison reports.
+    unresolved = sorted({
+        wp
+        for e in resolution
+        for wp in (e.get('unresolved_pathways') or [])
+    })
+    if unresolved:
+        shown = ", ".join(unresolved[:5])
+        if len(unresolved) > 5:
+            shown += f" and {len(unresolved) - 5} more"
+        warnings.append(
+            f"{len(unresolved)} mapped pathway(s) could not be resolved to genes "
+            f"({shown}) and contributed nothing to this analysis. Key Events whose "
+            f"only mappings are affected are reported as having no gene set, but "
+            f"they are curated — their coverage is understated here."
+        )
     return warnings
 
 

--- a/helpers.py
+++ b/helpers.py
@@ -146,7 +146,9 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
                         wp_gene_path='data/edges_wpid_to_gene.csv',
                         node_path='data/node_attributes.csv',
                         ke_wp_df=None,
-                        min_confidence=DEFAULT_MIN_CONFIDENCE):
+                        min_confidence=DEFAULT_MIN_CONFIDENCE,
+                        wp_gene_map=None,
+                        unresolved_out=None):
     """Build KE-to-gene reference sets from local CSV files or a pre-built DataFrame.
 
     Parameters
@@ -168,6 +170,18 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
         only the genes of its qualifying pathways and a KE whose mappings are
         all below threshold is absent from the result. The filter is a no-op
         when the mappings carry no confidence column (CSV fallback).
+    wp_gene_map : dict[str, set[str]] or None
+        Optional pathway-to-gene membership, normally the Builder's live copy
+        from :func:`services.api_service.fetch_wp_pathway_gene_map`. Takes
+        precedence over ``wp_gene_path`` per pathway; the CSV still covers any
+        pathway the map lacks. Issue #79: the bundled CSV is a snapshot, so
+        pathways curated after it was taken resolved to no genes at all.
+    unresolved_out : list or None
+        Optional sink. Pathway IDs that neither source can resolve are appended
+        here so the caller can surface them. Without it such a pathway vanishes
+        in the inner join, which is exactly the silence #79 reported: the Key
+        Event is then reported as having no gene set mapped, when in truth it
+        is mapped and the mapping could not be resolved.
 
     Returns
     -------
@@ -217,6 +231,33 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
 
     logger.debug("After annotation merge: %s", wp_gene_annotated.shape)
 
+    # Issue #79: prefer the Builder's live pathway membership, per pathway, and
+    # fall back to the bundled CSV for anything it does not carry. Rows are
+    # appended rather than replacing the CSV wholesale so a partial Builder
+    # response cannot lose pathways the snapshot does cover.
+    if wp_gene_map:
+        wanted = set(ke_wp_df['WP_ID'].unique())
+        live_rows = [
+            {'WPID': wp_id, 'GeneName': gene}
+            for wp_id in wanted
+            for gene in wp_gene_map.get(wp_id, ())
+        ]
+        if live_rows:
+            live_df = pd.DataFrame(live_rows)
+            covered = set(live_df['WPID'].unique())
+            # Drop the snapshot's rows for pathways the Builder answered for, so
+            # a pathway whose membership changed upstream does not end up as the
+            # union of both versions.
+            csv_only = wp_gene_annotated[~wp_gene_annotated['WPID'].isin(covered)]
+            wp_gene_annotated = pd.concat(
+                [csv_only[['WPID', 'GeneName']], live_df], ignore_index=True
+            )
+            logger.info(
+                "WP gene membership: %d of %d mapped pathways resolved from the "
+                "Builder, remainder from the bundled CSV",
+                len(covered & wanted), len(wanted),
+            )
+
     # Merge WP → KE
     merged = ke_wp_df.merge(
         wp_gene_annotated,
@@ -233,13 +274,20 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
 
     logger.debug("Final merged KE-gene mapping after dropna: %s", merged.shape)
 
-    # Report any KE-WP mappings lost in the inner join
-    dropped_ke_wp = len(ke_wp_df) - merged['KE_ID'].nunique()
-    if dropped_ke_wp > 0:
+    # Issue #79: name the pathways that resolved to nothing, rather than
+    # reporting a count of "lost mappings" that compared rows against unique
+    # KEs and so could not be acted on. A pathway here is curated and mapped;
+    # the analyser simply cannot say which genes it contains.
+    resolvable = set(merged['WP_ID'].unique()) if len(merged) else set()
+    unresolved = sorted(set(ke_wp_df['WP_ID'].unique()) - resolvable)
+    if unresolved:
         logger.warning(
-            "Inner join dropped %d of %d KE-WP mappings (no matching WikiPathways genes)",
-            dropped_ke_wp, len(ke_wp_df)
+            "%d mapped pathway(s) could not be resolved to genes and are absent "
+            "from the reference sets: %s",
+            len(unresolved), ", ".join(unresolved),
         )
+        if unresolved_out is not None:
+            unresolved_out.extend(unresolved)
 
     # Group into dict: KE_ID → set of gene symbols
     reference_sets = (

--- a/services/api_service.py
+++ b/services/api_service.py
@@ -24,16 +24,26 @@ from helpers import (
 logger = logging.getLogger(__name__)
 
 # Builder GMT export paths that already resolve pathways/terms to genes.
-# WikiPathways is intentionally omitted here — it keeps its existing
-# CSV-backed pipeline (see fetch_reference_sets_from_api / load_reference_sets).
+# WikiPathways keeps its own KE-WP pipeline (mappings API + confidence filter),
+# but its GMT is still used as the *pathway-to-gene* source — see
+# WP_GMT_PATH and fetch_wp_pathway_gene_map.
 GMT_RESOURCE_PATHS = {
     "GO_BP": "exports/gmt/ke-go",
     "Reactome": "exports/gmt/ke-reactome",
 }
 
+# The KE-WP GMT. Not in GMT_RESOURCE_PATHS because WikiPathways reference sets
+# are not built from it directly: the GMT carries no confidence level, so
+# building KE sets from it would silently ignore min_confidence (#67). It is
+# read only to learn which genes each *pathway* contains.
+WP_GMT_PATH = "exports/gmt/ke-wp"
+
 # Matches the leading "KE<number>" token of a GMT descriptor column, e.g.
 # "KE177_Increase_Mitochondrial_dysfunction_WP5241" -> "177".
 _KE_ID_RE = re.compile(r"^KE\s?(\d+)_")
+
+# Matches the trailing pathway token of the same descriptor -> "WP5241".
+_WP_ID_RE = re.compile(r"_(WP\d+)$", re.IGNORECASE)
 
 
 def _make_api_session(retries=3, backoff_factor=1.0):
@@ -213,9 +223,13 @@ def fetch_reference_sets_from_api(config, min_confidence=DEFAULT_MIN_CONFIDENCE)
 
     Returns
     -------
-    dict[str, set[str]]
-        Mapping of KE ID -> set of gene symbols, identical in shape to
-        the CSV-based output of :func:`helpers.load_reference_sets`.
+    tuple[dict[str, set[str]], list[str]]
+        The KE ID -> gene symbol mapping (identical in shape to the CSV-based
+        output of :func:`helpers.load_reference_sets`), and the sorted list of
+        mapped pathway IDs that could not be resolved to genes by either the
+        Builder or the bundled snapshot (issue #79). The second element is
+        normally empty; when it is not, those Key Events are missing gene sets
+        they are curated to have, and the caller must surface that.
 
     Raises
     ------
@@ -255,14 +269,105 @@ def fetch_reference_sets_from_api(config, min_confidence=DEFAULT_MIN_CONFIDENCE)
         min_confidence,
     )
 
-    reference_sets = load_reference_sets(ke_wp_df=ke_wp_df)
+    # Issue #79: resolve pathway membership from the Builder, not only from the
+    # bundled snapshot. Without this a pathway curated after the snapshot was
+    # taken contributes no genes, and the KE is reported as unmapped.
+    wp_gene_map = fetch_wp_pathway_gene_map(config)
+    unresolved = []
+    reference_sets = load_reference_sets(
+        ke_wp_df=ke_wp_df,
+        wp_gene_map=wp_gene_map,
+        unresolved_out=unresolved,
+    )
 
     logger.info(
         "Reference sets loaded: %d KE gene sets produced from API data",
         len(reference_sets),
     )
-    return reference_sets
+    return reference_sets, sorted(set(unresolved))
 
+
+def parse_gmt_pathway_gene_map(gmt_text):
+    """Parse a KE-WP GMT export into a *pathway*-to-gene map.
+
+    :func:`parse_gmt_reference_sets` collapses the same file to KE -> genes.
+    This keeps the pathway dimension instead, because the WikiPathways pipeline
+    needs to apply the confidence threshold to KE->pathway mappings first and
+    only then look up each qualifying pathway's genes.
+
+    Genes are unioned across every row naming the same pathway (a pathway
+    mapped by several KEs appears several times, with identical membership).
+
+    Parameters
+    ----------
+    gmt_text : str
+        Raw GMT file contents.
+
+    Returns
+    -------
+    dict[str, set[str]]
+        Mapping of upper-case pathway ID (``"WP5477"``) -> gene symbols.
+    """
+    pathway_genes = {}
+    for line in gmt_text.splitlines():
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        if len(fields) < 3:
+            continue  # descriptor + title but no genes
+        match = _WP_ID_RE.search(fields[0])
+        if not match:
+            continue
+        wp_id = match.group(1).upper()
+        genes = {g.strip().upper() for g in fields[2:] if g.strip()}
+        if not genes:
+            continue
+        pathway_genes.setdefault(wp_id, set()).update(genes)
+    return pathway_genes
+
+
+def fetch_wp_pathway_gene_map(config):
+    """Fetch pathway-to-gene membership for WikiPathways from the Builder.
+
+    The bundled ``data/edges_wpid_to_gene.csv`` is a snapshot, so any pathway
+    curated after it was taken resolves to no genes at all — silently, because
+    the merge is an inner join (issue #79). The Builder resolves pathway
+    membership itself for its GMT export, so its copy is the fresher source.
+
+    Parameters
+    ----------
+    config : Config
+        Application config providing ``BUILDER_API_URL`` and
+        ``BUILDER_API_TIMEOUT``.
+
+    Returns
+    -------
+    dict[str, set[str]]
+        Pathway ID -> gene symbols. Empty dict if the Builder is not
+        configured or the export cannot be fetched — callers fall back to the
+        bundled CSV rather than failing, since a stale gene set beats none.
+    """
+    if not config.BUILDER_API_URL:
+        logger.info("BUILDER_API_URL not configured; skipping WP pathway-gene fetch")
+        return {}
+
+    url = f"{config.BUILDER_API_URL.rstrip('/')}/{WP_GMT_PATH}"
+    try:
+        session = _make_api_session()
+        response = session.get(url, timeout=config.BUILDER_API_TIMEOUT)
+        response.raise_for_status()
+        pathway_genes = parse_gmt_pathway_gene_map(response.text)
+        logger.info(
+            "Loaded gene membership for %d WikiPathways pathways from %s",
+            len(pathway_genes), url,
+        )
+        return pathway_genes
+    except Exception as exc:
+        logger.warning(
+            "Could not fetch WikiPathways gene membership from the Builder (%s); "
+            "falling back to the bundled CSV snapshot", exc
+        )
+        return {}
 
 def parse_gmt_reference_sets(gmt_text):
     """Parse a Builder GMT export into KE-to-gene reference sets.

--- a/tests/test_api_service.py
+++ b/tests/test_api_service.py
@@ -205,3 +205,60 @@ class TestFetchReferenceSetsConfidence:
         # KE:1 keeps WP1 only; KE:3 (all Low) disappears entirely.
         assert list(df["WP_ID"]) == ["WP1"]
         assert list(df["KE_ID"]) == ["KE:1"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #79: pathway gene membership must not come only from the bundled CSV
+# ---------------------------------------------------------------------------
+
+class TestPathwayGeneMap:
+    """parse_gmt_pathway_gene_map / fetch_wp_pathway_gene_map."""
+
+    GMT = (
+        "KE1115_Increase_Reactive_oxygen_species_WP5477\tOxidative stress\tSOD1\tCAT\n"
+        "KE1392_Increase_Oxidative_Stress_WP5477\tOxidative stress\tSOD1\tGPX1\n"
+        "KE177_Increase_Mitochondrial_dysfunction_WP5507\tMito\tNDUFA1\n"
+        "KE999_No_genes_WP1\tEmpty\n"
+        "not a descriptor\tignored\tXYZ\n"
+    )
+
+    def test_keys_on_pathway_not_ke(self):
+        """The map is pathway-centric — that is what the KE-WP merge needs."""
+        from services.api_service import parse_gmt_pathway_gene_map
+
+        result = parse_gmt_pathway_gene_map(self.GMT)
+        assert set(result) == {"WP5477", "WP5507"}
+
+    def test_unions_genes_across_kes_sharing_a_pathway(self):
+        """WP5477 is mapped by two KEs; membership is the union of both rows."""
+        from services.api_service import parse_gmt_pathway_gene_map
+
+        assert parse_gmt_pathway_gene_map(self.GMT)["WP5477"] == {"SOD1", "CAT", "GPX1"}
+
+    def test_rows_without_genes_or_pathway_are_skipped(self):
+        """A descriptor with no genes must not create an empty gene set."""
+        from services.api_service import parse_gmt_pathway_gene_map
+
+        result = parse_gmt_pathway_gene_map(self.GMT)
+        assert "WP1" not in result
+        assert all(genes for genes in result.values())
+
+    def test_fetch_returns_empty_when_builder_unset(self):
+        """No Builder configured falls back to the CSV rather than raising."""
+        from services.api_service import fetch_wp_pathway_gene_map
+
+        cfg = MagicMock()
+        cfg.BUILDER_API_URL = ""
+        assert fetch_wp_pathway_gene_map(cfg) == {}
+
+    def test_fetch_swallows_builder_failure(self):
+        """A Builder outage must degrade to the CSV, not fail the analysis."""
+        from services.api_service import fetch_wp_pathway_gene_map
+
+        cfg = MagicMock()
+        cfg.BUILDER_API_URL = "https://b.example.com"
+        cfg.BUILDER_API_TIMEOUT = 5
+        session = MagicMock()
+        session.get.side_effect = RuntimeError("connection refused")
+        with patch("services.api_service._make_api_session", return_value=session):
+            assert fetch_wp_pathway_gene_map(cfg) == {}

--- a/tests/test_reference_resources.py
+++ b/tests/test_reference_resources.py
@@ -15,7 +15,7 @@ class TestLoadCachedReferenceSets:
 
     def test_default_is_wikipathways_only(self):
         wp = {"KE:1": {"A", "B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")) as wp_loader, \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader, \
              patch.object(app, "_load_gmt_resource_reference_sets") as gmt_loader:
             sets, source, _ = app.load_cached_reference_sets()
         wp_loader.assert_called_once()
@@ -27,7 +27,7 @@ class TestLoadCachedReferenceSets:
     def test_unions_genes_across_resources(self):
         wp = {"KE:1": {"A", "B"}}
         go = {"KE:1": {"B", "C"}, "KE:2": {"D"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             sets, source, _ = app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
         assert sets == {"KE:1": {"A", "B", "C"}, "KE:2": {"D"}}
@@ -36,7 +36,7 @@ class TestLoadCachedReferenceSets:
     def test_does_not_mutate_source_sets(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
         # Cached per-resource sets are untouched by the merge.
@@ -49,7 +49,7 @@ class TestLoadCachedReferenceSets:
         def _boom(resource, min_confidence="all"):
             raise RuntimeError("builder GMT export unavailable")
 
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
              patch.object(app, "_load_gmt_resource_reference_sets", side_effect=_boom):
             sets, source, _ = app.load_cached_reference_sets(["WikiPathways", "Reactome"])
         # Reactome skipped; WikiPathways retained -> analysis still runs.
@@ -58,7 +58,7 @@ class TestLoadCachedReferenceSets:
 
     def test_unknown_resource_falls_back_to_default(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")) as wp_loader:
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader:
             sets, source, _ = app.load_cached_reference_sets(["bogus"])
         wp_loader.assert_called_once()
         assert sets == {"KE:1": {"A"}}
@@ -207,7 +207,7 @@ class TestMinConfidenceThreading:
     def test_threshold_forwarded_to_resource_loaders(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")) as wp_loader, \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])) as wp_loader, \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")) as gmt_loader:
             app.load_cached_reference_sets(["WikiPathways", "GO_BP"], min_confidence="high")
         assert wp_loader.call_args.args[0] == "high"
@@ -215,13 +215,13 @@ class TestMinConfidenceThreading:
 
     def test_default_threshold_is_all(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")) as wp_loader:
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader:
             app.load_cached_reference_sets(["WikiPathways"])
         assert wp_loader.call_args.args[0] == "all"
 
     def test_junk_threshold_falls_back_to_all(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")) as wp_loader:
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader:
             app.load_cached_reference_sets(["WikiPathways"], min_confidence="'; DROP TABLE --")
         assert wp_loader.call_args.args[0] == "all"
 
@@ -254,8 +254,8 @@ class TestConfidenceScopedCacheKeys:
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
-        with patch.object(app, "fetch_reference_sets_from_api", return_value={"KE:1": {"A"}}) as fetch:
-            sets, source = app._load_wikipathways_reference_sets("high")
+        with patch.object(app, "fetch_reference_sets_from_api", return_value=({"KE:1": {"A"}}, [])) as fetch:
+            sets, source, _ = app._load_wikipathways_reference_sets("high")
 
         # Cache miss for 'high' -> a fresh fetch at that threshold, not the 'all' set.
         fetch.assert_called_once()
@@ -274,8 +274,8 @@ class TestConfidenceScopedCacheKeys:
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
-        with patch.object(app, "fetch_reference_sets_from_api", return_value={"KE:1": {"A", "B"}}):
-            sets, _ = app._load_wikipathways_reference_sets("all")
+        with patch.object(app, "fetch_reference_sets_from_api", return_value=({"KE:1": {"A", "B"}}, [])):
+            sets, _, _ = app._load_wikipathways_reference_sets("all")
         assert sets == {"KE:1": {"A", "B"}}
 
     def test_gmt_loader_caches_per_threshold(self, monkeypatch):
@@ -312,7 +312,7 @@ class TestCachePreservesOriginalSource:
         key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
         self._fake_cache(monkeypatch, {key: ({"KE:1": {"A"}}, "csv")})
 
-        sets, source = app._load_wikipathways_reference_sets("all")
+        sets, source, _ = app._load_wikipathways_reference_sets("all")
         assert sets == {"KE:1": {"A"}}
         assert source == "cache(csv)"
 
@@ -320,7 +320,7 @@ class TestCachePreservesOriginalSource:
         key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
         self._fake_cache(monkeypatch, {key: ({"KE:1": {"A"}}, "api")})
 
-        _, source = app._load_wikipathways_reference_sets("all")
+        _, source, _ = app._load_wikipathways_reference_sets("all")
         assert source == "cache(api)"
 
     def test_a_cached_csv_fallback_is_still_warned_about(self, monkeypatch):
@@ -337,7 +337,7 @@ class TestResourceResolutionRecording:
     def test_loaded_resources_are_recorded_with_their_source(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}, "KE:2": {"C"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "cache(api)")):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
 
@@ -355,7 +355,7 @@ class TestResourceResolutionRecording:
         def _boom(resource, min_confidence="all"):
             raise RuntimeError("builder GMT export unavailable")
 
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
              patch.object(app, "_load_gmt_resource_reference_sets", side_effect=_boom):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways", "Reactome"])
 
@@ -368,7 +368,7 @@ class TestResourceResolutionRecording:
 
     def test_csv_fallback_is_disclosed(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
 
         warnings = app.resource_resolution_warnings(resolution)
@@ -376,13 +376,13 @@ class TestResourceResolutionRecording:
 
     def test_clean_run_produces_no_warnings(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
         assert app.resource_resolution_warnings(resolution, "high") == []
 
     def test_description_reads_as_a_sentence(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "cache(csv)")):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "cache(csv)", [])):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
         assert app.describe_resource_resolution(resolution) == (
             "WikiPathways (bundled reference files, cached)"
@@ -402,7 +402,7 @@ class TestConfidenceApplicabilityIsRecorded:
     def test_gmt_resources_are_marked_unfiltered(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             _, _, resolution = app.load_cached_reference_sets(
                 ["WikiPathways", "GO_BP"], min_confidence="high"
@@ -417,7 +417,7 @@ class TestConfidenceApplicabilityIsRecorded:
     def test_csv_fallback_cannot_apply_the_threshold_either(self):
         """KE-WP.csv has no confidence column, so 'high' is a no-op there too."""
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv")):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])):
             _, _, resolution = app.load_cached_reference_sets(
                 ["WikiPathways"], min_confidence="high"
             )
@@ -427,9 +427,108 @@ class TestConfidenceApplicabilityIsRecorded:
         """'All mappings' filters nothing, so there is nothing to caveat."""
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api")), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             _, _, resolution = app.load_cached_reference_sets(
                 ["WikiPathways", "GO_BP"], min_confidence="all"
             )
         assert app.resource_resolution_warnings(resolution, "all") == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #79: a mapped pathway the bundled CSV does not know about
+# ---------------------------------------------------------------------------
+
+class TestPathwayResolutionGap:
+    """load_reference_sets must not silently drop unresolvable pathways.
+
+    Reproduces the reported case: KE 1115 maps only to WP5477, which is curated
+    in the Builder but absent from data/edges_wpid_to_gene.csv. Before the fix
+    the inner join dropped it without trace, so the KE was reported as having no
+    gene set mapped — the opposite of what had happened.
+    """
+
+    KE_WP = pd.DataFrame([
+        {"KE_ID": "KE:1115", "WP_ID": "WP5477"},   # only in the Builder
+        {"KE_ID": "KE:177", "WP_ID": "WP4324"},    # in the bundled CSV
+    ])
+
+    def _csv_files(self, tmp_path):
+        """Write a minimal stand-in for the two bundled CSVs."""
+        wp_gene = tmp_path / "edges.csv"
+        wp_gene.write_text("WPID,gene_id,edge_id\nWP4324,111,e1\n")
+        nodes = tmp_path / "nodes.csv"
+        nodes.write_text("GeneID,GeneName\n111,TP53\n")
+        return str(wp_gene), str(nodes)
+
+    def test_pathway_absent_from_csv_is_reported_not_dropped(self, tmp_path):
+        wp_gene_path, node_path = self._csv_files(tmp_path)
+        unresolved = []
+
+        sets = load_reference_sets(
+            ke_wp_df=self.KE_WP.copy(),
+            wp_gene_path=wp_gene_path,
+            node_path=node_path,
+            unresolved_out=unresolved,
+        )
+
+        assert unresolved == ["WP5477"]
+        # The KE really does end up with no genes — the point is that we say so.
+        assert "KE:1115" not in sets
+        assert sets["KE:177"] == {"TP53"}
+
+    def test_builder_membership_resolves_the_gap(self, tmp_path):
+        """With the Builder's map, the same KE gets its genes and nothing is unresolved."""
+        wp_gene_path, node_path = self._csv_files(tmp_path)
+        unresolved = []
+
+        sets = load_reference_sets(
+            ke_wp_df=self.KE_WP.copy(),
+            wp_gene_path=wp_gene_path,
+            node_path=node_path,
+            wp_gene_map={"WP5477": {"SOD1", "CAT"}},
+            unresolved_out=unresolved,
+        )
+
+        assert unresolved == []
+        assert sets["KE:1115"] == {"SOD1", "CAT"}
+        # The CSV still covers pathways the Builder did not answer for.
+        assert sets["KE:177"] == {"TP53"}
+
+    def test_builder_membership_replaces_rather_than_unions_the_snapshot(self, tmp_path):
+        """When both sources know a pathway, the Builder's membership wins.
+
+        Unioning would resurrect genes removed upstream, which is worse than
+        either source alone: the result would match no version of the pathway.
+        """
+        wp_gene_path, node_path = self._csv_files(tmp_path)
+
+        sets = load_reference_sets(
+            ke_wp_df=pd.DataFrame([{"KE_ID": "KE:177", "WP_ID": "WP4324"}]),
+            wp_gene_path=wp_gene_path,
+            node_path=node_path,
+            wp_gene_map={"WP4324": {"MT-CO1"}},
+        )
+
+        assert sets["KE:177"] == {"MT-CO1"}, "stale TP53 should not survive"
+
+    def test_unresolved_pathways_surface_as_a_warning(self):
+        """The run must say so — that is the whole complaint in #79."""
+        resolution = [{
+            'resource': 'WikiPathways', 'status': 'loaded', 'source': 'api',
+            'ke_count': 90, 'confidence_applied': True,
+            'unresolved_pathways': ['WP1234', 'WP5477'], 'error': None,
+        }]
+
+        warnings = app.resource_resolution_warnings(resolution)
+        joined = " ".join(warnings)
+        assert "WP5477" in joined and "WP1234" in joined
+        assert "no gene set" in joined
+
+    def test_no_warning_when_everything_resolves(self):
+        resolution = [{
+            'resource': 'WikiPathways', 'status': 'loaded', 'source': 'api',
+            'ke_count': 90, 'confidence_applied': True,
+            'unresolved_pathways': [], 'error': None,
+        }]
+        assert app.resource_resolution_warnings(resolution) == []


### PR DESCRIPTION
Closes #79.

## The defect

KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was resolved against the bundled `data/edges_wpid_to_gene.csv` — a snapshot whose highest ID is `WP5452`. Any pathway curated since resolved to **no genes at all**, and because the merge is an inner join it did so in silence.

**8 of the 79 live-mapped pathways** were affected. 8 Key Events lost every gene they had and were then reported as *"no gene set mapped"* — the opposite of what happened. KE 1115 (Reactive oxygen species) maps to exactly one pathway, `WP5477`, so it disappeared from the analysis entirely.

The run meanwhile advertised its provenance as `WikiPathways (Builder API, live)`. True of the mappings; not of the gene membership behind them — and nothing distinguished the two.

## The fix

Membership now comes from the Builder's **KE-WP GMT export**, which resolves pathways to genes upstream and covers 76 of the 79. Applied *per pathway*, with the bundled CSV still covering anything the Builder does not answer for, so a partial response cannot lose pathways the snapshot does have. Where the Builder answers, its rows **replace** the snapshot's rather than being unioned — otherwise a pathway whose membership changed upstream ends up as both versions at once.

The GMT is read only for pathway→gene membership, never to build KE sets directly: it carries no confidence level, so building from it would silently ignore `min_confidence` (#67).

| | before | after |
|---|---|---|
| KE gene sets | 87 | **90** |
| KE 1115 | excluded entirely | **49 genes** |
| KE 1392 | 33 genes | **73 genes** |
| KE 177 | 109 genes | **115 genes** |

## What stays unresolvable is now said out loud

`WP1234`, `WP3980`, `WP4010` resolve in neither source (`WP1234` is a 404 upstream). They are now named in a warning on the results page and recorded in the run's `resource_resolution`, so a Key Event that *looks* uncovered can be told apart from one that genuinely is. The previous code logged a count here that compared row totals against unique KEs — not a number anyone could act on.

## Verification

427 tests pass (417 before + 10 new): pathway-centric GMT parsing, gene union across KEs sharing a pathway, skipping gene-less and malformed rows, graceful empty on Builder outage or missing config, the resolution gap being reported rather than dropped, Builder membership closing it, replace-not-union semantics, and the warning firing only when something is genuinely unresolved. Verified against the live Builder, with the before/after numbers above measured on `main` vs this branch.

Cache entries written before this change are 2-tuples; they are read as "nothing known to be unresolved" rather than invalidating a warm cache on deploy.