### PR TITLE
Tell a curation gap apart from an unresolvable mapping (#81)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,11 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   known but went unmeasured in the uploaded dataset were all reported as *"excluded (no gene
   set mapped)"*. They call for opposite responses: the first is a curation gap to fill in the
   molAOP Builder, the second is stale reference data in this tool and should be reported as a
-  bug, the third is a fact about the experiment's coverage and about nobody's curation. In a
-  WikiPathways-only run on AOP:472, KE 1115 was listed among the unmapped despite carrying a
+  bug, the third is a fact about the experiment's coverage and about nobody's curation. The
+  case that exposed it was KE 1115 on AOP:472, listed among the unmapped while carrying a
   live, high-confidence mapping to `WP5477` — a data-pipeline failure presented as missing
-  curation.
+  curation. (#79 has since made `WP5477` resolvable, so that particular Key Event is now
+  tested; the reporting bug it exposed outlived it.)
 
   Exclusions are now counted under three separate reasons — no curated mapping, mapped but
   unresolvable, and fewer than `MIN_KE_GENES` measured genes (zero measured genes included,
@@ -50,8 +51,22 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   clause **names the pathway IDs** so the claim can be checked against the Builder. The
   wording still comes from the single authority `format_ke_summary()`, so the results page,
   the single report and the batch report say the same thing; the network styles the new
-  reason apart from an uncurated Key Event, and its legend distinguishes them. Summaries and
-  networks stored before the split carry only the old reasons and render exactly as they did.
+  reason apart from an uncurated Key Event, and both the results page and the shared-link
+  view carry that style and legend entry. Summaries and networks stored before the split
+  carry only the old reasons and render exactly as they did.
+
+  Telling the two apart needs one piece of information that used to be thrown away: which
+  Key Event each unresolvable pathway belongs to. The KE→pathway mappings are merged with
+  pathway membership on an inner join, so a Key Event whose only pathway is unresolvable
+  never reaches the reference sets at all and is indistinguishable, downstream, from one
+  nobody has mapped. `load_reference_sets()` now builds that map *before* the merge and
+  carries it on the returned gene sets, which is what lets both the single-analysis route
+  and the batch runner hand it to the enrichment backend, and what puts the pathway IDs on
+  the network nodes so a batch report or shared link rebuilt from stored network JSON still
+  names them. Against the live Builder today, three mapped pathways resolve in neither
+  source (`WP1234`, `WP3980`, `WP4010`) and six Key Events are affected: KE 345, for
+  instance, is now reported as *"1 excluded (mapped, but no genes could be resolved:
+  WP4010)"* rather than counted among the uncurated.
 
 - **WikiPathways gene membership no longer comes only from a bundled snapshot** (#79).
   KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,27 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Fixed
 
+- **"No gene set mapped" no longer covers Key Events that are mapped** (#81). The
+  per-condition accounting had two exclusion counters, and one of them was answering three
+  different questions at once. A Key Event with no curated mapping, a Key Event whose
+  mapping exists but could not be resolved to genes (#79), and a Key Event whose gene set is
+  known but went unmeasured in the uploaded dataset were all reported as *"excluded (no gene
+  set mapped)"*. They call for opposite responses: the first is a curation gap to fill in the
+  molAOP Builder, the second is stale reference data in this tool and should be reported as a
+  bug, the third is a fact about the experiment's coverage and about nobody's curation. In a
+  WikiPathways-only run on AOP:472, KE 1115 was listed among the unmapped despite carrying a
+  live, high-confidence mapping to `WP5477` — a data-pipeline failure presented as missing
+  curation.
+
+  Exclusions are now counted under three separate reasons — no curated mapping, mapped but
+  unresolvable, and fewer than `MIN_KE_GENES` measured genes (zero measured genes included,
+  since that is a coverage number, not a curation one) — and the mapped-but-unresolvable
+  clause **names the pathway IDs** so the claim can be checked against the Builder. The
+  wording still comes from the single authority `format_ke_summary()`, so the results page,
+  the single report and the batch report say the same thing; the network styles the new
+  reason apart from an uncurated Key Event, and its legend distinguishes them. Summaries and
+  networks stored before the split carry only the old reasons and render exactly as they did.
+
 - **WikiPathways gene membership no longer comes only from a bundled snapshot** (#79).
   KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was
   resolved against `data/edges_wpid_to_gene.csv` — a snapshot topping out at `WP5452`. Any

--- a/app.py
+++ b/app.py
@@ -24,7 +24,9 @@ from helpers import (
     DEFAULT_MIN_CONFIDENCE,
     MIN_CONFIDENCE_LABELS,
     VALID_MIN_CONFIDENCE,
+    ReferenceSets,
     load_reference_sets,
+    unresolved_ke_pathways_for,
 )
 from cache_manager import cache, cached_data_loader, get_reference_cache
 from services.api_service import (
@@ -834,6 +836,13 @@ def analyze():
             resources, min_confidence=min_confidence
         )
 
+        # Issue #81: a KE whose only pathway could not be resolved to genes is
+        # absent from the reference sets exactly like an uncurated one. This
+        # map is the only thing that tells the two apart, so it has to reach
+        # the enrichment backend — without it the run reports a live, curated
+        # mapping as a curation gap.
+        unresolved_ke_pathways = unresolved_ke_pathways_for(current_reference_sets)
+
         # Pre-build gene_logfc_map so the enrichment service can derive the
         # observed Direction column ("N↑ / M↓") for each KE alongside the
         # direction-agnostic Fisher result. Reused below for the per-KE
@@ -855,6 +864,7 @@ def analyze():
                 method,
                 df_processed, current_reference_sets, ke_list, ke_title_map,
                 gene_logfc_map=gene_logfc_map if method == 'ora' else None,
+                unresolved_ke_pathways=unresolved_ke_pathways,
             )
         except ValueError:
             # Issue #69: with the wrong ID column nothing overlaps, every KE is
@@ -885,6 +895,7 @@ def analyze():
             reference_sets=current_reference_sets,
             method=method,
             excluded_kes=(ke_summary or {}).get('excluded_reasons'),
+            unresolved_ke_pathways=(ke_summary or {}).get('unresolved_pathways_by_ke'),
         )
 
         # Plan 11-03 (D-04 passthrough): capture raw and adjusted p-value
@@ -1459,43 +1470,62 @@ def _load_wikipathways_reference_sets(min_confidence=DEFAULT_MIN_CONFIDENCE):
             sets are built; the cache entry is keyed by the threshold.
 
     Returns:
-        tuple: (reference_sets dict, source string) where source is one of
-        'api', 'cache(api)', 'cache(csv)', 'csv'. Issue #68: a cache hit keeps
-        the original provenance rather than collapsing to 'cache' — otherwise a
-        set built from the bundled CSVs during a Builder outage is
-        indistinguishable, one cache hop later, from a live API response.
+        tuple: (reference_sets, source, unresolved_pathways, unresolved_ke_pathways).
+
+        ``source`` is one of 'api', 'cache(api)', 'cache(csv)', 'csv'. Issue
+        #68: a cache hit keeps the original provenance rather than collapsing
+        to 'cache' — otherwise a set built from the bundled CSVs during a
+        Builder outage is indistinguishable, one cache hop later, from a live
+        API response.
+
+        ``unresolved_pathways`` (#79) lists the mapped pathway IDs no source
+        could resolve to genes; ``unresolved_ke_pathways`` (#81) attributes
+        those pathways to their Key Events, which is what lets the enrichment
+        backends tell a mapped-but-unresolvable KE apart from an uncurated
+        one. The returned mapping also carries that map on
+        ``.unresolved_ke_pathways`` (see ``helpers.ReferenceSets``).
     """
     cache_key = _confidence_cache_key(REFERENCE_CACHE_KEY, min_confidence)
     cached = _reference_cache.get(cache_key)
     if cached is not None:
-        # Entries written before #79 are 2-tuples; treat them as "nothing known
-        # to be unresolved" rather than invalidating a warm cache on deploy.
-        if len(cached) == 3:
+        # Entries written before #79 are 2-tuples and before #81 3-tuples;
+        # treat them as "nothing known to be unresolved" rather than
+        # invalidating a warm cache on deploy.
+        unresolved_ke = {}
+        if len(cached) == 4:
+            reference_sets, original_source, unresolved, unresolved_ke = cached
+        elif len(cached) == 3:
             reference_sets, original_source, unresolved = cached
         else:
             reference_sets, original_source = cached
             unresolved = []
+        # An old entry pickled a plain dict; rewrap so the attribute-carrying
+        # contract holds for every caller regardless of cache age.
+        reference_sets = ReferenceSets(
+            reference_sets, unresolved_ke_pathways=unresolved_ke
+        )
         logger.info(
             f"Loaded {len(reference_sets)} WikiPathways KE sets from disk cache "
             f"(originally from {original_source}, min_confidence={min_confidence})"
         )
-        return reference_sets, f"cache({original_source})", unresolved
+        return reference_sets, f"cache({original_source})", unresolved, unresolved_ke
 
     # Try API
     try:
         reference_sets, unresolved = fetch_reference_sets_from_api(
             Config, min_confidence=min_confidence
         )
+        unresolved_ke = unresolved_ke_pathways_for(reference_sets)
         _reference_cache.set(
             cache_key,
-            (reference_sets, "api", unresolved),
+            (dict(reference_sets), "api", unresolved, unresolved_ke),
             expire=Config.CACHE_TTL,
         )
         logger.info(
             f"Loaded {len(reference_sets)} WikiPathways KE sets from Builder API, "
             f"cached for {Config.CACHE_TTL}s"
         )
-        return reference_sets, "api", unresolved
+        return reference_sets, "api", unresolved, unresolved_ke
     except Exception as exc:
         logger.warning(
             f"Builder API unavailable ({exc}); falling back to local CSV files"
@@ -1511,16 +1541,18 @@ def _load_wikipathways_reference_sets(min_confidence=DEFAULT_MIN_CONFIDENCE):
         min_confidence=min_confidence,
         unresolved_out=unresolved,
     )
+    unresolved_ke = unresolved_ke_pathways_for(reference_sets)
+    unresolved = sorted(set(unresolved))
     _reference_cache.set(
         cache_key,
-        (reference_sets, "csv", unresolved),
+        (dict(reference_sets), "csv", unresolved, unresolved_ke),
         expire=Config.CACHE_TTL,
     )
     logger.info(
         f"Loaded {len(reference_sets)} WikiPathways KE sets from local CSV files, "
         f"cached for {Config.CACHE_TTL}s"
     )
-    return reference_sets, "csv", sorted(set(unresolved))
+    return reference_sets, "csv", unresolved, unresolved_ke
 
 
 def _load_gmt_resource_reference_sets(resource, min_confidence=DEFAULT_MIN_CONFIDENCE):
@@ -1631,7 +1663,15 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
             flows so both stay consistent by construction.
 
     Returns:
-        tuple: (merged reference_sets dict, data_source string, resolution list).
+        tuple: (merged reference sets, data_source string, resolution list).
+
+        The merged sets are a ``helpers.ReferenceSets`` — a dict of KE_ID ->
+        gene set that additionally carries ``.unresolved_ke_pathways``, the
+        union across resources of KE_ID -> pathway IDs that are curated and
+        mapped but that no source could resolve to genes (issue #81). Read it
+        with ``helpers.unresolved_ke_pathways_for()`` and hand it to the
+        enrichment backend, which otherwise cannot tell such a Key Event from
+        one nobody has mapped.
 
         ``data_source`` reflects the WikiPathways component's source
         ('api'/'cache(api)'/'cache(csv)'/'csv') when WikiPathways is selected —
@@ -1645,6 +1685,8 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
              'source': 'api' | 'cache(api)' | 'cache(csv)' | 'csv' | None,
              'ke_count': 412,
              'confidence_applied': False,   # issue #67
+             'unresolved_pathways': ['WP5477'],          # issue #79
+             'unresolved_ke_pathways': {'KE:1115': ['WP5477']},  # issue #81
              'error': 'HTTP 502' or None}
 
         Recording resolution rather than selection is the point: a run where
@@ -1659,16 +1701,21 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
         min_confidence = DEFAULT_MIN_CONFIDENCE
 
     merged = {}
+    # Issue #81: KE -> unresolvable pathway IDs, unioned across resources. This
+    # rides on the merged mapping (helpers.ReferenceSets) so it survives every
+    # hand-off between here and the enrichment backends, including the batch
+    # thread, which is handed nothing but the gene sets.
+    merged_unresolved_ke = {}
     wp_source = None
     loaded = []
     resolution = []
     for resource in selected:
         try:
             unresolved_pathways = []
+            unresolved_ke = {}
             if resource == "WikiPathways":
-                sets, source, unresolved_pathways = _load_wikipathways_reference_sets(
-                    min_confidence
-                )
+                (sets, source, unresolved_pathways,
+                 unresolved_ke) = _load_wikipathways_reference_sets(min_confidence)
                 wp_source = source
             else:
                 sets, source = _load_gmt_resource_reference_sets(resource, min_confidence)
@@ -1683,12 +1730,15 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
                 'ke_count': 0,
                 'confidence_applied': False,
                 'unresolved_pathways': [],
+                'unresolved_ke_pathways': {},
                 'error': str(exc),
             })
             continue
         # Build fresh sets so cached resource sets are never mutated.
         for ke_id, genes in sets.items():
             merged.setdefault(ke_id, set()).update(genes)
+        for ke_id, pathways in (unresolved_ke or {}).items():
+            merged_unresolved_ke.setdefault(ke_id, set()).update(pathways)
         loaded.append(f"{resource}:{source}")
         resolution.append({
             'resource': resource,
@@ -1703,6 +1753,9 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
             # membership no source could resolve. Their KEs silently lose those
             # genes, and a KE that loses all of them looks unmapped.
             'unresolved_pathways': unresolved_pathways,
+            # Issue #81: the same pathways attributed to their Key Events, so a
+            # stored resolution can say which KE was misreported as unmapped.
+            'unresolved_ke_pathways': unresolved_ke,
             'error': None,
         })
 
@@ -1714,10 +1767,16 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
         data_source = "gmt"
 
     logger.info(
-        "Merged %d KE sets across resources [%s] (data_source=%s, min_confidence=%s)",
+        "Merged %d KE sets across resources [%s] (data_source=%s, min_confidence=%s, "
+        "%d KE(s) with unresolvable mappings)",
         len(merged), ", ".join(loaded) or "-", data_source, min_confidence,
+        len(merged_unresolved_ke),
     )
-    return merged, data_source, resolution
+    return (
+        ReferenceSets(merged, unresolved_ke_pathways=merged_unresolved_ke),
+        data_source,
+        resolution,
+    )
 
 
 def describe_resource_resolution(resolution):
@@ -1822,11 +1881,31 @@ def resource_resolution_warnings(resolution, min_confidence=DEFAULT_MIN_CONFIDEN
         shown = ", ".join(unresolved[:5])
         if len(unresolved) > 5:
             shown += f" and {len(unresolved) - 5} more"
+        # Issue #81: this sentence used to end "...are reported as having no
+        # gene set", because they were. They are not any more — the exclusion
+        # accounting now separates "mapped, but no genes could be resolved"
+        # from "no gene set mapped" — so say what actually happens instead of
+        # apologising for a misreport that has been fixed.
+        affected_kes = sorted({
+            ke
+            for e in resolution
+            for ke in (e.get('unresolved_ke_pathways') or {})
+        })
+        ke_clause = ''
+        if affected_kes:
+            ke_shown = ", ".join(affected_kes[:5])
+            if len(affected_kes) > 5:
+                ke_shown += f" and {len(affected_kes) - 5} more"
+            ke_clause = (
+                f" {len(affected_kes)} Key Event(s) lost genes this way "
+                f"({ke_shown}); those left with none are listed as mapped but "
+                f"unresolvable rather than unmapped."
+            )
         warnings.append(
             f"{len(unresolved)} mapped pathway(s) could not be resolved to genes "
-            f"({shown}) and contributed nothing to this analysis. Key Events whose "
-            f"only mappings are affected are reported as having no gene set, but "
-            f"they are curated — their coverage is understated here."
+            f"({shown}) and contributed nothing to this analysis.{ke_clause} "
+            f"The affected Key Events are curated — their coverage is "
+            f"understated here."
         )
     return warnings
 

--- a/helpers.py
+++ b/helpers.py
@@ -28,6 +28,51 @@ _CONFIDENCE_RANKS = {"low": 1, "medium": 2, "high": 3}
 CONFIDENCE_KEYS = ("confidence_level", "Confidence_Level", "Confidence", "confidence")
 
 
+class ReferenceSets(dict):
+    """KE_ID -> gene set mapping that remembers what it could not resolve.
+
+    A plain ``dict`` in every respect, plus one attribute:
+    ``unresolved_ke_pathways``, the KE_ID -> sorted pathway-ID map of curated
+    mappings whose gene membership no configured source could resolve.
+
+    Issue #81: that information is produced deep inside
+    :func:`load_reference_sets`, but it is needed at the far end of the call
+    chain — in the enrichment backends, which decide whether an untestable Key
+    Event is *uncurated* or *unresolvable*. Between the two sit callers that
+    only ever hand the gene sets on (``api_service.fetch_reference_sets_from_api``,
+    ``batch_service.run_batch``), so carrying it on the mapping itself keeps it
+    from being dropped by an intermediary that has no reason to know about it.
+    Consumers should read it through :func:`unresolved_ke_pathways_for`, which
+    tolerates a plain dict from a cache written before this existed.
+    """
+
+    def __init__(self, *args, unresolved_ke_pathways=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.unresolved_ke_pathways = {
+            str(ke): sorted(pathways)
+            for ke, pathways in (unresolved_ke_pathways or {}).items()
+            if pathways
+        }
+
+
+def unresolved_ke_pathways_for(reference_sets):
+    """Read the KE -> unresolvable-pathway-ID map off a reference-set mapping.
+
+    Parameters
+    ----------
+    reference_sets : dict
+        Any KE_ID -> gene set mapping. A :class:`ReferenceSets` carries the
+        map; a plain dict (an older cache entry, a hand-built test fixture)
+        does not.
+
+    Returns
+    -------
+    dict[str, list[str]]
+        The map, or ``{}`` when the mapping does not carry one.
+    """
+    return dict(getattr(reference_sets, 'unresolved_ke_pathways', None) or {})
+
+
 def confidence_rank(value):
     """Map a confidence label to its ordinal rank.
 
@@ -148,7 +193,8 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
                         ke_wp_df=None,
                         min_confidence=DEFAULT_MIN_CONFIDENCE,
                         wp_gene_map=None,
-                        unresolved_out=None):
+                        unresolved_out=None,
+                        unresolved_ke_out=None):
     """Build KE-to-gene reference sets from local CSV files or a pre-built DataFrame.
 
     Parameters
@@ -182,11 +228,20 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
         in the inner join, which is exactly the silence #79 reported: the Key
         Event is then reported as having no gene set mapped, when in truth it
         is mapped and the mapping could not be resolved.
+    unresolved_ke_out : dict or None
+        Optional sink for the same information attributed to Key Events:
+        KE_ID -> sorted list of that KE's unresolvable pathway IDs, taken from
+        the mappings *before* the inner merge drops them. Issue #81: a KE whose
+        only pathway is unresolvable is absent from the returned sets entirely,
+        so this is the only place the association still exists. The same map is
+        always attached to the return value (see :class:`ReferenceSets`); the
+        sink exists for callers that want it without depending on the type.
 
     Returns
     -------
-    dict[str, set[str]]
-        Mapping of KE ID -> set of uppercase gene symbols.
+    ReferenceSets
+        Mapping of KE ID -> set of uppercase gene symbols, carrying the
+        KE -> unresolvable-pathway-ID map on ``.unresolved_ke_pathways``.
     """
     # Use the provided DataFrame or read from the CSV file
     if ke_wp_df is None:
@@ -280,6 +335,7 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
     # the analyser simply cannot say which genes it contains.
     resolvable = set(merged['WP_ID'].unique()) if len(merged) else set()
     unresolved = sorted(set(ke_wp_df['WP_ID'].unique()) - resolvable)
+    unresolved_by_ke = {}
     if unresolved:
         logger.warning(
             "%d mapped pathway(s) could not be resolved to genes and are absent "
@@ -289,6 +345,25 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
         if unresolved_out is not None:
             unresolved_out.extend(unresolved)
 
+        # Issue #81: attribute the unresolvable pathways to their Key Events
+        # here, on the pre-merge mappings. After the inner merge below the
+        # association is gone — a KE whose only pathway is unresolvable does
+        # not appear in the merged frame at all, so downstream it is
+        # indistinguishable from a KE nobody has ever mapped. That is exactly
+        # the misreport #81 is about, and this map is what fixes it.
+        unresolved_set = set(unresolved)
+        collected = {}
+        for ke_id, wp_id in zip(ke_wp_df['KE_ID'], ke_wp_df['WP_ID']):
+            if wp_id in unresolved_set:
+                collected.setdefault(str(ke_id), set()).add(wp_id)
+        unresolved_by_ke = {ke: sorted(wps) for ke, wps in collected.items()}
+        logger.info(
+            "%d Key Event(s) carry at least one unresolvable pathway mapping",
+            len(unresolved_by_ke),
+        )
+        if unresolved_ke_out is not None:
+            unresolved_ke_out.update(unresolved_by_ke)
+
     # Group into dict: KE_ID → set of gene symbols
     reference_sets = (
         merged.groupby('KE_ID')['GeneName']
@@ -296,5 +371,5 @@ def load_reference_sets(ke_wp_path='data/KE-WP.csv',
         .to_dict()
     )
 
-    return reference_sets
+    return ReferenceSets(reference_sets, unresolved_ke_pathways=unresolved_by_ke)
 

--- a/services/batch_service.py
+++ b/services/batch_service.py
@@ -269,6 +269,10 @@ def _run_condition(
         batch: Parent BatchRecord (provides shared parameters).
         harmonised_genes: Intersection gene set used to filter each file.
         reference_sets: KE-to-gene reference dict from load_cached_reference_sets.
+            Normally a ``helpers.ReferenceSets``, which also carries the
+            KE -> unresolvable-pathway map used for the exclusion accounting
+            (issue #81); a plain dict works unchanged and simply reports no
+            unresolvable mappings.
         ke_list: Set of KE IDs for the selected AOP.
         edges: DataFrame of KE-to-KE edges for the selected AOP.
         ke_type_map: Dict mapping KE IDs to type strings.
@@ -310,9 +314,15 @@ def _run_condition(
     total_genes = len(df_filtered)
     significant_genes = int(df_filtered['significant'].sum())
 
-    # Run enrichment on the harmonised/filtered data
+    # Run enrichment on the harmonised/filtered data. Issue #81: the reference
+    # sets carry the KE -> unresolvable-pathway map (helpers.ReferenceSets), so
+    # a Key Event whose curated pathway could not be resolved to genes is
+    # reported as that, not as one nobody has mapped. run_batch is handed only
+    # the gene sets, which is precisely why the map travels on them.
+    from helpers import unresolved_ke_pathways_for
     enrichment_results = run_enrichment_analysis(
-        df_filtered, reference_sets, ke_list, ke_title_map
+        df_filtered, reference_sets, ke_list, ke_title_map,
+        unresolved_ke_pathways=unresolved_ke_pathways_for(reference_sets),
     )
 
     # Build Cytoscape network. The tested/excluded KE accounting (issue #65)
@@ -323,6 +333,7 @@ def _run_condition(
         ke_list, edges, enrichment_results, ke_title_map, ke_type_map,
         reference_sets=reference_sets,
         excluded_kes=(ke_summary or {}).get('excluded_reasons'),
+        unresolved_ke_pathways=(ke_summary or {}).get('unresolved_pathways_by_ke'),
     )
 
     # Build KE gene membership maps for the drawer / results page

--- a/services/enrichment_service.py
+++ b/services/enrichment_service.py
@@ -329,6 +329,7 @@ def run_enrichment_analysis(
                 'excluded_error': 0,          # contingency / Fisher failure
                 'min_ke_genes': 5,
                 'unresolved_pathways': ['WP5477'],
+                'unresolved_pathways_by_ke': {'KE:1115': ['WP5477']},
                 'excluded_reasons': {'KE:123': 'too_few_genes', ...},
             }
     """
@@ -576,6 +577,10 @@ def _build_ke_summary(
         # Issue #81 — named so the reader can check them against the Builder
         # rather than being told, wrongly, that the Key Event is uncurated.
         'unresolved_pathways': unresolved_pathways,
+        # Issue #81 — kept per Key Event as well as flattened, so the network
+        # can write the IDs onto the node that lost them and a summary rebuilt
+        # from stored network JSON still names them.
+        'unresolved_pathways_by_ke': dict(unresolved_pathways_by_ke or {}),
         'excluded_reasons': excluded_reasons,
     }
 

--- a/services/enrichment_service.py
+++ b/services/enrichment_service.py
@@ -19,6 +19,52 @@ logger = logging.getLogger(__name__)
 # the accounting read it back with ``get_ke_summary()``.
 KE_SUMMARY_ATTR = 'ke_summary'
 
+# Issue #81 — the reasons a Key Event never reached a statistical test. These
+# strings are the shared vocabulary of the ORA backend, the GSEA backend, the
+# network's per-node ``excluded_reason`` and the accounting sentence, so all of
+# them make the same claim about the same KE.
+#
+# ``no_mapping`` and ``unresolved_mapping`` used to be one counter, and that
+# conflation pointed the reader at the wrong person: "no gene set mapped" says
+# the curation is incomplete and sends them to the Builder to add a mapping,
+# while a mapping that exists but resolves to no genes is a stale-reference-data
+# bug in this tool. A KE whose gene set is known but barely measured in the
+# uploaded dataset is a third thing again, and belongs with ``too_few_genes``
+# (zero measured genes is "fewer than the minimum", not "not curated").
+EXCLUDED_NO_MAPPING = 'no_mapping'
+EXCLUDED_UNRESOLVED_MAPPING = 'unresolved_mapping'
+EXCLUDED_TOO_FEW_GENES = 'too_few_genes'
+EXCLUDED_ERROR = 'error'
+
+
+def normalise_unresolved_ke_pathways(
+    unresolved_ke_pathways: Optional[Dict[str, Any]],
+) -> Dict[str, List[str]]:
+    """Normalise a KE -> unresolvable-pathway-ID mapping (issue #81).
+
+    Args:
+        unresolved_ke_pathways: KE_ID -> iterable of pathway IDs that are
+            curated and mapped to that KE but whose gene membership no
+            configured source could resolve (see ``load_reference_sets``'s
+            ``unresolved_out`` and the resolution entry's
+            ``unresolved_pathways``). A plain string is accepted for a single
+            pathway. None or empty yields an empty dict.
+
+    Returns:
+        KE_ID -> sorted list of unique, upper-cased pathway IDs, with entries
+        that name no pathway dropped.
+    """
+    normalised: Dict[str, List[str]] = {}
+    for ke, pathways in (unresolved_ke_pathways or {}).items():
+        if not pathways:
+            continue
+        if isinstance(pathways, str):
+            pathways = [pathways]
+        ids = sorted({str(p).strip().upper() for p in pathways if str(p).strip()})
+        if ids:
+            normalised[str(ke)] = ids
+    return normalised
+
 
 def get_ke_summary(results: pd.DataFrame) -> Optional[Dict[str, Any]]:
     """Return the tested/excluded KE accounting attached to an enrichment result.
@@ -42,12 +88,23 @@ def format_ke_summary(summary: Optional[Dict[str, Any]]) -> str:
     """Render a KE accounting summary as a one-line human-readable sentence.
 
     Example: ``"18 of 24 Key Events tested; 4 excluded (fewer than 5 measured
-    genes), 2 excluded (no gene set mapped)"``. Shared by the results page, the
-    single report and the batch report so all three word it identically.
+    genes), 2 excluded (no gene set mapped), 1 excluded (mapped, but no genes
+    could be resolved: WP5477)"``. Shared by the results page, the single report
+    and the batch report so all three word it identically.
+
+    Issue #81: the mapped-but-unresolvable clause is deliberately separate from
+    "no gene set mapped" and names the offending pathways. The two sentences
+    ask different things of the reader — one is a curation gap to fill in the
+    Builder, the other is stale reference data in this tool — and a summary
+    that says the first when it means the second sends the reader to fix
+    something that is not broken.
 
     Args:
         summary: Dict from ``get_ke_summary`` (or an equivalently-shaped dict
             rebuilt from a network payload). None/empty yields an empty string.
+            Keys added after a summary was stored are read with defaults, so
+            payloads written before #81 (which carry only the two older
+            exclusion counters) still render.
 
     Returns:
         The formatted sentence, or '' when there is nothing to report.
@@ -68,12 +125,44 @@ def format_ke_summary(summary: Optional[Dict[str, Any]]) -> str:
     no_mapping = summary.get('excluded_no_mapping', 0)
     if no_mapping:
         clauses.append(f"{no_mapping} excluded (no gene set mapped)")
+    unresolved = summary.get('excluded_unresolved_mapping', 0)
+    if unresolved:
+        clauses.append(
+            f"{unresolved} excluded (mapped, but no genes could be resolved"
+            f"{_format_unresolved_pathways(summary.get('unresolved_pathways'))})"
+        )
     errored = summary.get('excluded_error', 0)
     if errored:
         clauses.append(f"{errored} excluded (statistics could not be computed)")
     if clauses:
         parts.append('; ' + ', '.join(clauses))
     return ''.join(parts)
+
+
+# How many unresolvable pathway IDs the accounting sentence names before it
+# summarises the rest. Naming them is the point of the clause -- an unnamed
+# count cannot be checked against the Builder -- but the sentence still has to
+# stay a sentence.
+MAX_NAMED_UNRESOLVED_PATHWAYS = 3
+
+
+def _format_unresolved_pathways(pathways: Optional[List[str]]) -> str:
+    """Render the ``": WP5477, WP5498 and 2 more"`` tail of the mapped-but-empty clause.
+
+    Args:
+        pathways: Pathway IDs that could not be resolved to genes, or None.
+
+    Returns:
+        The tail including its leading ``": "``, or '' when nothing is known.
+    """
+    if not pathways:
+        return ''
+    shown = list(pathways)[:MAX_NAMED_UNRESOLVED_PATHWAYS]
+    tail = ', '.join(shown)
+    remaining = len(pathways) - len(shown)
+    if remaining > 0:
+        tail += f" and {remaining} more"
+    return f": {tail}"
 
 
 # Below this fraction of the uploaded genes matching the reference universe,
@@ -180,6 +269,7 @@ def run_enrichment_analysis(
     gene_logfc_map: Optional[Dict[str, float]] = None,
     min_ke_genes: int = Config.MIN_KE_GENES,
     fdr_cutoff: float = Config.SIGNIFICANCE_FDR_CUTOFF,
+    unresolved_ke_pathways: Optional[Dict[str, Any]] = None,
 ) -> pd.DataFrame:
     """
     Run Fisher's exact test enrichment analysis for Key Events.
@@ -205,6 +295,15 @@ def run_enrichment_analysis(
             tests and from the BH denominator, and are recorded in the KE
             accounting summary instead of being dropped silently.
 
+        unresolved_ke_pathways: Optional KE_ID -> pathway IDs that are mapped
+            to that KE but whose gene membership no source could resolve
+            (issue #81; see ``load_reference_sets``'s ``unresolved_out``).
+            Such a KE is absent from ``reference_sets`` exactly like an
+            uncurated one, so without this hint the two are indistinguishable
+            here and both would be reported as "no gene set mapped" — telling
+            the reader the curation is incomplete when in fact the mapping
+            exists and this tool's reference data is stale.
+
         fdr_cutoff: BH-adjusted cutoff used to fill the ``Representation``
             column (issue #70). Both tails are always computed; this only
             decides where the pre-rendered ``enriched`` / ``depleted`` / ``ns``
@@ -224,10 +323,12 @@ def run_enrichment_analysis(
             {
                 'total_kes': 24,              # KEs in the AOP
                 'tested': 18,                 # rows in the returned DataFrame
-                'excluded_no_mapping': 2,     # no gene set, or no measured overlap
-                'excluded_too_few_genes': 4,  # overlap below min_ke_genes
+                'excluded_no_mapping': 2,     # no curated gene set at all
+                'excluded_unresolved_mapping': 1,  # mapped, zero genes resolved
+                'excluded_too_few_genes': 3,  # overlap below min_ke_genes
                 'excluded_error': 0,          # contingency / Fisher failure
                 'min_ke_genes': 5,
+                'unresolved_pathways': ['WP5477'],
                 'excluded_reasons': {'KE:123': 'too_few_genes', ...},
             }
     """
@@ -266,27 +367,46 @@ def run_enrichment_analysis(
     # Issue #65 — record why each KE never reached a Fisher test, so the
     # multiple-testing denominator is visible and "could not assess" is
     # distinguishable from "assessed and not enriched" downstream.
-    excluded_reasons: Dict[str, str] = {
-        ke: 'no_mapping' for ke in ke_list if ke not in filtered_reference_sets
-    }
+    # Issue #81 — and so that "not curated" is distinguishable from "curated,
+    # but this tool could not resolve the mapping to genes".
+    unresolved_map = normalise_unresolved_ke_pathways(unresolved_ke_pathways)
+    unresolved_named: Dict[str, List[str]] = {}
+    excluded_reasons: Dict[str, str] = {}
+    for ke in ke_list:
+        if ke in filtered_reference_sets:
+            continue
+        if unresolved_map.get(ke):
+            excluded_reasons[ke] = EXCLUDED_UNRESOLVED_MAPPING
+            unresolved_named[ke] = unresolved_map[ke]
+        else:
+            excluded_reasons[ke] = EXCLUDED_NO_MAPPING
 
     for ke, ref_genes in filtered_reference_sets.items():
         try:
+            # A KE present in the reference sets but carrying no genes is
+            # mapped — the mapping simply resolved to nothing (issue #81).
+            if not ref_genes:
+                logger.debug(f"KE {ke} is mapped but its gene set is empty")
+                excluded_reasons[ke] = EXCLUDED_UNRESOLVED_MAPPING
+                if unresolved_map.get(ke):
+                    unresolved_named[ke] = unresolved_map[ke]
+                continue
+
             # Find overlap between KE genes and user genes (ref_genes already normalized)
             ke_genes = ref_genes & all_genes
 
-            if not ke_genes:
-                logger.debug(f"No overlap found for KE {ke}")
-                excluded_reasons[ke] = 'no_mapping'
-                continue
-
-            # Skip KEs with too few genes for reliable statistics
-            if len(ke_genes) < min_ke_genes:
+            # Skip KEs with too few genes for reliable statistics. Issue #81:
+            # zero measured genes belongs here too — the KE has a gene set,
+            # none of it was measured in this dataset, and calling that "no
+            # gene set mapped" blamed the curator for the experiment's
+            # coverage.
+            if len(ke_genes) < max(min_ke_genes, 1):
                 logger.debug(
-                    f"Skipping KE {ke}: only {len(ke_genes)} genes "
+                    f"Skipping KE {ke}: only {len(ke_genes)} of its "
+                    f"{len(ref_genes)} genes measured "
                     f"(minimum {min_ke_genes} required)"
                 )
-                excluded_reasons[ke] = 'too_few_genes'
+                excluded_reasons[ke] = EXCLUDED_TOO_FEW_GENES
                 continue
 
             sig_in_ke = {g for g in ke_genes if user_gene_status.get(g, False)}
@@ -301,7 +421,7 @@ def run_enrichment_analysis(
             # Validate contingency table cells are non-negative
             if b < 0 or d < 0:
                 logger.error(f"KE {ke}: invalid contingency table (a={a}, b={b}, c={c}, d={d}) — skipping")
-                excluded_reasons[ke] = 'error'
+                excluded_reasons[ke] = EXCLUDED_ERROR
                 continue
 
             # Run Fisher's exact test (one-tailed, greater)
@@ -355,7 +475,7 @@ def run_enrichment_analysis(
 
         except Exception as e:
             logger.error(f"Error processing KE {ke}: {e}")
-            excluded_reasons[ke] = 'error'
+            excluded_reasons[ke] = EXCLUDED_ERROR
             continue
 
     if not r_ke:
@@ -403,7 +523,8 @@ def run_enrichment_analysis(
     # Issue #65 — attach the KE accounting after the sort, since pandas only
     # propagates .attrs through operations that call __finalize__.
     df_results.attrs[KE_SUMMARY_ATTR] = _build_ke_summary(
-        ke_list, len(r_ke), excluded_reasons, min_ke_genes
+        ke_list, len(r_ke), excluded_reasons, min_ke_genes,
+        unresolved_pathways_by_ke=unresolved_named,
     )
 
     logger.info(
@@ -419,6 +540,7 @@ def _build_ke_summary(
     tested: int,
     excluded_reasons: Dict[str, str],
     min_ke_genes: int,
+    unresolved_pathways_by_ke: Optional[Dict[str, List[str]]] = None,
 ) -> Dict[str, Any]:
     """Assemble the tested/excluded KE accounting dict (issue #65).
 
@@ -426,19 +548,34 @@ def _build_ke_summary(
         ke_list: All KE IDs of the selected AOP (the accounting denominator).
         tested: Number of KEs that reached a statistical test — i.e. the number
             of rows in the result table, and the size of the BH denominator.
-        excluded_reasons: KE_ID → 'no_mapping' | 'too_few_genes' | 'error'.
+        excluded_reasons: KE_ID → one of the ``EXCLUDED_*`` reasons.
         min_ke_genes: Minimum measured-gene threshold that was applied.
+        unresolved_pathways_by_ke: KE_ID → pathway IDs that are mapped to that
+            KE but resolved to no genes (issue #81). Flattened into the
+            summary's ``unresolved_pathways`` so the sentence can name them.
 
     Returns:
         Summary dict as documented on ``run_enrichment_analysis``.
     """
+    reasons = list(excluded_reasons.values())
+    unresolved_pathways = sorted({
+        wp
+        for wps in (unresolved_pathways_by_ke or {}).values()
+        for wp in wps
+    })
     return {
         'total_kes': len(set(ke_list)),
         'tested': tested,
-        'excluded_no_mapping': sum(1 for r in excluded_reasons.values() if r == 'no_mapping'),
-        'excluded_too_few_genes': sum(1 for r in excluded_reasons.values() if r == 'too_few_genes'),
-        'excluded_error': sum(1 for r in excluded_reasons.values() if r == 'error'),
+        'excluded_no_mapping': sum(1 for r in reasons if r == EXCLUDED_NO_MAPPING),
+        'excluded_unresolved_mapping': sum(
+            1 for r in reasons if r == EXCLUDED_UNRESOLVED_MAPPING
+        ),
+        'excluded_too_few_genes': sum(1 for r in reasons if r == EXCLUDED_TOO_FEW_GENES),
+        'excluded_error': sum(1 for r in reasons if r == EXCLUDED_ERROR),
         'min_ke_genes': min_ke_genes,
+        # Issue #81 — named so the reader can check them against the Builder
+        # rather than being told, wrongly, that the Key Event is uncurated.
+        'unresolved_pathways': unresolved_pathways,
         'excluded_reasons': excluded_reasons,
     }
 
@@ -531,6 +668,9 @@ def run_enrichment(
         **kwargs: Additional keyword arguments forwarded to the chosen backend.
             For ORA: ``gene_logfc_map`` drives the Direction column.
             For GSEA: ``gene_logfc_map`` is suppressed by the caller (D-14).
+            ``unresolved_ke_pathways`` (issue #81) is accepted by both
+            backends, so the exclusion accounting reads identically whichever
+            method was used.
 
     Returns:
         pd.DataFrame from the chosen backend, sorted by FDR ascending.

--- a/services/gsea_service.py
+++ b/services/gsea_service.py
@@ -8,13 +8,20 @@ user's method selection.
 """
 import math
 import logging
-from typing import Dict, Set
+from typing import Any, Dict, Optional, Set
 
 import numpy as np
 import pandas as pd
 import gseapy as gp
 
-from services.enrichment_service import KE_SUMMARY_ATTR, _build_ke_summary
+from services.enrichment_service import (
+    EXCLUDED_NO_MAPPING,
+    EXCLUDED_TOO_FEW_GENES,
+    EXCLUDED_UNRESOLVED_MAPPING,
+    KE_SUMMARY_ATTR,
+    _build_ke_summary,
+    normalise_unresolved_ke_pathways,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +70,7 @@ def run_gsea_analysis(
     max_size: int = 1000,
     permutation_num: int = 1000,
     seed: int = 42,
+    unresolved_ke_pathways: Optional[Dict[str, Any]] = None,
 ) -> pd.DataFrame:
     """Run GSEA (prerank) enrichment analysis for Key Events.
 
@@ -84,6 +92,10 @@ def run_gsea_analysis(
         permutation_num: Number of permutations for the null distribution
             (keyword-only).
         seed: Random seed for reproducibility (keyword-only).
+        unresolved_ke_pathways: Optional KE_ID -> pathway IDs that are mapped
+            to that KE but could not be resolved to genes (issue #81). Same
+            meaning and effect as in ``run_enrichment_analysis`` — ORA and
+            GSEA report exclusions with one vocabulary.
 
     Returns:
         pd.DataFrame sorted by FDR ascending with columns:
@@ -177,14 +189,31 @@ def run_gsea_analysis(
 
     # Issue #65 — same tested/excluded accounting the Fisher backend produces,
     # so the results page, network and reports read one shape regardless of
-    # method. A dropped KE with zero measured overlap is 'no_mapping'; one with
-    # a non-empty but sub-min_size overlap is 'too_few_genes'.
-    excluded_reasons = {ke: 'no_mapping' for ke in set(ke_list) - set(reference_sets.keys())}
+    # method.
+    # Issue #81 — three distinct exclusions, not two: a KE with no curated
+    # mapping, a KE whose mapping resolved to no genes, and a KE whose gene set
+    # is known but under-measured in this dataset (zero measured genes included
+    # — that is a coverage fact about the upload, not a curation gap).
+    unresolved_map = normalise_unresolved_ke_pathways(unresolved_ke_pathways)
+    unresolved_named = {}
+    excluded_reasons = {}
+    for ke in set(ke_list) - set(reference_sets.keys()):
+        if unresolved_map.get(ke):
+            excluded_reasons[ke] = EXCLUDED_UNRESOLVED_MAPPING
+            unresolved_named[ke] = unresolved_map[ke]
+        else:
+            excluded_reasons[ke] = EXCLUDED_NO_MAPPING
     for ke in dropped:
-        excluded_reasons[ke] = (
-            'too_few_genes' if kes_to_overlap_count.get(ke, 0) else 'no_mapping'
-        )
-    ke_summary = _build_ke_summary(ke_list, len(res), excluded_reasons, min_size)
+        if not gene_sets.get(ke):
+            excluded_reasons[ke] = EXCLUDED_UNRESOLVED_MAPPING
+            if unresolved_map.get(ke):
+                unresolved_named[ke] = unresolved_map[ke]
+        else:
+            excluded_reasons[ke] = EXCLUDED_TOO_FEW_GENES
+    ke_summary = _build_ke_summary(
+        ke_list, len(res), excluded_reasons, min_size,
+        unresolved_pathways_by_ke=unresolved_named,
+    )
 
     # Sort by FDR ascending; use KE ID as tie-breaker so row order is fully
     # deterministic regardless of the internal ordering gseapy returns.

--- a/services/network_service.py
+++ b/services/network_service.py
@@ -56,6 +56,7 @@ def build_cytoscape_network(
     method: str = 'ora',
     fdr_cutoff: float = Config.SIGNIFICANCE_FDR_CUTOFF,
     excluded_kes: Optional[Dict[str, str]] = None,
+    unresolved_ke_pathways: Optional[Dict[str, List[str]]] = None,
 ) -> Dict[str, List[Dict[str, Any]]]:
     """
     Build Cytoscape.js network data structure.
@@ -90,6 +91,13 @@ def build_cytoscape_network(
             class (issue #81), so "could not assess" never renders like
             "assessed but not enriched" and a mapped Key Event whose pathway
             could not be resolved never renders like an uncurated one.
+        unresolved_ke_pathways: Optional KE_ID → the pathway IDs behind an
+            ``'unresolved_mapping'`` exclusion, as produced by
+            ``get_ke_summary()['unresolved_pathways_by_ke']`` (issue #81).
+            Written onto the node payload as ``unresolved_pathways`` so a
+            summary rebuilt from stored network JSON — the batch report, a
+            shared link — can still name them. Naming them is the point of the
+            clause: an unnamed count cannot be checked against the Builder.
 
     Returns:
         Dictionary with 'nodes' and 'edges' keys for Cytoscape.js
@@ -163,14 +171,16 @@ def build_cytoscape_network(
             # Issue #81 — the KE *is* mapped; the mapping resolved to no genes.
             # Styled apart from the uncurated case because the two ask for
             # different repairs: one a Builder mapping, the other this tool's
-            # reference data.
+            # reference data. This is the *only* reason that withholds
+            # `no-genes`; every other gene-set-less KE keeps the muted styling
+            # it had before #81, including one excluded with reason 'error'.
             classes.append("unresolved-mapping")
         elif excluded_reason == EXCLUDED_NO_MAPPING or (
-            reference_sets is not None and not has_gene_set and not excluded_reason
+            reference_sets is not None and not has_gene_set
         ):
-            # No curated gene set at all. Note the reason, when present, is
-            # authoritative: a mapped-but-unresolvable KE also has no gene set
-            # here and must not be dressed up as a curation gap (issue #81).
+            # No usable gene set. An explicit 'no_mapping' says so; otherwise
+            # the KE simply has nothing in the reference sets, which is what
+            # this class has always meant.
             classes.append("no-genes")
 
         # D-10: build node payload with method-aware fields.
@@ -196,6 +206,15 @@ def build_cytoscape_network(
             # recover the tested/excluded accounting without a second payload.
             "excluded_reason": excluded_reason,
         }
+        # Issue #81: carry the offending pathway IDs on the node, not only in
+        # the in-memory summary. ConditionRecord and SharedResult store the
+        # network and nothing else, so without this the batch report and the
+        # shared view rebuild the sentence with the IDs stripped out — and the
+        # IDs are the part a reader can act on. Written only when there are
+        # any, so every other node payload is byte-identical to before.
+        node_unresolved = (unresolved_ke_pathways or {}).get(ke)
+        if node_unresolved:
+            node_payload["unresolved_pathways"] = sorted(node_unresolved)
         if method == 'gsea':
             node_payload["nes"] = nes
             node_payload["logfc"] = 0  # neutral surrogate per D-10 back-compat
@@ -251,7 +270,9 @@ def ke_accounting_from_network(network_json: Any) -> Optional[Dict[str, Any]]:
 
     Returns:
         Summary dict shaped like ``enrichment_service.get_ke_summary()`` (minus
-        the per-KE ``excluded_reasons`` map), or None when unavailable.
+        the per-KE ``excluded_reasons`` and ``unresolved_pathways_by_ke`` maps,
+        but including the flat ``unresolved_pathways`` list so the rendered
+        sentence still names them), or None when unavailable.
     """
     try:
         if isinstance(network_json, str):
@@ -278,6 +299,14 @@ def ke_accounting_from_network(network_json: Any) -> Optional[Dict[str, Any]]:
             'excluded_too_few_genes': sum(1 for r in reasons if r == EXCLUDED_TOO_FEW_GENES),
             'excluded_error': sum(1 for r in reasons if r == EXCLUDED_ERROR),
             'min_ke_genes': Config.MIN_KE_GENES,
+            # Issue #81 — the pathway IDs behind those exclusions, recovered
+            # from the nodes that carry them. Empty for networks stored before
+            # they were written, which reads as "not known" rather than wrong.
+            'unresolved_pathways': sorted({
+                str(wp)
+                for d in ke_nodes
+                for wp in (d.get('unresolved_pathways') or [])
+            }),
         }
     except (json.JSONDecodeError, TypeError, AttributeError) as exc:
         logger.warning(f"ke_accounting_from_network failed: {exc}")

--- a/services/network_service.py
+++ b/services/network_service.py
@@ -8,6 +8,12 @@ import logging
 from typing import Dict, Set, List, Any, Optional
 
 from config import Config
+from services.enrichment_service import (
+    EXCLUDED_ERROR,
+    EXCLUDED_NO_MAPPING,
+    EXCLUDED_TOO_FEW_GENES,
+    EXCLUDED_UNRESOLVED_MAPPING,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -78,9 +84,12 @@ def build_cytoscape_network(
             (issue #70).
         excluded_kes: Optional KE_ID → exclusion reason map (issue #65), as
             produced by ``enrichment_service.get_ke_summary()['excluded_reasons']``.
-            KEs excluded for ``'too_few_genes'`` get a `too-few-genes` class and
-            KEs excluded for ``'no_mapping'`` get the existing `no-genes` class,
-            so "could not assess" never renders like "assessed but not enriched".
+            KEs excluded for ``'too_few_genes'`` get a `too-few-genes` class,
+            KEs excluded for ``'no_mapping'`` get the `no-genes` class, and KEs
+            excluded for ``'unresolved_mapping'`` get an `unresolved-mapping`
+            class (issue #81), so "could not assess" never renders like
+            "assessed but not enriched" and a mapped Key Event whose pathway
+            could not be resolved never renders like an uncurated one.
 
     Returns:
         Dictionary with 'nodes' and 'edges' keys for Cytoscape.js
@@ -146,13 +155,22 @@ def build_cytoscape_network(
             # Issue #70 — significantly under-represented. A distinct class, not
             # the significance border, so the reader can tell which way it went.
             classes.append("depleted")
-        if excluded_reason == 'too_few_genes':
+        if excluded_reason == EXCLUDED_TOO_FEW_GENES:
             # Assessed-impossible, not assessed-and-null: fewer than the
             # minimum number of the KE's genes were measured (issue #65).
             classes.append("too-few-genes")
-        if (reference_sets is not None and not has_gene_set) or excluded_reason == 'no_mapping':
-            # No curated gene set at all, or a gene set with no measured
-            # overlap — either way the KE could not be assessed.
+        if excluded_reason == EXCLUDED_UNRESOLVED_MAPPING:
+            # Issue #81 — the KE *is* mapped; the mapping resolved to no genes.
+            # Styled apart from the uncurated case because the two ask for
+            # different repairs: one a Builder mapping, the other this tool's
+            # reference data.
+            classes.append("unresolved-mapping")
+        elif excluded_reason == EXCLUDED_NO_MAPPING or (
+            reference_sets is not None and not has_gene_set and not excluded_reason
+        ):
+            # No curated gene set at all. Note the reason, when present, is
+            # authoritative: a mapped-but-unresolvable KE also has no gene set
+            # here and must not be dressed up as a curation gap (issue #81).
             classes.append("no-genes")
 
         # D-10: build node payload with method-aware fields.
@@ -250,9 +268,15 @@ def ke_accounting_from_network(network_json: Any) -> Optional[Dict[str, Any]]:
         return {
             'total_kes': len(ke_nodes),
             'tested': sum(1 for r in reasons if not r),
-            'excluded_no_mapping': sum(1 for r in reasons if r == 'no_mapping'),
-            'excluded_too_few_genes': sum(1 for r in reasons if r == 'too_few_genes'),
-            'excluded_error': sum(1 for r in reasons if r == 'error'),
+            'excluded_no_mapping': sum(1 for r in reasons if r == EXCLUDED_NO_MAPPING),
+            # Issue #81 — absent from networks stored before the distinction
+            # existed, which is exactly right: those runs did not know it, and
+            # a zero here keeps the clause out of the rendered sentence.
+            'excluded_unresolved_mapping': sum(
+                1 for r in reasons if r == EXCLUDED_UNRESOLVED_MAPPING
+            ),
+            'excluded_too_few_genes': sum(1 for r in reasons if r == EXCLUDED_TOO_FEW_GENES),
+            'excluded_error': sum(1 for r in reasons if r == EXCLUDED_ERROR),
             'min_ke_genes': Config.MIN_KE_GENES,
         }
     except (json.JSONDecodeError, TypeError, AttributeError) as exc:

--- a/templates/results.html
+++ b/templates/results.html
@@ -327,7 +327,11 @@
                             </div>
                             <div class="network-legend__item">
                                 <div class="network-legend__swatch" style="background: #cccccc; width: 14px; height: 14px; opacity: 0.7;"></div>
-                                <span>No gene set mapped (no curated mapping in the Builder)</span>
+                                {# The class is also applied to any KE that simply has no
+                                   gene set in the loaded reference data, so the wording
+                                   stays hedged — only the entry below makes a positive
+                                   claim about what went wrong. #}
+                                <span>No measurable gene set (not curated, or none of its genes measured)</span>
                             </div>
                             {# Issue #81: a mapped Key Event whose pathway could not be
                                resolved to genes is a reference-data problem here, not a

--- a/templates/results.html
+++ b/templates/results.html
@@ -199,6 +199,15 @@
             <strong>Key Events assessed:</strong> {{ ke_summary_text }}.
             The Benjamini-Hochberg correction is applied across the {{ ke_summary.tested }} tested Key Events;
             excluded Key Events are shown in the network but carry no result.
+            {# Issue #81: "no gene set mapped" and "mapped, but unresolvable" are
+               different findings about different people. Only the first is a
+               curation gap worth reporting to the Builder. #}
+            {% if ke_summary and ke_summary.get('excluded_unresolved_mapping') %}
+            <br>The mapped-but-unresolved Key Events are curated: their pathways exist,
+            but this tool could not resolve them to genes, so their coverage is understated
+            here. That is a reference-data problem to report against the analyser, not a
+            missing mapping to add in the Builder.
+            {% endif %}
         </p>
         {% endif %}
 
@@ -288,6 +297,7 @@
             - KE nodes with a <span style="color:red;">red border</span> are significantly enriched (FDR &lt; <span class="fdr-cutoff-label">{{ fdr_cutoff | default(0.05) }}</span>, Benjamini-Hochberg adjusted).<br>
             - KE nodes with a <span style="color:#307BBF;">double blue border</span> are significantly <em>depleted</em> — fewer of their genes responded than the background rate predicts.<br>
             - KE nodes with a <span style="color:#777;">dashed grey border</span> could not be assessed (fewer than {{ ke_summary.min_ke_genes if ke_summary else 5 }} of their genes were measured).<br>
+            - KE nodes with a <span style="color:#EB5B25;">dotted orange border</span> are mapped, but their pathway could not be resolved to genes — a gap in this tool's reference data, not in the curation.<br>
             - Gene nodes with a <span style="color:green;">green border</span> are also significantly affected.
             <br><br>
             Click on any KE node to expand and show its associated genes. Use 'Collapse All' to return to the KE-only view.
@@ -317,7 +327,14 @@
                             </div>
                             <div class="network-legend__item">
                                 <div class="network-legend__swatch" style="background: #cccccc; width: 14px; height: 14px; opacity: 0.7;"></div>
-                                <span>No measurable gene set (not curated, or none of its genes measured)</span>
+                                <span>No gene set mapped (no curated mapping in the Builder)</span>
+                            </div>
+                            {# Issue #81: a mapped Key Event whose pathway could not be
+                               resolved to genes is a reference-data problem here, not a
+                               curation gap — the legend has to be able to say so. #}
+                            <div class="network-legend__item">
+                                <div class="network-legend__swatch" style="background: #f7e6d5; border: 2px dotted #EB5B25; opacity: 0.85;"></div>
+                                <span>Mapped, but no genes could be resolved</span>
                             </div>
                             <div class="network-legend__item">
                                 <div class="network-legend__swatch" style="background: #e8e8e8; border: 2px dashed #999; opacity: 0.75;"></div>
@@ -875,6 +892,24 @@ const cy = cytoscape({
             'color': '#777',
             'font-size': 10,
             'opacity': 0.7
+        }
+    },
+    {
+        // Issue #81 — KEs that ARE mapped but whose pathway could not be
+        // resolved to genes. Orange and dotted rather than the muted grey of
+        // an uncurated KE: the reader is being told the reference data is
+        // stale, not that a curator has work to do.
+        selector: 'node.unresolved-mapping',
+        style: {
+            'width': 32,
+            'height': 32,
+            'background-color': '#f7e6d5',
+            'border-color': '#EB5B25',
+            'border-width': 2,
+            'border-style': 'dotted',
+            'color': '#8a4520',
+            'font-size': 10,
+            'opacity': 0.85
         }
     },
     {

--- a/templates/shared_results.html
+++ b/templates/shared_results.html
@@ -231,6 +231,15 @@
                                 <div class="network-legend__swatch" style="background: #cccccc; width: 14px; height: 14px; opacity: 0.7;"></div>
                                 <span>No measurable gene set (not curated, or none of its genes measured)</span>
                             </div>
+                            {# Issue #81: a mapped Key Event whose pathway could not be
+                               resolved to genes is a reference-data problem here, not a
+                               curation gap — the legend has to be able to say so. Kept
+                               in step with results.html so the shared view of a run
+                               cannot describe it differently from the run itself. #}
+                            <div class="network-legend__item">
+                                <div class="network-legend__swatch" style="background: #f7e6d5; border: 2px dotted #EB5B25; opacity: 0.85;"></div>
+                                <span>Mapped, but no genes could be resolved</span>
+                            </div>
                             <div class="network-legend__item">
                                 <div class="network-legend__swatch" style="background: #e8e8e8; border: 2px dashed #999; opacity: 0.75;"></div>
                                 <span>Not tested (too few measured genes)</span>
@@ -499,6 +508,24 @@ const cy = cytoscape({
             'color': '#777',
             'font-size': 10,
             'opacity': 0.7
+        }
+    },
+    {
+        // Issue #81 — KEs that ARE mapped but whose pathway could not be
+        // resolved to genes. build_cytoscape_network withholds `no-genes` from
+        // these, so without this rule a shared network would render them at
+        // full size and colour — worse than the muted grey they used to get.
+        selector: 'node.unresolved-mapping',
+        style: {
+            'width': 32,
+            'height': 32,
+            'background-color': '#f7e6d5',
+            'border-color': '#EB5B25',
+            'border-width': 2,
+            'border-style': 'dotted',
+            'color': '#8a4520',
+            'font-size': 10,
+            'opacity': 0.85
         }
     },
     {

--- a/tests/test_enrichment_service.py
+++ b/tests/test_enrichment_service.py
@@ -463,12 +463,15 @@ class TestKeAccountingSummary:
         assert summary['total_kes'] == 4
         assert summary['tested'] == 1
         assert summary['tested'] == len(result)  # BH denominator == rows returned
-        assert summary['excluded_too_few_genes'] == 1
-        assert summary['excluded_no_mapping'] == 2  # KE:MISS + KE:NOSET
+        # Issue #81: KE:MISS is mapped and its gene set is known — none of it
+        # was measured here, which is a coverage fact about the upload, not the
+        # curation gap that 'no gene set mapped' claims.
+        assert summary['excluded_too_few_genes'] == 2  # KE:SMALL + KE:MISS
+        assert summary['excluded_no_mapping'] == 1  # KE:NOSET only
         assert summary['excluded_error'] == 0
         assert summary['min_ke_genes'] == 5
         assert summary['excluded_reasons']['KE:SMALL'] == 'too_few_genes'
-        assert summary['excluded_reasons']['KE:MISS'] == 'no_mapping'
+        assert summary['excluded_reasons']['KE:MISS'] == 'too_few_genes'
         assert summary['excluded_reasons']['KE:NOSET'] == 'no_mapping'
         assert 'KE:OK' not in summary['excluded_reasons']
         # Accounting must be exhaustive: nothing vanishes silently.

--- a/tests/test_ke_exclusion_reasons.py
+++ b/tests/test_ke_exclusion_reasons.py
@@ -1,0 +1,283 @@
+"""Issue #81: a Key Event that is mapped is never reported as unmapped.
+
+The exclusion accounting used to collapse three different findings into
+"no gene set mapped":
+
+* the Key Event has no curated mapping at all — a curation gap, fixed in the
+  Builder;
+* the Key Event is mapped but the pathway could not be resolved to genes — a
+  stale-reference-data bug in the analyser (issue #79 plumbed the unresolvable
+  pathway IDs through for exactly this reason);
+* the Key Event's gene set is known but none of its genes were measured in the
+  uploaded dataset — a coverage fact about the experiment.
+
+Only the first is a curation gap, so these tests pin each of them to its own
+counter and check that the mapped-but-unresolvable case names the pathways.
+"""
+import json
+
+import pandas as pd
+import pytest
+
+from services.enrichment_service import (
+    EXCLUDED_NO_MAPPING,
+    EXCLUDED_TOO_FEW_GENES,
+    EXCLUDED_UNRESOLVED_MAPPING,
+    format_ke_summary,
+    get_ke_summary,
+    normalise_unresolved_ke_pathways,
+    run_enrichment_analysis,
+)
+from services.network_service import build_cytoscape_network, ke_accounting_from_network
+
+
+def _make_gene_df(n_genes=50, n_sig=10):
+    """Build a minimal processed expression frame with `n_sig` significant genes."""
+    genes = [f"GENE{i}" for i in range(n_genes)]
+    return pd.DataFrame({
+        'ID': genes,
+        'significant': [i < n_sig for i in range(n_genes)],
+        'log2FC': [1.0 if i < n_sig else 0.0 for i in range(n_genes)],
+        'pval': [0.001 if i < n_sig else 0.5 for i in range(n_genes)],
+    })
+
+
+def _run(reference_sets, ke_list, **kwargs):
+    """Run ORA over a fixed background and return the accounting summary."""
+    df = _make_gene_df()
+    result = run_enrichment_analysis(
+        df, reference_sets, ke_list, {k: k for k in ke_list}, **kwargs
+    )
+    return get_ke_summary(result)
+
+
+class TestExclusionReasonsAreDistinct:
+    """The three exclusions are counted separately (issue #81)."""
+
+    def test_mapped_but_unresolvable_is_not_a_curation_gap(self):
+        """A KE whose pathway could not be resolved is never called unmapped."""
+        reference_sets = {'KE:OK': {f"GENE{i}" for i in range(10)}}
+        ke_list = {'KE:OK', 'KE:1115', 'KE:NOSET'}
+
+        summary = _run(
+            reference_sets, ke_list,
+            unresolved_ke_pathways={'KE:1115': ['WP5477']},
+        )
+
+        assert summary['excluded_reasons']['KE:1115'] == EXCLUDED_UNRESOLVED_MAPPING
+        assert summary['excluded_reasons']['KE:NOSET'] == EXCLUDED_NO_MAPPING
+        assert summary['excluded_unresolved_mapping'] == 1
+        assert summary['excluded_no_mapping'] == 1
+        # The offending pathway is named, so the reader can check it against
+        # the Builder rather than being sent to curate a mapping that exists.
+        assert summary['unresolved_pathways'] == ['WP5477']
+
+    def test_empty_reference_gene_set_counts_as_unresolvable(self):
+        """A mapping that survives into the reference sets with no genes is mapped."""
+        reference_sets = {
+            'KE:OK': {f"GENE{i}" for i in range(10)},
+            'KE:EMPTY': set(),
+        }
+        summary = _run(reference_sets, {'KE:OK', 'KE:EMPTY'})
+
+        assert summary['excluded_reasons']['KE:EMPTY'] == EXCLUDED_UNRESOLVED_MAPPING
+        assert summary['excluded_no_mapping'] == 0
+
+    def test_unmeasured_gene_set_is_a_coverage_finding(self):
+        """A known gene set with nothing measured is 'too few measured genes'."""
+        reference_sets = {
+            'KE:OK': {f"GENE{i}" for i in range(10)},
+            'KE:MISS': {'ABSENT1', 'ABSENT2', 'ABSENT3'},
+        }
+        summary = _run(reference_sets, {'KE:OK', 'KE:MISS'})
+
+        assert summary['excluded_reasons']['KE:MISS'] == EXCLUDED_TOO_FEW_GENES
+        assert summary['excluded_no_mapping'] == 0
+        assert summary['excluded_unresolved_mapping'] == 0
+
+    def test_accounting_stays_exhaustive(self):
+        """Every KE of the AOP is still accounted for exactly once."""
+        reference_sets = {
+            'KE:OK': {f"GENE{i}" for i in range(10)},
+            'KE:SMALL': {'GENE0', 'GENE1'},
+            'KE:MISS': {'ABSENT1'},
+        }
+        ke_list = {'KE:OK', 'KE:SMALL', 'KE:MISS', 'KE:NOSET', 'KE:1115'}
+        summary = _run(
+            reference_sets, ke_list,
+            unresolved_ke_pathways={'KE:1115': ('WP5477',)},
+        )
+
+        assert (
+            summary['tested']
+            + summary['excluded_too_few_genes']
+            + summary['excluded_no_mapping']
+            + summary['excluded_unresolved_mapping']
+            + summary['excluded_error']
+            == summary['total_kes'] == 5
+        )
+
+    def test_unresolved_hint_for_a_tested_ke_is_ignored(self):
+        """A KE that resolved to genes is tested, whatever the hint claims."""
+        reference_sets = {'KE:OK': {f"GENE{i}" for i in range(10)}}
+        summary = _run(
+            reference_sets, {'KE:OK'},
+            unresolved_ke_pathways={'KE:OK': ['WP1']},
+        )
+
+        assert summary['tested'] == 1
+        assert summary['excluded_reasons'] == {}
+        assert summary['unresolved_pathways'] == []
+
+
+class TestNormaliseUnresolvedKePathways:
+    """The hint accepts what the pipeline actually produces."""
+
+    def test_none_and_empty_entries_are_dropped(self):
+        assert normalise_unresolved_ke_pathways(None) == {}
+        assert normalise_unresolved_ke_pathways({'KE:1': [], 'KE:2': None}) == {}
+
+    def test_single_string_is_accepted(self):
+        assert normalise_unresolved_ke_pathways({'KE:1': 'wp5477'}) == {'KE:1': ['WP5477']}
+
+    def test_ids_are_deduplicated_and_sorted(self):
+        assert normalise_unresolved_ke_pathways(
+            {'KE:1': {'WP99', 'wp10', ' WP99 '}}
+        ) == {'KE:1': ['WP10', 'WP99']}
+
+
+class TestFormatKeSummaryWording:
+    """One wording authority for the results page and both reports."""
+
+    def test_unresolved_clause_names_the_pathways(self):
+        text = format_ke_summary({
+            'total_kes': 9, 'tested': 6, 'excluded_no_mapping': 1,
+            'excluded_unresolved_mapping': 1, 'excluded_too_few_genes': 1,
+            'excluded_error': 0, 'min_ke_genes': 5,
+            'unresolved_pathways': ['WP5477'],
+        })
+        assert text == (
+            '6 of 9 Key Events tested; 1 excluded (fewer than 5 measured genes), '
+            '1 excluded (no gene set mapped), '
+            '1 excluded (mapped, but no genes could be resolved: WP5477)'
+        )
+
+    def test_long_pathway_lists_are_summarised(self):
+        text = format_ke_summary({
+            'total_kes': 9, 'tested': 4, 'excluded_unresolved_mapping': 5,
+            'min_ke_genes': 5,
+            'unresolved_pathways': ['WP1', 'WP2', 'WP3', 'WP4', 'WP5'],
+        })
+        assert 'WP1, WP2, WP3 and 2 more' in text
+
+    def test_unnamed_pathways_still_read_as_mapped(self):
+        text = format_ke_summary({
+            'total_kes': 9, 'tested': 8, 'excluded_unresolved_mapping': 1,
+            'min_ke_genes': 5,
+        })
+        assert text.endswith('1 excluded (mapped, but no genes could be resolved)')
+
+    def test_pre_issue_81_summary_is_unchanged(self):
+        """Summaries stored before the split carry only the two old counters."""
+        text = format_ke_summary({
+            'total_kes': 24, 'tested': 18, 'excluded_no_mapping': 2,
+            'excluded_too_few_genes': 4, 'excluded_error': 0, 'min_ke_genes': 5,
+        })
+        assert text == (
+            '18 of 24 Key Events tested; 4 excluded (fewer than 5 measured genes), '
+            '2 excluded (no gene set mapped)'
+        )
+
+
+def _network_for(excluded_kes, reference_sets, extra_kes=()):
+    """Build a one-KE-per-reason network with a single tested KE."""
+    ke_list = set(excluded_kes) | set(extra_kes) | {'KE:OK'}
+    enrichment = pd.DataFrame({'KE': ['KE:OK'], 'p_value': [0.01], 'FDR': [0.01]})
+    edges = pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID'])
+    return build_cytoscape_network(
+        ke_list, edges, enrichment,
+        {k: k for k in ke_list}, {k: 'intermediate' for k in ke_list},
+        reference_sets=reference_sets,
+        excluded_kes=excluded_kes,
+    )
+
+
+class TestNetworkStyling:
+    """The network distinguishes the reasons it reports (issue #81)."""
+
+    def test_unresolved_ke_is_not_styled_as_uncurated(self):
+        network = _network_for(
+            {'KE:1115': EXCLUDED_UNRESOLVED_MAPPING, 'KE:NOSET': EXCLUDED_NO_MAPPING},
+            {'KE:OK': {'GENE0'}},
+        )
+        classes = {n['data']['id']: n['classes'] for n in network['nodes']}
+
+        assert 'unresolved-mapping' in classes['KE:1115']
+        assert 'no-genes' not in classes['KE:1115']
+        assert 'no-genes' in classes['KE:NOSET']
+
+    def test_unknown_reason_keeps_the_legacy_no_genes_styling(self):
+        """Without an exclusion map, a KE with no gene set is still muted."""
+        network = _network_for(
+            {}, {'KE:OK': {'GENE0'}, 'KE:GAP': set()}, extra_kes={'KE:GAP'}
+        )
+        classes = {n['data']['id']: n['classes'] for n in network['nodes']}
+        assert 'no-genes' in classes['KE:GAP']
+
+    def test_accounting_recovered_from_a_stored_network(self):
+        network = _network_for(
+            {'KE:1115': EXCLUDED_UNRESOLVED_MAPPING, 'KE:NOSET': EXCLUDED_NO_MAPPING},
+            {'KE:OK': {'GENE0'}},
+        )
+        summary = ke_accounting_from_network(json.dumps(network))
+
+        assert summary['excluded_unresolved_mapping'] == 1
+        assert summary['excluded_no_mapping'] == 1
+        assert 'mapped, but no genes could be resolved' in format_ke_summary(summary)
+
+    def test_pre_issue_81_network_reports_no_unresolved_kes(self):
+        """A network stored before the split cannot claim a distinction it lacks."""
+        stored = {
+            'nodes': [
+                {'data': {'id': 'KE:1', 'ke_type': 'MIE', 'excluded_reason': None}},
+                {'data': {'id': 'KE:2', 'ke_type': 'AO', 'excluded_reason': 'no_mapping'}},
+            ],
+            'edges': [],
+        }
+        summary = ke_accounting_from_network(stored)
+
+        assert summary['excluded_unresolved_mapping'] == 0
+        assert summary['excluded_no_mapping'] == 1
+        assert 'could not be resolved' not in format_ke_summary(summary)
+
+
+class TestGseaParity:
+    """ORA and GSEA report exclusions with one vocabulary."""
+
+    def test_gsea_uses_the_same_reasons(self):
+        gp = pytest.importorskip('gseapy')  # noqa: F841
+        from services.gsea_service import run_gsea_analysis
+
+        genes = [f"GENE{i:03d}" for i in range(60)]
+        df = pd.DataFrame({
+            'ID': genes,
+            'log2FC': [(-1) ** i * (i / 10.0) for i in range(60)],
+            'pval': [0.001 + i * 0.001 for i in range(60)],
+        })
+        reference_sets = {
+            'KE:OK': set(genes[:20]),
+            'KE:MISS': {'ABSENT1', 'ABSENT2'},
+        }
+        ke_list = {'KE:OK', 'KE:MISS', 'KE:NOSET', 'KE:1115'}
+
+        result = run_gsea_analysis(
+            df, reference_sets, ke_list, {k: k for k in ke_list},
+            permutation_num=10,
+            unresolved_ke_pathways={'KE:1115': ['WP5477']},
+        )
+        summary = get_ke_summary(result)
+
+        assert summary['excluded_reasons']['KE:1115'] == EXCLUDED_UNRESOLVED_MAPPING
+        assert summary['excluded_reasons']['KE:NOSET'] == EXCLUDED_NO_MAPPING
+        assert summary['excluded_reasons']['KE:MISS'] == EXCLUDED_TOO_FEW_GENES
+        assert summary['unresolved_pathways'] == ['WP5477']

--- a/tests/test_ke_exclusion_wiring.py
+++ b/tests/test_ke_exclusion_wiring.py
@@ -1,0 +1,461 @@
+"""Issue #81, production wiring: does the running app actually build and forward
+the KE -> unresolvable-pathway map?
+
+The vocabulary for the three exclusion reasons is covered by
+``test_ke_exclusion_reasons.py``. These tests cover the part that vocabulary is
+useless without: the map has to be produced in ``helpers.load_reference_sets``
+(the only place the association still exists, before the inner merge drops it),
+survive every hand-off, and reach both enrichment call sites. Without that,
+``unresolved_mapping`` is unreachable in production and KE:1115 on AOP:472 is
+still reported as uncurated while carrying a live mapping to WP5477.
+"""
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+import app
+from helpers import (
+    ReferenceSets,
+    load_reference_sets,
+    unresolved_ke_pathways_for,
+)
+from services.enrichment_service import (
+    EXCLUDED_ERROR,
+    EXCLUDED_NO_MAPPING,
+    EXCLUDED_UNRESOLVED_MAPPING,
+    format_ke_summary,
+    get_ke_summary,
+)
+from services.network_service import (
+    build_cytoscape_network,
+    ke_accounting_from_network,
+)
+
+# The case in the issue: AOP:472's KE:1115 is mapped to WP5477, which no source
+# in this repo can resolve to genes.
+KE_UNRESOLVABLE = 'KE:1115'
+WP_UNRESOLVABLE = 'WP5477'
+KE_OK = 'KE:18'
+WP_OK = 'WP3941'
+
+RESOLVABLE_GENES = {f'G{i}' for i in range(1, 11)}
+
+
+def _fake_wp_gene_csvs(tmp_path):
+    """Minimal WP->gene and gene-annotation CSVs (neither one covers WP5477)."""
+    wp_gene = tmp_path / 'edges.csv'
+    node = tmp_path / 'nodes.csv'
+    pd.DataFrame([
+        {'WPID': WP_OK, 'gene_id': str(1000 + i), 'edge_id': i}
+        for i in range(1, 11)
+    ]).to_csv(wp_gene, index=False)
+    pd.DataFrame([
+        {'GeneID': 1000 + i, 'GeneName': f'G{i}'} for i in range(1, 11)
+    ]).to_csv(node, index=False)
+    return str(wp_gene), str(node)
+
+
+class TestReferenceSetsCarryTheMap:
+    """helpers.load_reference_sets is where the association still exists."""
+
+    def test_unresolvable_pathway_is_attributed_to_its_key_event(self, tmp_path):
+        wp_gene_path, node_path = _fake_wp_gene_csvs(tmp_path)
+        ke_wp_df = pd.DataFrame([
+            {'KE_ID': KE_OK, 'WP_ID': WP_OK},
+            {'KE_ID': KE_UNRESOLVABLE, 'WP_ID': WP_UNRESOLVABLE},
+        ])
+
+        sets = load_reference_sets(
+            ke_wp_df=ke_wp_df,
+            wp_gene_path=wp_gene_path,
+            node_path=node_path,
+        )
+
+        # The KE is absent from the sets entirely -- which is exactly why the
+        # map is needed: nothing downstream could otherwise tell it from a KE
+        # nobody has ever mapped.
+        assert KE_UNRESOLVABLE not in sets
+        assert sets[KE_OK] == RESOLVABLE_GENES
+        assert unresolved_ke_pathways_for(sets) == {
+            KE_UNRESOLVABLE: [WP_UNRESOLVABLE]
+        }
+
+    def test_sink_parameter_receives_the_same_map(self, tmp_path):
+        wp_gene_path, node_path = _fake_wp_gene_csvs(tmp_path)
+        sink = {}
+        load_reference_sets(
+            ke_wp_df=pd.DataFrame([
+                {'KE_ID': KE_UNRESOLVABLE, 'WP_ID': WP_UNRESOLVABLE},
+                {'KE_ID': KE_OK, 'WP_ID': WP_OK},
+            ]),
+            wp_gene_path=wp_gene_path,
+            node_path=node_path,
+            unresolved_ke_out=sink,
+        )
+        assert sink == {KE_UNRESOLVABLE: [WP_UNRESOLVABLE]}
+
+    def test_a_key_event_keeps_its_resolvable_pathways(self, tmp_path):
+        """A KE mapped to both a resolvable and an unresolvable pathway is
+        still tested -- but the unresolvable one is recorded against it."""
+        wp_gene_path, node_path = _fake_wp_gene_csvs(tmp_path)
+        sets = load_reference_sets(
+            ke_wp_df=pd.DataFrame([
+                {'KE_ID': KE_OK, 'WP_ID': WP_OK},
+                {'KE_ID': KE_OK, 'WP_ID': WP_UNRESOLVABLE},
+            ]),
+            wp_gene_path=wp_gene_path,
+            node_path=node_path,
+        )
+        assert sets[KE_OK] == RESOLVABLE_GENES
+        assert unresolved_ke_pathways_for(sets) == {KE_OK: [WP_UNRESOLVABLE]}
+
+    def test_nothing_unresolvable_means_an_empty_map(self, tmp_path):
+        wp_gene_path, node_path = _fake_wp_gene_csvs(tmp_path)
+        sets = load_reference_sets(
+            ke_wp_df=pd.DataFrame([{'KE_ID': KE_OK, 'WP_ID': WP_OK}]),
+            wp_gene_path=wp_gene_path,
+            node_path=node_path,
+        )
+        assert unresolved_ke_pathways_for(sets) == {}
+
+    def test_a_plain_dict_is_tolerated(self):
+        """Older cache entries and test fixtures are plain dicts."""
+        assert unresolved_ke_pathways_for({KE_OK: {'A'}}) == {}
+
+
+def _fake_reference_cache(monkeypatch):
+    store = {}
+    fake = MagicMock()
+    fake.get.side_effect = lambda key: store.get(key)
+    fake.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
+    monkeypatch.setattr(app, '_reference_cache', fake)
+    return store
+
+
+class TestAppLoadersForwardTheMap:
+    """app.py must carry the map from the Builder boundary to the caller."""
+
+    def test_wikipathways_loader_returns_the_map(self, monkeypatch):
+        _fake_reference_cache(monkeypatch)
+        sets = ReferenceSets(
+            {KE_OK: RESOLVABLE_GENES},
+            unresolved_ke_pathways={KE_UNRESOLVABLE: [WP_UNRESOLVABLE]},
+        )
+        with patch.object(app, 'fetch_reference_sets_from_api',
+                          return_value=(sets, [WP_UNRESOLVABLE])):
+            _, source, unresolved, unresolved_ke = \
+                app._load_wikipathways_reference_sets('all')
+
+        assert source == 'api'
+        assert unresolved == [WP_UNRESOLVABLE]
+        assert unresolved_ke == {KE_UNRESOLVABLE: [WP_UNRESOLVABLE]}
+
+    def test_the_map_survives_the_disk_cache(self, monkeypatch):
+        store = _fake_reference_cache(monkeypatch)
+        sets = ReferenceSets(
+            {KE_OK: RESOLVABLE_GENES},
+            unresolved_ke_pathways={KE_UNRESOLVABLE: [WP_UNRESOLVABLE]},
+        )
+        with patch.object(app, 'fetch_reference_sets_from_api',
+                          return_value=(sets, [WP_UNRESOLVABLE])):
+            app._load_wikipathways_reference_sets('all')
+
+        assert len(store) == 1
+        # Second call is served from the cache and must not lose the map.
+        cached_sets, source, _, unresolved_ke = \
+            app._load_wikipathways_reference_sets('all')
+        assert source == 'cache(api)'
+        assert unresolved_ke == {KE_UNRESOLVABLE: [WP_UNRESOLVABLE]}
+        assert unresolved_ke_pathways_for(cached_sets) == {
+            KE_UNRESOLVABLE: [WP_UNRESOLVABLE]
+        }
+
+    def test_pre_81_three_tuple_cache_entry_still_loads(self, monkeypatch):
+        """A warm cache written before #81 must not blow up on deploy."""
+        store = _fake_reference_cache(monkeypatch)
+        key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, 'all')
+        store[key] = ({KE_OK: {'A'}}, 'csv', [WP_UNRESOLVABLE])
+
+        sets, source, unresolved, unresolved_ke = \
+            app._load_wikipathways_reference_sets('all')
+        assert sets == {KE_OK: {'A'}}
+        assert source == 'cache(csv)'
+        assert unresolved == [WP_UNRESOLVABLE]
+        assert unresolved_ke == {}
+
+    def test_merged_sets_carry_the_union_across_resources(self, monkeypatch):
+        _fake_reference_cache(monkeypatch)
+        wp = ReferenceSets({KE_OK: RESOLVABLE_GENES})
+        with patch.object(
+            app, '_load_wikipathways_reference_sets',
+            return_value=(wp, 'api', [WP_UNRESOLVABLE],
+                          {KE_UNRESOLVABLE: [WP_UNRESOLVABLE]}),
+        ):
+            merged, _, resolution = app.load_cached_reference_sets(['WikiPathways'])
+
+        assert unresolved_ke_pathways_for(merged) == {
+            KE_UNRESOLVABLE: [WP_UNRESOLVABLE]
+        }
+        assert resolution[0]['unresolved_ke_pathways'] == {
+            KE_UNRESOLVABLE: [WP_UNRESOLVABLE]
+        }
+
+
+class TestAnalyseRouteClassifiesTheKeyEvent:
+    """The end-to-end check #81 asks for, through the real /analyze handler."""
+
+    @staticmethod
+    def _dataset():
+        rows = []
+        for i in range(1, 21):
+            sig = i <= 10
+            rows.append({
+                'ID': f'G{i}',
+                'log2FC': 2.0 if sig else 0.1,
+                'pval': 0.001 if sig else 0.5,
+                'significant': sig,
+            })
+        return pd.DataFrame(rows)
+
+    def test_ke1115_is_mapped_but_unresolvable_and_wp5477_is_named(
+        self, authenticated_client, monkeypatch, tmp_path
+    ):
+        _fake_reference_cache(monkeypatch)
+        wp_gene_path, node_path = _fake_wp_gene_csvs(tmp_path)
+
+        # Only the network boundary is faked: the Builder says KE:1115 is
+        # mapped to WP5477, and no source can resolve WP5477's membership.
+        records = [
+            {'ke_id': 'KE 18', 'pathway_id': WP_OK, 'confidence_level': 'High'},
+            {'ke_id': 'KE 1115', 'pathway_id': WP_UNRESOLVABLE,
+             'confidence_level': 'High'},
+        ]
+        real_load_reference_sets = app.load_reference_sets
+
+        def _csv_backed(**kwargs):
+            kwargs['wp_gene_path'] = wp_gene_path
+            kwargs['node_path'] = node_path
+            return real_load_reference_sets(**kwargs)
+
+        df = self._dataset()
+        edges = pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID', 'AOP_ID'])
+        ke_list = {KE_OK, KE_UNRESOLVABLE}
+
+        with patch('services.api_service.fetch_all_ke_wp_mappings', return_value=records), \
+             patch('services.api_service.fetch_wp_pathway_gene_map',
+                   return_value={WP_OK: RESOLVABLE_GENES}), \
+             patch('services.api_service.load_reference_sets', side_effect=_csv_backed), \
+             patch('app.load_and_validate_data', return_value=df), \
+             patch('app.process_gene_expression', return_value=(df, {'total_genes': 20})), \
+             patch('app.load_aop_data', return_value=(
+                 ke_list, edges,
+                 {KE_OK: 'MIE', KE_UNRESOLVABLE: 'AO'},
+                 {KE_OK: 'Event 18', KE_UNRESOLVABLE: 'Increase, Reactive oxygen species'},
+             )), \
+             patch('app.guess_id_type', return_value='HGNC'), \
+             patch('app.cleanup_file'), \
+             patch('os.path.exists', return_value=True), \
+             patch('app.validate_file_path', return_value=True):
+
+            response = authenticated_client.post('/analyze', data={
+                'filename': 'test.csv',
+                'id_column': 'ID',
+                'fc_column': 'log2FC',
+                'pval_column': 'pval',
+                'aop_selection': 'AOP:472',
+                'logfc_threshold': '1.0',
+            })
+
+        assert response.status_code == 200
+        body = response.get_data(as_text=True)
+        # The whole point of #81: the sentence must say "mapped, but no genes
+        # could be resolved", name WP5477, and not blame the curator.
+        assert 'mapped, but no genes could be resolved' in body
+        assert WP_UNRESOLVABLE in body
+        assert 'excluded (no gene set mapped)' not in body
+
+
+class TestBatchConditionsClassifyTheKeyEvent:
+    """The batch thread is handed nothing but the gene sets (#81 finding 1)."""
+
+    def test_run_batch_stores_the_reason_and_the_pathway_ids(
+        self, temp_database, tmp_path, monkeypatch
+    ):
+        from database import ConditionRecord
+        from services.batch_service import run_batch
+
+        upload_root = tmp_path / 'uploads'
+        upload_root.mkdir()
+        monkeypatch.setattr('config.Config.UPLOAD_FOLDER', str(upload_root))
+
+        def _fake_load_aop_data(aop_id):
+            return (
+                {KE_OK, KE_UNRESOLVABLE},
+                pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID', 'AOP_ID']),
+                {KE_OK: 'MIE', KE_UNRESOLVABLE: 'AO'},
+                {KE_OK: 'Event 18', KE_UNRESOLVABLE: 'Increase, ROS'},
+            )
+        monkeypatch.setattr('services.data_service.load_aop_data', _fake_load_aop_data)
+
+        batch_id = _seed_single_condition_batch(temp_database, str(upload_root))
+
+        reference_sets = ReferenceSets(
+            {KE_OK: RESOLVABLE_GENES},
+            unresolved_ke_pathways={KE_UNRESOLVABLE: [WP_UNRESOLVABLE]},
+        )
+        run_batch(batch_id, temp_database.db_url, reference_sets)
+
+        session = temp_database.get_session()
+        try:
+            cond = session.query(ConditionRecord).filter_by(batch_id=batch_id).first()
+            assert cond.status == 'complete'
+            network = json.loads(cond.network_json)
+            node = next(
+                n['data'] for n in network['nodes']
+                if n['data']['id'] == KE_UNRESOLVABLE
+            )
+            assert node['excluded_reason'] == EXCLUDED_UNRESOLVED_MAPPING
+            assert node['unresolved_pathways'] == [WP_UNRESOLVABLE]
+        finally:
+            session.close()
+
+
+def _seed_single_condition_batch(db_manager, upload_root):
+    import uuid as _uuid
+    from datetime import datetime, timedelta, timezone
+    from database import BatchRecord, ConditionRecord
+
+    batch_uuid = str(_uuid.uuid4())
+    batch_dir = os.path.join(upload_root, batch_uuid)
+    os.makedirs(batch_dir, exist_ok=True)
+    rows = [
+        {'gene': f'G{i}', 'logFC': 2.0 if i <= 10 else 0.1,
+         'pval': 0.001 if i <= 10 else 0.5}
+        for i in range(1, 21)
+    ]
+    pd.DataFrame(rows).to_csv(
+        os.path.join(batch_dir, 'cond0.tsv'), sep='\t', index=False
+    )
+
+    session = db_manager.get_session()
+    try:
+        batch = BatchRecord(
+            uuid=batch_uuid, status='pending', aop_id='AOP:472',
+            aop_label='Test AOP', logfc_threshold=1.0, pval_cutoff=0.05,
+            selected_resources='WikiPathways', id_column='gene',
+            fc_column='logFC', pval_column='pval',
+            harmonised_background=json.dumps([f'G{i}' for i in range(1, 21)]),
+            harmonised_gene_count=20, batch_name='Test Batch',
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
+            + timedelta(days=14),
+        )
+        session.add(batch)
+        session.flush()
+        session.add(ConditionRecord(
+            batch_id=batch.id, position=0, filename='cond0.tsv',
+            condition_label='Cond 0', status='pending',
+        ))
+        session.commit()
+        return batch.id
+    finally:
+        session.close()
+
+
+class TestStoredNetworksKeepThePathwayIds:
+    """Finding 3: the batch report and shared links rebuild the sentence from
+    the stored network, and the IDs are the actionable part."""
+
+    @staticmethod
+    def _network():
+        results = pd.DataFrame({'KE': [KE_OK], 'p_value': [0.01], 'FDR': [0.02]})
+        return build_cytoscape_network(
+            {KE_OK, KE_UNRESOLVABLE},
+            pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID']),
+            results,
+            {KE_OK: 'Event 18', KE_UNRESOLVABLE: 'Increase, ROS'},
+            {KE_OK: 'MIE', KE_UNRESOLVABLE: 'AO'},
+            reference_sets={KE_OK: RESOLVABLE_GENES},
+            excluded_kes={KE_UNRESOLVABLE: EXCLUDED_UNRESOLVED_MAPPING},
+            unresolved_ke_pathways={KE_UNRESOLVABLE: [WP_UNRESOLVABLE]},
+        )
+
+    def test_round_trip_names_the_pathways(self):
+        summary = ke_accounting_from_network(self._network())
+        assert summary['excluded_unresolved_mapping'] == 1
+        assert summary['unresolved_pathways'] == [WP_UNRESOLVABLE]
+        assert WP_UNRESOLVABLE in format_ke_summary(summary)
+
+    def test_round_trip_survives_json_serialisation(self):
+        summary = ke_accounting_from_network(json.dumps(self._network()))
+        assert summary['unresolved_pathways'] == [WP_UNRESOLVABLE]
+
+    def test_networks_without_the_ids_report_none(self):
+        """Stored before #81: the clause renders without IDs, not wrongly."""
+        network = self._network()
+        for node in network['nodes']:
+            node['data'].pop('unresolved_pathways', None)
+        summary = ke_accounting_from_network(network)
+        assert summary['unresolved_pathways'] == []
+        assert 'mapped, but no genes could be resolved' in format_ke_summary(summary)
+
+    def test_unrelated_nodes_gain_no_new_keys(self):
+        node = next(
+            n['data'] for n in self._network()['nodes'] if n['data']['id'] == KE_OK
+        )
+        assert 'unresolved_pathways' not in node
+
+
+class TestErrorExclusionKeepsItsMutedStyling:
+    """Finding 4: only 'unresolved_mapping' withholds the `no-genes` class."""
+
+    @staticmethod
+    def _classes(reason):
+        network = build_cytoscape_network(
+            {KE_UNRESOLVABLE},
+            pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID']),
+            pd.DataFrame({'KE': [], 'p_value': [], 'FDR': []}),
+            {KE_UNRESOLVABLE: 'Increase, ROS'},
+            {KE_UNRESOLVABLE: 'AO'},
+            reference_sets={},
+            excluded_kes={KE_UNRESOLVABLE: reason} if reason else None,
+        )
+        return network['nodes'][0]['classes'].split()
+
+    def test_error_without_a_gene_set_is_still_muted(self):
+        assert 'no-genes' in self._classes(EXCLUDED_ERROR)
+
+    def test_no_mapping_is_muted(self):
+        assert 'no-genes' in self._classes(EXCLUDED_NO_MAPPING)
+
+    def test_unresolved_mapping_is_styled_apart(self):
+        classes = self._classes(EXCLUDED_UNRESOLVED_MAPPING)
+        assert 'unresolved-mapping' in classes
+        assert 'no-genes' not in classes
+
+
+class TestTheTwoResultViewsAgree:
+    """Finding 2: shared_results.html renders the same networks results.html
+    does, so a class one styles and the other does not is a silent regression."""
+
+    @staticmethod
+    def _read(name):
+        here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        with open(os.path.join(here, 'templates', name), encoding='utf-8') as fh:
+            return fh.read()
+
+    @pytest.mark.parametrize('template', ['results.html', 'shared_results.html'])
+    def test_every_exclusion_class_is_styled_and_in_the_legend(self, template):
+        body = self._read(template)
+        for selector in ('node.no-genes', 'node.too-few-genes',
+                         'node.unresolved-mapping'):
+            assert selector in body, f"{template} does not style {selector}"
+        assert 'Mapped, but no genes could be resolved' in body
+
+    def test_the_no_gene_set_legend_wording_is_identical(self):
+        wording = ('No measurable gene set (not curated, or none of its genes '
+                   'measured)')
+        assert wording in self._read('results.html')
+        assert wording in self._read('shared_results.html')

--- a/tests/test_reference_resources.py
+++ b/tests/test_reference_resources.py
@@ -15,7 +15,7 @@ class TestLoadCachedReferenceSets:
 
     def test_default_is_wikipathways_only(self):
         wp = {"KE:1": {"A", "B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader, \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [], {})) as wp_loader, \
              patch.object(app, "_load_gmt_resource_reference_sets") as gmt_loader:
             sets, source, _ = app.load_cached_reference_sets()
         wp_loader.assert_called_once()
@@ -27,7 +27,7 @@ class TestLoadCachedReferenceSets:
     def test_unions_genes_across_resources(self):
         wp = {"KE:1": {"A", "B"}}
         go = {"KE:1": {"B", "C"}, "KE:2": {"D"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             sets, source, _ = app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
         assert sets == {"KE:1": {"A", "B", "C"}, "KE:2": {"D"}}
@@ -36,7 +36,7 @@ class TestLoadCachedReferenceSets:
     def test_does_not_mutate_source_sets(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
         # Cached per-resource sets are untouched by the merge.
@@ -49,7 +49,7 @@ class TestLoadCachedReferenceSets:
         def _boom(resource, min_confidence="all"):
             raise RuntimeError("builder GMT export unavailable")
 
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
              patch.object(app, "_load_gmt_resource_reference_sets", side_effect=_boom):
             sets, source, _ = app.load_cached_reference_sets(["WikiPathways", "Reactome"])
         # Reactome skipped; WikiPathways retained -> analysis still runs.
@@ -58,7 +58,7 @@ class TestLoadCachedReferenceSets:
 
     def test_unknown_resource_falls_back_to_default(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader:
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [], {})) as wp_loader:
             sets, source, _ = app.load_cached_reference_sets(["bogus"])
         wp_loader.assert_called_once()
         assert sets == {"KE:1": {"A"}}
@@ -207,7 +207,7 @@ class TestMinConfidenceThreading:
     def test_threshold_forwarded_to_resource_loaders(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])) as wp_loader, \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})) as wp_loader, \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")) as gmt_loader:
             app.load_cached_reference_sets(["WikiPathways", "GO_BP"], min_confidence="high")
         assert wp_loader.call_args.args[0] == "high"
@@ -215,13 +215,13 @@ class TestMinConfidenceThreading:
 
     def test_default_threshold_is_all(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader:
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [], {})) as wp_loader:
             app.load_cached_reference_sets(["WikiPathways"])
         assert wp_loader.call_args.args[0] == "all"
 
     def test_junk_threshold_falls_back_to_all(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])) as wp_loader:
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [], {})) as wp_loader:
             app.load_cached_reference_sets(["WikiPathways"], min_confidence="'; DROP TABLE --")
         assert wp_loader.call_args.args[0] == "all"
 
@@ -255,7 +255,7 @@ class TestConfidenceScopedCacheKeys:
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
         with patch.object(app, "fetch_reference_sets_from_api", return_value=({"KE:1": {"A"}}, [])) as fetch:
-            sets, source, _ = app._load_wikipathways_reference_sets("high")
+            sets, source, _, _ = app._load_wikipathways_reference_sets("high")
 
         # Cache miss for 'high' -> a fresh fetch at that threshold, not the 'all' set.
         fetch.assert_called_once()
@@ -275,7 +275,7 @@ class TestConfidenceScopedCacheKeys:
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
         with patch.object(app, "fetch_reference_sets_from_api", return_value=({"KE:1": {"A", "B"}}, [])):
-            sets, _, _ = app._load_wikipathways_reference_sets("all")
+            sets, _, _, _ = app._load_wikipathways_reference_sets("all")
         assert sets == {"KE:1": {"A", "B"}}
 
     def test_gmt_loader_caches_per_threshold(self, monkeypatch):
@@ -312,7 +312,7 @@ class TestCachePreservesOriginalSource:
         key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
         self._fake_cache(monkeypatch, {key: ({"KE:1": {"A"}}, "csv")})
 
-        sets, source, _ = app._load_wikipathways_reference_sets("all")
+        sets, source, _, _ = app._load_wikipathways_reference_sets("all")
         assert sets == {"KE:1": {"A"}}
         assert source == "cache(csv)"
 
@@ -320,7 +320,7 @@ class TestCachePreservesOriginalSource:
         key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
         self._fake_cache(monkeypatch, {key: ({"KE:1": {"A"}}, "api")})
 
-        _, source, _ = app._load_wikipathways_reference_sets("all")
+        _, source, _, _ = app._load_wikipathways_reference_sets("all")
         assert source == "cache(api)"
 
     def test_a_cached_csv_fallback_is_still_warned_about(self, monkeypatch):
@@ -337,7 +337,7 @@ class TestResourceResolutionRecording:
     def test_loaded_resources_are_recorded_with_their_source(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}, "KE:2": {"C"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "cache(api)")):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways", "GO_BP"])
 
@@ -355,7 +355,7 @@ class TestResourceResolutionRecording:
         def _boom(resource, min_confidence="all"):
             raise RuntimeError("builder GMT export unavailable")
 
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
              patch.object(app, "_load_gmt_resource_reference_sets", side_effect=_boom):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways", "Reactome"])
 
@@ -368,7 +368,7 @@ class TestResourceResolutionRecording:
 
     def test_csv_fallback_is_disclosed(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [], {})):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
 
         warnings = app.resource_resolution_warnings(resolution)
@@ -376,13 +376,13 @@ class TestResourceResolutionRecording:
 
     def test_clean_run_produces_no_warnings(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
         assert app.resource_resolution_warnings(resolution, "high") == []
 
     def test_description_reads_as_a_sentence(self):
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "cache(csv)", [])):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "cache(csv)", [], {})):
             _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
         assert app.describe_resource_resolution(resolution) == (
             "WikiPathways (bundled reference files, cached)"
@@ -402,7 +402,7 @@ class TestConfidenceApplicabilityIsRecorded:
     def test_gmt_resources_are_marked_unfiltered(self):
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             _, _, resolution = app.load_cached_reference_sets(
                 ["WikiPathways", "GO_BP"], min_confidence="high"
@@ -417,7 +417,7 @@ class TestConfidenceApplicabilityIsRecorded:
     def test_csv_fallback_cannot_apply_the_threshold_either(self):
         """KE-WP.csv has no confidence column, so 'high' is a no-op there too."""
         wp = {"KE:1": {"A"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [])):
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "csv", [], {})):
             _, _, resolution = app.load_cached_reference_sets(
                 ["WikiPathways"], min_confidence="high"
             )
@@ -427,7 +427,7 @@ class TestConfidenceApplicabilityIsRecorded:
         """'All mappings' filters nothing, so there is nothing to caveat."""
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
-        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [])), \
+        with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
              patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "api")):
             _, _, resolution = app.load_cached_reference_sets(
                 ["WikiPathways", "GO_BP"], min_confidence="all"
@@ -517,13 +517,19 @@ class TestPathwayResolutionGap:
         resolution = [{
             'resource': 'WikiPathways', 'status': 'loaded', 'source': 'api',
             'ke_count': 90, 'confidence_applied': True,
-            'unresolved_pathways': ['WP1234', 'WP5477'], 'error': None,
+            'unresolved_pathways': ['WP1234', 'WP5477'],
+            'unresolved_ke_pathways': {'KE:1115': ['WP5477']},
+            'error': None,
         }]
 
         warnings = app.resource_resolution_warnings(resolution)
         joined = " ".join(warnings)
         assert "WP5477" in joined and "WP1234" in joined
-        assert "no gene set" in joined
+        # Issue #81: the affected Key Events are named, and the sentence no
+        # longer says they are reported as unmapped — they are not any more.
+        assert "KE:1115" in joined
+        assert "no gene set" not in joined
+        assert "curated" in joined
 
     def test_no_warning_when_everything_resolves(self):
         resolution = [{
@@ -552,7 +558,7 @@ class TestCacheFormatUpgrade:
         key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
         self._cache(monkeypatch, {key: ({"KE:1": {"A"}}, "api")})
 
-        sets, source, unresolved = app._load_wikipathways_reference_sets("all")
+        sets, source, unresolved, unresolved_ke = app._load_wikipathways_reference_sets("all")
 
         assert sets == {"KE:1": {"A"}}
         assert source == "cache(api)"
@@ -562,7 +568,7 @@ class TestCacheFormatUpgrade:
         key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
         self._cache(monkeypatch, {key: ({"KE:1": {"A"}}, "api", ["WP5477"])})
 
-        sets, source, unresolved = app._load_wikipathways_reference_sets("all")
+        sets, source, unresolved, unresolved_ke = app._load_wikipathways_reference_sets("all")
 
         assert unresolved == ["WP5477"]
         assert source == "cache(api)"


### PR DESCRIPTION
Closes #81. Companion to #79.

The per-condition Key Event accounting used *"no gene set mapped"* for two different situations: a KE with no curated mapping, and a KE that is mapped but whose pathways could not be resolved to genes. On an AOP:472 WikiPathways-only run, KE 1115 was reported as unmapped despite carrying a live, high-confidence mapping to `WP5477`.

The two readings point at different people. *No gene set mapped* says the curation is incomplete and sends a user to the Builder to add a mapping that already exists. *Mapped but unresolvable* says the tool's reference data is stale and is a bug report. As written, a data-pipeline failure was presented as a curation gap.

## What changed

Exclusions are now counted under three reasons — unmapped, mapped-but-unresolvable, and too few measured genes — and the mapped-but-unresolvable clause **names the pathway IDs**, so the claim can be checked against the Builder.

The map of Key Event → unresolvable pathways has to be built in `load_reference_sets()` *before* the inner merge, since that merge is exactly what drops these Key Events from the reference sets: after it, a KE whose only pathway is unresolvable is absent entirely rather than present with an empty set. It is carried on the returned gene sets through both the API and CSV branches, the reference-set cache (older 2- and 3-tuple entries are still read, so a warm cache survives the deploy), and into the enrichment call on both the single and batch paths.

Also here: a Key Event whose gene set resolves fine but whose genes are simply not measured is now counted as *too few measured genes* rather than *no mapping*, which is what it is. `shared_results.html` gained the matching network styling — without it, an unresolvable KE would have rendered as a normal tested KE there.

## Verification

467 tests pass (coverage 77.8%, gate 75%), including a route-level test through `/analyze` and an end-to-end `run_batch` test. Independently checked against the live Builder: 6 Key Events carry a named unresolvable pathway, and the rendered page reports `WP5477` instead of "no gene set mapped".