### PR TITLE
Drop symbol-less rows from the background and order the driver-gene export (#80, #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,18 +43,30 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   significance threshold, `NAN` counted as a significant gene that can never overlap a Key
   Event gene set, biasing every Fisher test very slightly toward the null.
 
-  Rows whose identifier is null, empty or a placeholder (`nan`, `NA`, `-`, …) are now
-  dropped before expansion and counted; the count is carried in the processing stats as
-  `dropped_unidentified_rows` so the discard is reported next to the background size rather
-  than silently renamed. A `A///NA` row keeps its real symbol.
+  Rows whose identifier is null, empty or a missing-value placeholder are now dropped
+  before expansion, so the pseudo-gene is gone and the reported background is the true
+  count of measured genes. A `A///NA` row keeps its real symbol. The placeholder
+  vocabulary is pandas' own `STR_NA_VALUES` plus the punctuation forms (`-`, `--`, `.`,
+  `?`, …) that R, Excel and array-annotation pipelines write for "no symbol". The number
+  of discarded rows is counted and carried in the processing stats as
+  `dropped_unidentified_rows`; it is **not yet shown in the interface** — displaying it
+  next to the background size is still open under #80.
 
-- **`genes_export.csv` rows now come out in a deterministic order** (#82). The long view
-  inherited its order from dict iteration over each condition's stored KE→gene map, so two
-  runs over identical result data produced files that were equal only once sorted —
-  `compare_export.csv`, by contrast, was already byte-stable. That made the gene export
-  unusable for diff-based reproducibility checks and generated spurious churn when exports
-  were version-controlled. Both views are now sorted by Key Event (numerically, so `KE:10`
-  follows `KE:9`), then gene symbol, then condition.
+  A file in which *no* row yields a usable identifier — most often a wrong ID column —
+  now fails with a validation error naming that column, instead of the generic
+  "unexpected error" page it produced once the pseudo-gene stopped standing in for those
+  rows.
+
+- **The driver-gene export comes out in a deterministic order** (#82). `build_gene_tracking`
+  appended its records in dict-iteration order over each condition's stored KE→gene map, so
+  the order of the Genes tab payload, the batch report and the CSV/Excel export was an
+  artefact of how that JSON happened to be written; two runs over identical result data
+  produced files that were equal only once sorted, while `compare_export.csv` was already
+  byte-stable. That made the gene export unusable for diff-based reproducibility checks and
+  generated spurious churn when exports were version-controlled. Records are now ordered at
+  the source, and the export re-applies the same order: Key Event numerically (so `KE:10`
+  follows `KE:9`), then gene symbol, then condition **in upload order** — sorting condition
+  labels as text would put `10uM` before `2uM` and break a dose series.
 
 - **WikiPathways gene membership no longer comes only from a bundled snapshot** (#79).
   KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,30 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Fixed
 
+- **Rows without a gene symbol no longer enter the background as a gene called `NAN`**
+  (#80). The loader expanded multi-symbol rows with `str(row[id_col]).split('///')`, and
+  `str()` on a missing value yields `'nan'` — uppercased into a literal identifier. Every
+  symbol-less row in an upload therefore collapsed into one pseudo-gene. On a DESeq2 table
+  of 13814 rows, 12939 of which carry a GeneSymbol and 12914 of which are distinct, the
+  tool reported a background of 12915: the extra entry stood in for 875 discarded rows.
+  Two things followed. The reported background was not the number of measured genes, so it
+  could not honestly be quoted in a methods section; and if the symbol-less row passed the
+  significance threshold, `NAN` counted as a significant gene that can never overlap a Key
+  Event gene set, biasing every Fisher test very slightly toward the null.
+
+  Rows whose identifier is null, empty or a placeholder (`nan`, `NA`, `-`, …) are now
+  dropped before expansion and counted; the count is carried in the processing stats as
+  `dropped_unidentified_rows` so the discard is reported next to the background size rather
+  than silently renamed. A `A///NA` row keeps its real symbol.
+
+- **`genes_export.csv` rows now come out in a deterministic order** (#82). The long view
+  inherited its order from dict iteration over each condition's stored KE→gene map, so two
+  runs over identical result data produced files that were equal only once sorted —
+  `compare_export.csv`, by contrast, was already byte-stable. That made the gene export
+  unusable for diff-based reproducibility checks and generated spurious churn when exports
+  were version-controlled. Both views are now sorted by Key Event (numerically, so `KE:10`
+  follows `KE:9`), then gene symbol, then condition.
+
 - **WikiPathways gene membership no longer comes only from a bundled snapshot** (#79).
   KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was
   resolved against `data/edges_wpid_to_gene.csv` — a snapshot topping out at `WP5452`. Any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,8 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   count of measured genes. A `A///NA` row keeps its real symbol. The placeholder
   vocabulary is pandas' own `STR_NA_VALUES` plus the punctuation forms (`-`, `--`, `.`,
   `?`, …) that R, Excel and array-annotation pipelines write for "no symbol". The number
-  of discarded rows is counted and carried in the processing stats as
-  `dropped_unidentified_rows`; it is **not yet shown in the interface** — displaying it
-  next to the background size is still open under #80.
+  of discarded rows is counted, but is **not yet shown anywhere in the interface** —
+  reporting it next to the background size is still open under #80.
 
   A file in which *no* row yields a usable identifier — most often a wrong ID column —
   now fails with a validation error naming that column, instead of the generic
@@ -59,14 +58,18 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 - **The driver-gene export comes out in a deterministic order** (#82). `build_gene_tracking`
   appended its records in dict-iteration order over each condition's stored KE→gene map, so
-  the order of the Genes tab payload, the batch report and the CSV/Excel export was an
-  artefact of how that JSON happened to be written; two runs over identical result data
-  produced files that were equal only once sorted, while `compare_export.csv` was already
-  byte-stable. That made the gene export unusable for diff-based reproducibility checks and
-  generated spurious churn when exports were version-controlled. Records are now ordered at
-  the source, and the export re-applies the same order: Key Event numerically (so `KE:10`
-  follows `KE:9`), then gene symbol, then condition **in upload order** — sorting condition
-  labels as text would put `10uM` before `2uM` and break a dose series.
+  the row order of `genes_export.csv` was an artefact of how that JSON happened to be
+  written; two runs over identical result data produced files that were equal only once
+  sorted, while `compare_export.csv` was already byte-stable. That made the gene export
+  unusable for diff-based reproducibility checks and generated spurious churn when exports
+  were version-controlled. Records are now ordered at the source, and the export re-applies
+  the same order: Key Event numerically (so `KE:10` follows `KE:9`), then gene symbol, then
+  condition **in upload order** — sorting condition labels as text would put `10uM` before
+  `2uM` and break a dose series. The summary view keeps its shared-first ordering (a gene
+  driving three conditions stays above one driving a single condition).
+
+  The export was the only affected artefact: the Genes tab payload was already sorted, and
+  the batch report does not use these records.
 
 - **WikiPathways gene membership no longer comes only from a bundled snapshot** (#79).
   KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was

--- a/app.py
+++ b/app.py
@@ -2671,24 +2671,59 @@ def batch_genes_export(batch_uuid_str):
         # Issue #82: the long view inherited its row order from dict iteration
         # over each condition's stored KE->gene map, so two runs over identical
         # inputs produced exports that were equal only after sorting. That made
-        # the file useless for diff-based reproducibility checks. Both views are
-        # ordered here by KE (numerically, so KE:10 follows KE:9), then gene,
-        # then condition.
+        # the file useless for diff-based reproducibility checks.
+        # build_gene_tracking() now orders its records at the source; this pass
+        # is kept because it is cheap and guards the frames against any other
+        # producer, and because it is where the frame-level column order is
+        # known. Both views are ordered by KE (numerically, so KE:10 follows
+        # KE:9), then gene symbol, then condition.
+        #
+        # Condition is ordered by *upload position*, not alphabetically: a dose
+        # series is the main use of this export and sorting '10uM' before '2uM'
+        # as text destroys it. tracking['condition_labels'] is already in
+        # position order. Nothing enforces label uniqueness, so duplicated
+        # labels share a rank; the row index is appended as a final key to keep
+        # the sort total and therefore reproducible.
         def _ke_sort_key(value):
             text = str(value)
-            match = re.search(r'(\d+)\s*$', text)
-            if match:
-                return (text[:match.start()], int(match.group(1)))
+            cut = len(text)
+            while cut > 0 and text[cut - 1].isdigit():
+                cut -= 1
+            if cut < len(text):
+                return (text[:cut], int(text[cut:]))
             return (text, -1)
+
+        condition_rank = {}
+        for idx, label in enumerate(tracking.get('condition_labels', [])):
+            # gene_tracking_to_dataframes() runs labels through csv_guard, so
+            # rank both spellings to be safe.
+            for spelling in (label, csv_guard(label)):
+                condition_rank.setdefault(str(spelling), idx)
+        unknown_condition_rank = len(condition_rank)
 
         for view_name, frame in frames.items():
             if frame.empty:
                 continue
-            sort_cols = [c for c in ('Gene_Symbol', 'Condition') if c in frame.columns]
-            ordered = frame.assign(_ke_order=frame['KE_ID'].map(_ke_sort_key))
-            ordered = ordered.sort_values(
-                by=['_ke_order'] + sort_cols, kind='mergesort'
-            ).drop(columns='_ke_order').reset_index(drop=True)
+            ordered = frame.assign(
+                _ke_order=frame['KE_ID'].map(_ke_sort_key),
+                _row_order=range(len(frame)),
+            )
+            sort_by = ['_ke_order']
+            if 'Gene_Symbol' in frame.columns:
+                ordered['_gene_order'] = frame['Gene_Symbol'].astype(str)
+                sort_by.append('_gene_order')
+            if 'Condition' in frame.columns:
+                ordered['_condition_order'] = frame['Condition'].map(
+                    lambda v: condition_rank.get(str(v), unknown_condition_rank)
+                )
+                sort_by.append('_condition_order')
+            sort_by.append('_row_order')
+            helper_cols = ['_ke_order', '_row_order', '_gene_order', '_condition_order']
+            ordered = (
+                ordered.sort_values(by=sort_by, kind='mergesort')
+                .drop(columns=[c for c in helper_cols if c in ordered.columns])
+                .reset_index(drop=True)
+            )
             frames[view_name] = ordered
 
         stem = f"molAOP_{_safe_filename_part(batch.aop_id)}_{_safe_filename_part(batch.batch_name)}_driver_genes"

--- a/app.py
+++ b/app.py
@@ -2668,6 +2668,29 @@ def batch_genes_export(batch_uuid_str):
         tracking = build_gene_tracking(conditions)
         frames = gene_tracking_to_dataframes(tracking)
 
+        # Issue #82: the long view inherited its row order from dict iteration
+        # over each condition's stored KE->gene map, so two runs over identical
+        # inputs produced exports that were equal only after sorting. That made
+        # the file useless for diff-based reproducibility checks. Both views are
+        # ordered here by KE (numerically, so KE:10 follows KE:9), then gene,
+        # then condition.
+        def _ke_sort_key(value):
+            text = str(value)
+            match = re.search(r'(\d+)\s*$', text)
+            if match:
+                return (text[:match.start()], int(match.group(1)))
+            return (text, -1)
+
+        for view_name, frame in frames.items():
+            if frame.empty:
+                continue
+            sort_cols = [c for c in ('Gene_Symbol', 'Condition') if c in frame.columns]
+            ordered = frame.assign(_ke_order=frame['KE_ID'].map(_ke_sort_key))
+            ordered = ordered.sort_values(
+                by=['_ke_order'] + sort_cols, kind='mergesort'
+            ).drop(columns='_ke_order').reset_index(drop=True)
+            frames[view_name] = ordered
+
         stem = f"molAOP_{_safe_filename_part(batch.aop_id)}_{_safe_filename_part(batch.batch_name)}_driver_genes"
 
         if fmt == 'xlsx':

--- a/app.py
+++ b/app.py
@@ -2709,6 +2709,13 @@ def batch_genes_export(batch_uuid_str):
                 _row_order=range(len(frame)),
             )
             sort_by = ['_ke_order']
+            if 'n_conditions_driver' in frame.columns:
+                # The summary view is deliberately shared-first within a KE (a
+                # gene driving 3 conditions is listed above one driving 1); see
+                # build_gene_tracking(). Re-sorting on KE and gene alone would
+                # silently discard that, so keep it as the second key.
+                ordered['_shared_order'] = -frame['n_conditions_driver']
+                sort_by.append('_shared_order')
             if 'Gene_Symbol' in frame.columns:
                 ordered['_gene_order'] = frame['Gene_Symbol'].astype(str)
                 sort_by.append('_gene_order')
@@ -2718,7 +2725,10 @@ def batch_genes_export(batch_uuid_str):
                 )
                 sort_by.append('_condition_order')
             sort_by.append('_row_order')
-            helper_cols = ['_ke_order', '_row_order', '_gene_order', '_condition_order']
+            helper_cols = [
+                '_ke_order', '_row_order', '_gene_order',
+                '_condition_order', '_shared_order',
+            ]
             ordered = (
                 ordered.sort_values(by=sort_by, kind='mergesort')
                 .drop(columns=[c for c in helper_cols if c in ordered.columns])

--- a/services/comparison_service.py
+++ b/services/comparison_service.py
@@ -270,7 +270,14 @@ def build_gene_tracking(conditions: list) -> dict[str, Any]:
             condition_labels — condition labels in upload-position order
             records          — tidy list, one dict per (KE, gene, condition)
                                driver event: KE_ID, KE_Title, Gene_Symbol,
-                               Condition, log2FC, significant
+                               Condition, log2FC, significant. Ordered by KE
+                               (numerically, so KE:10 follows KE:9), then gene
+                               symbol, then condition upload position (issue
+                               #82) — the stored ``ke_gene_json`` is a JSON
+                               object whose key order is an artefact of how it
+                               was written, so an unordered list made both the
+                               Genes tab payload and the batch report vary
+                               between runs over identical data.
             gene_ke_summary  — derived list, one dict per (KE, gene) that is a
                                driver somewhere: KE_ID, KE_Title, Gene_Symbol,
                                n_conditions_driver, conditions_driver (list),
@@ -293,7 +300,24 @@ def build_gene_tracking(conditions: list) -> dict[str, Any]:
         except (json.JSONDecodeError, TypeError):
             continue
 
-    records: list[dict] = []
+    def _ke_sort_key(value: Any) -> tuple:
+        """Order KE IDs by their trailing integer, so KE:10 follows KE:9.
+
+        Kept local (rather than shared with the export route) so the ordering
+        contract of this function is readable in one place; IDs with no numeric
+        suffix sort before numbered ones within the same prefix.
+        """
+        text = str(value)
+        cut = len(text)
+        while cut > 0 and text[cut - 1].isdigit():
+            cut -= 1
+        if cut < len(text):
+            return (text[:cut], int(text[cut:]))
+        return (text, -1)
+
+    # (sort key, record) pairs; the trailing counter makes the key total so the
+    # sort never falls back to comparing dicts and never depends on input order.
+    indexed_records: list[tuple[tuple, dict]] = []
     # summary keyed by (KE, gene) -> aggregation dict
     summary: dict[tuple, dict] = {}
 
@@ -320,14 +344,17 @@ def build_gene_tracking(conditions: list) -> dict[str, Any]:
                 log2fc = entry.get('log2FC')
                 title = ke_title_map.get(ke, ke)
 
-                records.append({
-                    'KE_ID': ke,
-                    'KE_Title': title,
-                    'Gene_Symbol': gene,
-                    'Condition': cond.condition_label,
-                    'log2FC': log2fc,
-                    'significant': True,
-                })
+                indexed_records.append((
+                    (_ke_sort_key(ke), str(gene), col_idx, len(indexed_records)),
+                    {
+                        'KE_ID': ke,
+                        'KE_Title': title,
+                        'Gene_Symbol': gene,
+                        'Condition': cond.condition_label,
+                        'log2FC': log2fc,
+                        'significant': True,
+                    },
+                ))
 
                 key = (ke, gene)
                 agg = summary.get(key)
@@ -356,10 +383,14 @@ def build_gene_tracking(conditions: list) -> dict[str, Any]:
             'log2FC_by_condition': agg['log2FC_by_condition'],
         })
 
-    # Stable, useful ordering: KE, then shared-first, then gene.
+    # Stable, useful ordering: KE (numerically), then shared-first, then gene.
     gene_ke_summary.sort(
-        key=lambda r: (r['KE_ID'], -r['n_conditions_driver'], r['Gene_Symbol'])
+        key=lambda r: (
+            _ke_sort_key(r['KE_ID']), -r['n_conditions_driver'], str(r['Gene_Symbol'])
+        )
     )
+
+    records = [record for _, record in sorted(indexed_records, key=lambda pair: pair[0])]
 
     return {
         'condition_labels': condition_labels,

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -11,9 +11,34 @@ from exceptions import FileProcessingError, DataValidationError, AOPDataError
 
 logger = logging.getLogger(__name__)
 
-# Placeholders that pandas/R/Excel write for a missing gene symbol. Compared
-# against the upper-cased, stripped identifier (issue #80).
-_MISSING_ID_TOKENS = {'NAN', 'NA', 'NONE', 'NULL', '#N/A', '-', '.'}
+try:  # pandas keeps its default na_values vocabulary in a private module
+    from pandas._libs.parsers import STR_NA_VALUES as _pandas_str_na_values
+except ImportError:  # pragma: no cover - only if pandas moves the symbol
+    _pandas_str_na_values = {
+        '', '#N/A', '#N/A N/A', '#NA', '-1.#IND', '-1.#QNAN', '-NaN', '-nan',
+        '1.#IND', '1.#QNAN', '<NA>', 'N/A', 'NA', 'NULL', 'NaN', 'None',
+        'n/a', 'nan', 'null',
+    }
+
+# Placeholders that stand in for a missing gene symbol, compared against the
+# upper-cased, stripped identifier (issue #80).
+#
+# This is deliberately a *second* line of defence, not the primary one. When the
+# file is read by `pd.read_csv` below, pandas has already turned its own
+# `STR_NA_VALUES` ("NA", "N/A", "#N/A", "null", ...) into NaN, which `str()`
+# then renders as the string "nan" — so in the normal path only "NAN" and the
+# punctuation entries are ever reached. The set still starts from pandas'
+# vocabulary so that the two agree exactly (previously it listed "#N/A" but not
+# "N/A", which read as protective without being so) and so that identifiers
+# arriving from a reader that did not apply `na_values` are handled the same
+# way. On top of pandas' list sit the punctuation placeholders R, Excel and
+# array-annotation pipelines emit for "no symbol"; the dash and dot runs are
+# spelled out to one, two and three characters because all three occur in the
+# wild.
+_PUNCTUATION_ID_PLACEHOLDERS = {'-', '--', '---', '.', '..', '...', '?', '??', 'N.A.'}
+_MISSING_ID_TOKENS = {
+    token.strip().upper() for token in _pandas_str_na_values if token.strip()
+} | _PUNCTUATION_ID_PLACEHOLDERS
 
 def load_and_validate_data(filepath: str, id_col: str, fc_col: str, pval_col: str) -> pd.DataFrame:
     """
@@ -71,6 +96,32 @@ def load_and_validate_data(filepath: str, id_col: str, fc_col: str, pval_col: st
                 })
 
         df = pd.DataFrame(df_expanded, columns=['ID', 'log2FC', 'pval']).dropna()
+
+        # Nothing survived. Before issue #80 this could not happen — every row
+        # produced at least the pseudo-gene "NAN" — so downstream code assumes a
+        # non-empty frame and process_gene_expression() would raise a bare
+        # KeyError on 'ID' (an empty groupby yields no rows, and pd.DataFrame([])
+        # has no columns), surfacing as the catch-all "unexpected error" page.
+        # The realistic cause is a user picking the wrong column, so say which
+        # column was read and what was wrong with it.
+        if not len(df):
+            if not df_expanded:
+                raise DataValidationError(
+                    f"No usable gene identifiers were found in column '{id_col}'. "
+                    f"All {dropped_rows} row(s) were blank or a missing-value "
+                    f"placeholder — check that '{id_col}' is the gene identifier "
+                    f"column.",
+                    field="id_column",
+                    value=id_col
+                )
+            raise DataValidationError(
+                f"No usable rows were found: every row read from column "
+                f"'{id_col}' was dropped because '{fc_col}' or '{pval_col}' was "
+                f"missing. Check that the fold-change and p-value columns are "
+                f"correct.",
+                field="columns",
+                value=str([id_col, fc_col, pval_col])
+            )
 
         # Carried through process_gene_expression() into its stats dict so the
         # count can be shown next to the background size.

--- a/services/data_service.py
+++ b/services/data_service.py
@@ -11,6 +11,10 @@ from exceptions import FileProcessingError, DataValidationError, AOPDataError
 
 logger = logging.getLogger(__name__)
 
+# Placeholders that pandas/R/Excel write for a missing gene symbol. Compared
+# against the upper-cased, stripped identifier (issue #80).
+_MISSING_ID_TOKENS = {'NAN', 'NA', 'NONE', 'NULL', '#N/A', '-', '.'}
+
 def load_and_validate_data(filepath: str, id_col: str, fc_col: str, pval_col: str) -> pd.DataFrame:
     """
     Load and validate gene expression data from file.
@@ -41,20 +45,44 @@ def load_and_validate_data(filepath: str, id_col: str, fc_col: str, pval_col: st
                 value=str(missing_cols)
             )
         
-        # Expand if symbols are separated by '///'
+        # Expand if symbols are separated by '///'.
+        #
+        # Issue #80: rows with no gene symbol used to survive this loop as the
+        # literal identifier "NAN" (str(NaN).upper()), so every symbol-less row
+        # in the upload collapsed into a single pseudo-gene that inflated the
+        # background by one and, if it passed the significance threshold, took
+        # part in every Fisher test while being unable to overlap any KE gene
+        # set. Such rows are dropped up front and counted, so the discard is
+        # reported rather than silently renamed.
         df_expanded = []
+        dropped_rows = 0
         for _, row in df_raw.iterrows():
-            genes = str(row[id_col]).split('///')
+            raw_id = row[id_col]
+            genes = [g.strip().upper() for g in str(raw_id).split('///')]
+            genes = [g for g in genes if g and g not in _MISSING_ID_TOKENS]
+            if not genes:
+                dropped_rows += 1
+                continue
             for gene in genes:
                 df_expanded.append({
-                    'ID': gene.strip().upper(),
+                    'ID': gene,
                     'log2FC': row[fc_col],
                     'pval': row[pval_col]
                 })
-        
-        df = pd.DataFrame(df_expanded).dropna()
+
+        df = pd.DataFrame(df_expanded, columns=['ID', 'log2FC', 'pval']).dropna()
+
+        # Carried through process_gene_expression() into its stats dict so the
+        # count can be shown next to the background size.
+        df.attrs['dropped_unidentified_rows'] = dropped_rows
+
+        if dropped_rows:
+            logger.info(
+                f"Dropped {dropped_rows} row(s) without a usable gene identifier "
+                f"in column '{id_col}'"
+            )
         logger.info(f"Expanded to {len(df)} gene entries after processing")
-        
+
         return df
         
     except DataValidationError:
@@ -119,10 +147,19 @@ def process_gene_expression(df: pd.DataFrame, logfc_threshold: float = 0.0, pval
         'significant_genes': n_sig,
         'non_significant_genes': n_non_sig,
         'logfc_threshold': logfc_threshold,
-        'pval_threshold': effective_pval
+        'pval_threshold': effective_pval,
+        # Issue #80: rows the loader discarded for having no gene identifier.
+        # Reported alongside the background size so 'total_genes' can be quoted
+        # as the number of measured genes and the discard stays visible.
+        'dropped_unidentified_rows': int(df.attrs.get('dropped_unidentified_rows', 0)),
     }
-    
-    logger.info(f"Processed {stats['total_genes']} unique genes: {stats['significant_genes']} significant, {stats['non_significant_genes']} non-significant")
+
+
+    logger.info(
+        f"Processed {stats['total_genes']} unique genes: {stats['significant_genes']} significant, "
+        f"{stats['non_significant_genes']} non-significant "
+        f"({stats['dropped_unidentified_rows']} row(s) dropped without a gene identifier)"
+    )
     
     if n_sig == 0:
         logger.warning("No significant genes found. Check thresholds.")

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import pytest
 import pandas as pd
+from exceptions import DataValidationError
 from services.data_service import (
     load_and_validate_data,
     process_gene_expression,
@@ -236,6 +237,38 @@ class TestMissingGeneSymbols:
         df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
         assert set(df['ID']) == {'BRCA1', 'TP53'}
         assert df.attrs['dropped_unidentified_rows'] == 0
+
+    def test_no_usable_identifier_raises_named_validation_error(self, tmp_path):
+        """A wrong ID column must be reported, not crash downstream.
+
+        Dropping symbol-less rows can empty the frame outright (the realistic
+        cause is a user pointing the wizard at the wrong column). An empty frame
+        used to reach process_gene_expression(), whose groupby yields no rows,
+        so the next read of ['ID'] raised a bare KeyError and the request fell
+        through to the "unexpected error" catch-all.
+        """
+        path = self._write_tsv(str(tmp_path / 'wrongcol.tsv'), {
+            'Gene': ['BRCA1', 'TP53'],
+            'Empty': [None, None],
+            'logFC': [1.5, -0.8],
+            'pval': [0.001, 0.05],
+        })
+        with pytest.raises(DataValidationError) as excinfo:
+            load_and_validate_data(path, 'Empty', 'logFC', 'pval')
+        message = str(excinfo.value)
+        assert 'Empty' in message
+        assert 'identifier' in message.lower()
+
+    def test_pandas_na_vocabulary_is_covered(self, tmp_path):
+        """The placeholder set agrees with pandas' own missing-value words."""
+        path = self._write_tsv(str(tmp_path / 'vocab.tsv'), {
+            'Gene': ['BRCA1', 'N/A', 'null', 'None', '<NA>', '#N/A', '--', '?'],
+            'logFC': [1.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            'pval': [0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        assert set(df['ID']) == {'BRCA1'}
+        assert df.attrs['dropped_unidentified_rows'] == 7
 
     def test_missing_symbol_row_cannot_be_significant(self, tmp_path):
         """A symbol-less row used to enter every Fisher test as 'NAN'."""

--- a/tests/test_data_service.py
+++ b/tests/test_data_service.py
@@ -164,3 +164,87 @@ class TestComputeLogfcPercentiles:
         """No usable data yields no thresholds rather than raising."""
         assert compute_logfc_percentiles(pd.Series([], dtype=float)) == {}
         assert compute_logfc_percentiles(pd.Series([None, None], dtype=object)) == {}
+
+
+class TestMissingGeneSymbols:
+    """Rows without a gene symbol must not become a pseudo-gene (issue #80)."""
+
+    def _write_tsv(self, path, data):
+        pd.DataFrame(data).to_csv(path, sep='\t', index=False)
+        return path
+
+    def test_missing_symbol_does_not_become_nan_gene(self, tmp_path):
+        path = self._write_tsv(str(tmp_path / 'missing.tsv'), {
+            'Gene': ['BRCA1', None, 'TP53', None],
+            'logFC': [1.5, 3.0, -0.8, 2.2],
+            'pval': [0.001, 0.001, 0.05, 0.001],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        assert 'NAN' not in set(df['ID'])
+        assert set(df['ID']) == {'BRCA1', 'TP53'}
+
+    def test_background_is_the_number_of_measured_genes(self, tmp_path):
+        """The background must not be inflated by the discarded rows."""
+        path = self._write_tsv(str(tmp_path / 'bg.tsv'), {
+            'Gene': ['BRCA1', None, 'TP53', float('nan'), 'EGFR'],
+            'logFC': [1.5, 3.0, -0.8, 2.2, 1.1],
+            'pval': [0.001, 0.001, 0.05, 0.001, 0.001],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        _, stats = process_gene_expression(df, logfc_threshold=0.0)
+        assert stats['total_genes'] == 3
+
+    def test_dropped_row_count_is_reported(self, tmp_path):
+        path = self._write_tsv(str(tmp_path / 'dropped.tsv'), {
+            'Gene': ['BRCA1', None, None, 'TP53'],
+            'logFC': [1.5, 3.0, 2.2, -0.8],
+            'pval': [0.001, 0.001, 0.001, 0.05],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        assert df.attrs['dropped_unidentified_rows'] == 2
+        _, stats = process_gene_expression(df, logfc_threshold=0.0)
+        assert stats['dropped_unidentified_rows'] == 2
+
+    def test_no_discards_reports_zero(self, tmp_path):
+        path = self._write_tsv(str(tmp_path / 'clean.tsv'), {
+            'Gene': ['BRCA1', 'TP53'],
+            'logFC': [1.5, -0.8],
+            'pval': [0.001, 0.05],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        _, stats = process_gene_expression(df, logfc_threshold=0.0)
+        assert stats['dropped_unidentified_rows'] == 0
+
+    def test_placeholder_strings_are_discarded(self, tmp_path):
+        """Literal NA / nan / empty placeholders are not gene symbols."""
+        path = self._write_tsv(str(tmp_path / 'placeholders.tsv'), {
+            'Gene': ['BRCA1', 'NA', 'nan', '-', 'TP53'],
+            'logFC': [1.5, 3.0, 2.0, 1.0, -0.8],
+            'pval': [0.001, 0.001, 0.001, 0.001, 0.05],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        assert set(df['ID']) == {'BRCA1', 'TP53'}
+        assert df.attrs['dropped_unidentified_rows'] == 3
+
+    def test_partial_multi_symbol_row_keeps_real_symbols(self, tmp_path):
+        """A '///' row with one usable symbol keeps it and is not counted as dropped."""
+        path = self._write_tsv(str(tmp_path / 'partial.tsv'), {
+            'Gene': ['BRCA1///NA', 'TP53'],
+            'logFC': [1.5, -0.8],
+            'pval': [0.001, 0.05],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        assert set(df['ID']) == {'BRCA1', 'TP53'}
+        assert df.attrs['dropped_unidentified_rows'] == 0
+
+    def test_missing_symbol_row_cannot_be_significant(self, tmp_path):
+        """A symbol-less row used to enter every Fisher test as 'NAN'."""
+        path = self._write_tsv(str(tmp_path / 'sig.tsv'), {
+            'Gene': ['BRCA1', None],
+            'logFC': [1.5, 9.0],
+            'pval': [0.001, 0.0001],
+        })
+        df = load_and_validate_data(path, 'Gene', 'logFC', 'pval')
+        result, stats = process_gene_expression(df, logfc_threshold=1.0)
+        assert stats['significant_genes'] == 1
+        assert 'NAN' not in set(result['ID'])

--- a/tests/test_genes_export_order.py
+++ b/tests/test_genes_export_order.py
@@ -45,12 +45,18 @@ def _seed(db_manager, uuid, ke_gene_map, labels=('C0', 'C1')):
         session.add(batch)
         session.flush()
         for pos, label in enumerate(labels):
+            # A list gives each condition its own map, so a gene can drive one
+            # condition without driving the others.
+            per_condition = (
+                ke_gene_map[pos] if isinstance(ke_gene_map, (list, tuple))
+                else ke_gene_map
+            )
             session.add(ConditionRecord(
                 batch_id=batch.id, position=pos, filename=f'c{pos}.tsv',
                 condition_label=label, dose=label, timepoint='4hr',
                 status='complete', gene_count=3, significant_genes=3,
                 enrichment_json=json.dumps(_ENRICHMENT),
-                ke_gene_json=json.dumps(ke_gene_map),
+                ke_gene_json=json.dumps(per_condition),
             ))
         session.commit()
     finally:
@@ -80,9 +86,18 @@ _DOSE_MAP = {
 }
 _DOSE_LABELS = ('2uM', '10uM')
 
+# Within KE:2, ZZZ drives both conditions and AAA only one. A plain
+# (KE, gene) sort would list AAA first and silently drop the shared-first
+# grouping the summary view exists to show.
+_SHARED_MAPS = (
+    {'KE:2': [_sig('ZZZ', 2.0), _sig('AAA', 1.5)]},
+    {'KE:2': [_sig('ZZZ', 2.1)]},
+)
+
 _UUID_A = '22222222-2222-2222-2222-222222222222'
 _UUID_B = '33333333-3333-3333-3333-333333333333'
 _UUID_DOSE = '44444444-4444-4444-4444-444444444444'
+_UUID_SHARED = '55555555-5555-5555-5555-555555555555'
 
 
 @pytest.fixture
@@ -91,6 +106,7 @@ def two_batches(flask_client, temp_database, monkeypatch):
     _seed(temp_database, _UUID_A, _ORDER_A)
     _seed(temp_database, _UUID_B, _ORDER_B)
     _seed(temp_database, _UUID_DOSE, _DOSE_MAP, labels=_DOSE_LABELS)
+    _seed(temp_database, _UUID_SHARED, _SHARED_MAPS)
     return flask_client
 
 
@@ -162,6 +178,17 @@ class TestGeneExportDeterminism:
             if not ke_order or ke_order[-1] != row[0]:
                 ke_order.append(row[0])
         assert ke_order == ['KE:2', 'KE:9', 'KE:10']
+
+    def test_summary_view_keeps_shared_first_ordering(self, two_batches):
+        """Sorting the export must not undo the summary's shared-first order.
+
+        A gene driving several conditions is listed above one driving a single
+        condition, which is the point of the summary view; re-sorting on Key
+        Event and gene symbol alone would replace that with the alphabet.
+        """
+        rows = _rows(two_batches, _UUID_SHARED, view='summary')
+        ke2 = [row[2] for row in rows if row[0] == 'KE:2']
+        assert ke2 == ['ZZZ', 'AAA']
 
     def test_conditions_follow_upload_order_not_alphabetical(self, two_batches):
         """A dose series must not be reordered as text ('10uM' before '2uM')."""

--- a/tests/test_genes_export_order.py
+++ b/tests/test_genes_export_order.py
@@ -1,0 +1,121 @@
+"""Row-order determinism of the driver-gene export (issue #82).
+
+The long view used to inherit its order from dict iteration over each
+condition's stored KE->gene map, so two runs over identical result data
+produced CSVs that were equal only after sorting. These tests seed two
+batches holding the same driver genes in different insertion orders and
+assert the exports are byte-identical.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import app as app_module
+from database import BatchRecord, ConditionRecord
+
+
+def _expiry():
+    return datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=14)
+
+
+_ENRICHMENT = [
+    {'KE': 'KE:2', 'Title': 'Beta', 'p_value': 0.001, 'FDR': 0.01,
+     'num_overlap': 2, 'odds_ratio': 2.0, 'total_KE_genes_in_dataset': 10},
+    {'KE': 'KE:10', 'Title': 'Gamma', 'p_value': 0.002, 'FDR': 0.02,
+     'num_overlap': 2, 'odds_ratio': 2.0, 'total_KE_genes_in_dataset': 10},
+    {'KE': 'KE:9', 'Title': 'Delta', 'p_value': 0.003, 'FDR': 0.03,
+     'num_overlap': 2, 'odds_ratio': 2.0, 'total_KE_genes_in_dataset': 10},
+]
+
+
+def _seed(db_manager, uuid, ke_gene_map):
+    session = db_manager.get_session()
+    try:
+        batch = BatchRecord(
+            uuid=uuid, status='complete', aop_id='AOP:1', aop_label='Test AOP',
+            logfc_threshold=1.0, pval_cutoff=0.05, selected_resources='WikiPathways',
+            id_column='gene', fc_column='logFC', pval_column='pval',
+            harmonised_background=json.dumps(['TP53', 'EGFR', 'BRCA1']),
+            harmonised_gene_count=3, batch_name='Order Test', expires_at=_expiry(),
+        )
+        session.add(batch)
+        session.flush()
+        for pos in range(2):
+            session.add(ConditionRecord(
+                batch_id=batch.id, position=pos, filename=f'c{pos}.tsv',
+                condition_label=f'C{pos}', dose=f'{pos + 1}uM', timepoint='4hr',
+                status='complete', gene_count=3, significant_genes=3,
+                enrichment_json=json.dumps(_ENRICHMENT),
+                ke_gene_json=json.dumps(ke_gene_map),
+            ))
+        session.commit()
+    finally:
+        session.close()
+
+
+def _sig(gene, logfc):
+    return {'id': gene, 'log2FC': logfc, 'significant': True}
+
+
+# Same content, different insertion order for both KEs and genes.
+_ORDER_A = {
+    'KE:2': [_sig('TP53', 2.0), _sig('BRCA1', 1.5)],
+    'KE:10': [_sig('EGFR', 1.1), _sig('TP53', 2.2)],
+    'KE:9': [_sig('BRCA1', -1.7)],
+}
+_ORDER_B = {
+    'KE:9': [_sig('BRCA1', -1.7)],
+    'KE:10': [_sig('TP53', 2.2), _sig('EGFR', 1.1)],
+    'KE:2': [_sig('BRCA1', 1.5), _sig('TP53', 2.0)],
+}
+
+_UUID_A = '22222222-2222-2222-2222-222222222222'
+_UUID_B = '33333333-3333-3333-3333-333333333333'
+
+
+@pytest.fixture
+def two_batches(flask_client, temp_database, monkeypatch):
+    monkeypatch.setattr(app_module, 'db_manager', temp_database)
+    _seed(temp_database, _UUID_A, _ORDER_A)
+    _seed(temp_database, _UUID_B, _ORDER_B)
+    return flask_client
+
+
+class TestGeneExportDeterminism:
+    @pytest.mark.parametrize('view', ['long', 'summary'])
+    def test_identical_result_data_gives_identical_bytes(self, two_batches, view):
+        client = two_batches
+        first = client.get(f'/batch/{_UUID_A}/genes/export?fmt=csv&view={view}')
+        second = client.get(f'/batch/{_UUID_B}/genes/export?fmt=csv&view={view}')
+        assert first.status_code == second.status_code == 200
+        assert first.get_data() == second.get_data()
+
+    def test_repeated_export_is_stable(self, two_batches):
+        client = two_batches
+        bodies = {
+            client.get(f'/batch/{_UUID_A}/genes/export?fmt=csv&view=long').get_data()
+            for _ in range(3)
+        }
+        assert len(bodies) == 1
+
+    def test_ke_ids_sorted_numerically(self, two_batches):
+        client = two_batches
+        body = client.get(
+            f'/batch/{_UUID_A}/genes/export?fmt=csv&view=long'
+        ).get_data(as_text=True)
+        rows = [line.split(',') for line in body.strip().splitlines()[1:]]
+        ke_order = []
+        for row in rows:
+            if not ke_order or ke_order[-1] != row[0]:
+                ke_order.append(row[0])
+        assert ke_order == ['KE:2', 'KE:9', 'KE:10']
+
+    def test_genes_sorted_within_ke(self, two_batches):
+        client = two_batches
+        body = client.get(
+            f'/batch/{_UUID_A}/genes/export?fmt=csv&view=long'
+        ).get_data(as_text=True)
+        rows = [line.split(',') for line in body.strip().splitlines()[1:]]
+        ke2 = [r[2] for r in rows if r[0] == 'KE:2']
+        assert ke2 == sorted(ke2)

--- a/tests/test_genes_export_order.py
+++ b/tests/test_genes_export_order.py
@@ -1,10 +1,12 @@
-"""Row-order determinism of the driver-gene export (issue #82).
+"""Row-order determinism of the driver-gene tracking and export (issue #82).
 
-The long view used to inherit its order from dict iteration over each
-condition's stored KE->gene map, so two runs over identical result data
-produced CSVs that were equal only after sorting. These tests seed two
-batches holding the same driver genes in different insertion orders and
-assert the exports are byte-identical.
+``build_gene_tracking`` used to append its records in dict-iteration order over
+each condition's stored ``ke_gene_json``, so the Genes tab payload, the batch
+report and the CSV/Excel export all inherited an order that was an artefact of
+how the JSON happened to be written. These tests pin the order at both ends:
+directly on ``build_gene_tracking`` (the source) and through the export route
+(the boundary), seeding batches that hold the same driver genes in different
+insertion orders.
 """
 import json
 from datetime import datetime, timedelta, timezone
@@ -13,6 +15,7 @@ import pytest
 
 import app as app_module
 from database import BatchRecord, ConditionRecord
+from services.comparison_service import build_gene_tracking
 
 
 def _expiry():
@@ -29,7 +32,7 @@ _ENRICHMENT = [
 ]
 
 
-def _seed(db_manager, uuid, ke_gene_map):
+def _seed(db_manager, uuid, ke_gene_map, labels=('C0', 'C1')):
     session = db_manager.get_session()
     try:
         batch = BatchRecord(
@@ -41,10 +44,10 @@ def _seed(db_manager, uuid, ke_gene_map):
         )
         session.add(batch)
         session.flush()
-        for pos in range(2):
+        for pos, label in enumerate(labels):
             session.add(ConditionRecord(
                 batch_id=batch.id, position=pos, filename=f'c{pos}.tsv',
-                condition_label=f'C{pos}', dose=f'{pos + 1}uM', timepoint='4hr',
+                condition_label=label, dose=label, timepoint='4hr',
                 status='complete', gene_count=3, significant_genes=3,
                 enrichment_json=json.dumps(_ENRICHMENT),
                 ke_gene_json=json.dumps(ke_gene_map),
@@ -70,8 +73,16 @@ _ORDER_B = {
     'KE:2': [_sig('BRCA1', 1.5), _sig('TP53', 2.0)],
 }
 
+# A dose series: label order and upload order disagree lexically.
+_DOSE_MAP = {
+    'KE:2': [_sig('TP53', 2.0), _sig('BRCA1', 1.5)],
+    'KE:10': [_sig('EGFR', 1.1)],
+}
+_DOSE_LABELS = ('2uM', '10uM')
+
 _UUID_A = '22222222-2222-2222-2222-222222222222'
 _UUID_B = '33333333-3333-3333-3333-333333333333'
+_UUID_DOSE = '44444444-4444-4444-4444-444444444444'
 
 
 @pytest.fixture
@@ -79,7 +90,54 @@ def two_batches(flask_client, temp_database, monkeypatch):
     monkeypatch.setattr(app_module, 'db_manager', temp_database)
     _seed(temp_database, _UUID_A, _ORDER_A)
     _seed(temp_database, _UUID_B, _ORDER_B)
+    _seed(temp_database, _UUID_DOSE, _DOSE_MAP, labels=_DOSE_LABELS)
     return flask_client
+
+
+def _rows(client, uuid, view='long'):
+    body = client.get(
+        f'/batch/{uuid}/genes/export?fmt=csv&view={view}'
+    ).get_data(as_text=True)
+    return [line.split(',') for line in body.strip().splitlines()[1:]]
+
+
+class _StubCondition:
+    """Minimal stand-in for a ConditionRecord for the unit-level tests."""
+
+    def __init__(self, label, ke_gene_map):
+        self.condition_label = label
+        self.ke_gene_json = json.dumps(ke_gene_map)
+        self.enrichment_json = json.dumps(_ENRICHMENT)
+
+
+class TestGeneTrackingRecordOrder:
+    """The source of the order, not just the export boundary."""
+
+    def test_records_are_ordered_independently_of_json_key_order(self):
+        first = build_gene_tracking([
+            _StubCondition('C0', _ORDER_A), _StubCondition('C1', _ORDER_A),
+        ])
+        second = build_gene_tracking([
+            _StubCondition('C0', _ORDER_B), _StubCondition('C1', _ORDER_B),
+        ])
+        assert first['records'] == second['records']
+
+    def test_records_are_ke_numeric_then_gene_then_upload_position(self):
+        tracking = build_gene_tracking([
+            _StubCondition(label, _DOSE_MAP) for label in _DOSE_LABELS
+        ])
+        triples = [
+            (r['KE_ID'], r['Gene_Symbol'], r['Condition'])
+            for r in tracking['records']
+        ]
+        assert triples == [
+            ('KE:2', 'BRCA1', '2uM'),
+            ('KE:2', 'BRCA1', '10uM'),
+            ('KE:2', 'TP53', '2uM'),
+            ('KE:2', 'TP53', '10uM'),
+            ('KE:10', 'EGFR', '2uM'),
+            ('KE:10', 'EGFR', '10uM'),
+        ]
 
 
 class TestGeneExportDeterminism:
@@ -91,31 +149,41 @@ class TestGeneExportDeterminism:
         assert first.status_code == second.status_code == 200
         assert first.get_data() == second.get_data()
 
-    def test_repeated_export_is_stable(self, two_batches):
-        client = two_batches
-        bodies = {
-            client.get(f'/batch/{_UUID_A}/genes/export?fmt=csv&view=long').get_data()
-            for _ in range(3)
-        }
-        assert len(bodies) == 1
+    def test_summary_view_ke_order_is_numeric(self, two_batches):
+        """The summary frame is sorted too, not merely stable by accident.
 
-    def test_ke_ids_sorted_numerically(self, two_batches):
-        client = two_batches
-        body = client.get(
-            f'/batch/{_UUID_A}/genes/export?fmt=csv&view=long'
-        ).get_data(as_text=True)
-        rows = [line.split(',') for line in body.strip().splitlines()[1:]]
+        The wide view was already insertion-order-independent, so byte equality
+        between two batches proves nothing about it. Its KE order, however, was
+        a lexical sort of the KE ID — 'KE:10' ahead of 'KE:2'.
+        """
+        rows = _rows(two_batches, _UUID_A, view='summary')
         ke_order = []
         for row in rows:
             if not ke_order or ke_order[-1] != row[0]:
                 ke_order.append(row[0])
         assert ke_order == ['KE:2', 'KE:9', 'KE:10']
 
+    def test_conditions_follow_upload_order_not_alphabetical(self, two_batches):
+        """A dose series must not be reordered as text ('10uM' before '2uM')."""
+        rows = _rows(two_batches, _UUID_DOSE)
+        triples = [(r[0], r[2], r[3]) for r in rows]
+        assert triples == [
+            ('KE:2', 'BRCA1', '2uM'),
+            ('KE:2', 'BRCA1', '10uM'),
+            ('KE:2', 'TP53', '2uM'),
+            ('KE:2', 'TP53', '10uM'),
+            ('KE:10', 'EGFR', '2uM'),
+            ('KE:10', 'EGFR', '10uM'),
+        ]
+
+    def test_ke_ids_sorted_numerically(self, two_batches):
+        ke_order = []
+        for row in _rows(two_batches, _UUID_A):
+            if not ke_order or ke_order[-1] != row[0]:
+                ke_order.append(row[0])
+        assert ke_order == ['KE:2', 'KE:9', 'KE:10']
+
     def test_genes_sorted_within_ke(self, two_batches):
-        client = two_batches
-        body = client.get(
-            f'/batch/{_UUID_A}/genes/export?fmt=csv&view=long'
-        ).get_data(as_text=True)
-        rows = [line.split(',') for line in body.strip().splitlines()[1:]]
+        rows = _rows(two_batches, _UUID_A)
         ke2 = [r[2] for r in rows if r[0] == 'KE:2']
         assert ke2 == sorted(ke2)


### PR DESCRIPTION
Closes #82. Advances #80 (the display half — reporting the discard count next to the background size — stays open).

## #80 — rows without a gene symbol entered the background as a gene called `NAN`

`str()` on a missing value yields `'nan'`, uppercased into a literal identifier, so every symbol-less row in an upload collapsed into one pseudo-gene. On a DESeq2 table of 13814 rows (12939 with a symbol, 12914 distinct) the tool reported a background of **12915** — the extra entry standing in for 875 discarded rows. That number cannot honestly be quoted in a methods section, and a symbol-less row passing the threshold made `NAN` a significant gene that can never overlap a KE gene set, biasing every Fisher test slightly toward the null.

Rows whose identifier is null, empty or a missing-value placeholder are now dropped before expansion; `A///NA` keeps its real symbol. A file where *no* row yields a usable identifier — most often a wrong ID column — now fails with a validation error naming that column instead of the generic error page.

## #82 — `genes_export.csv` row order was not deterministic

`build_gene_tracking` appended records in dict-iteration order over each condition's stored KE→gene map, so two runs over identical results produced files equal only once sorted. Records are ordered at the source now, and the export re-applies that order: Key Event numerically (`KE:10` after `KE:9`), then gene, then condition **in upload order** — sorting labels as text puts `10uM` before `2uM` and breaks a dose series. The summary view keeps its shared-first grouping.

## Verification

447 tests pass (coverage 77.7%, gate 75%). New tests were checked to fail against the pre-fix code.