### PR TITLE
Add GSEA to batch mode (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Added
 
+- **Batch analysis can now run GSEA, not only Fisher/ORA** (#76). Batch mode existed to
+  compare conditions — compound, dose, timepoint — yet it was hardwired to the one method
+  that is worst suited to that job: over-representation asks whether a thresholded gene list
+  is unusually full of a Key Event's genes, and answers per condition in isolation. GSEA asks
+  whether a Key Event's genes shift coherently in the ranking, which is exactly the quantity
+  worth reading down a dose series. On a nine-condition platinum/AOP-472 dataset the two
+  disagree informatively: KE 1194 (DNA damage) reaches significance in 2 of 9 conditions by
+  ORA and 7 of 9 by GSEA, and KE 177 (mitochondrial dysfunction) is called *depleted* by ORA
+  while GSEA shows coordinated positive enrichment — small per-gene effects with a consistent
+  upward bias, which a threshold discards by construction. Getting that table before meant
+  running every condition as a separate single analysis and assembling NES and FDR by hand,
+  which also threw away the harmonised background that makes batch results comparable at all.
+
+  The batch form gains the same method selector as the single-analysis form (selecting GSEA
+  hides the thresholds, which it ignores), the method is stored on the batch rather than per
+  condition so every condition is scored identically, and the comparison view switches to
+  NES + FDR: the heatmap colours on the signed NES over a diverging scale centred at zero, so
+  a coordinated up-shift and a down-shift are no longer both rendered as "significant", and
+  the matrix keeps a sub-threshold NES rather than blanking it, because a consistent weak
+  signal across a dose series is itself the observation. `batches.method` is added by the
+  established idempotent PRAGMA-then-ALTER migration, and a NULL — every batch created before
+  this change — reads back as `ora`, so existing batches still open, run, export and compare
+  exactly as they did.
+
 - **The AOP picker can now be populated from the molAOP Builder** (#3). The Builder gained
   `GET /api/v1/aops` (builder #207), which returns whole AOPs — title, KE count, and mapping
   coverage split across WikiPathways / GO / Reactome — rather than the bare KE IDs that were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,24 +15,44 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   that is worst suited to that job: over-representation asks whether a thresholded gene list
   is unusually full of a Key Event's genes, and answers per condition in isolation. GSEA asks
   whether a Key Event's genes shift coherently in the ranking, which is exactly the quantity
-  worth reading down a dose series. On a nine-condition platinum/AOP-472 dataset the two
-  disagree informatively: KE 1194 (DNA damage) reaches significance in 2 of 9 conditions by
-  ORA and 7 of 9 by GSEA, and KE 177 (mitochondrial dysfunction) is called *depleted* by ORA
-  while GSEA shows coordinated positive enrichment — small per-gene effects with a consistent
-  upward bias, which a threshold discards by construction. Getting that table before meant
+  worth reading down a dose series, and it keeps the small per-gene effects with a consistent
+  direction that a threshold discards by construction. Getting that table before meant
   running every condition as a separate single analysis and assembling NES and FDR by hand,
   which also threw away the harmonised background that makes batch results comparable at all.
 
-  The batch form gains the same method selector as the single-analysis form (selecting GSEA
-  hides the thresholds, which it ignores), the method is stored on the batch rather than per
-  condition so every condition is scored identically, and the comparison view switches to
-  NES + FDR: the heatmap colours on the signed NES over a diverging scale centred at zero, so
-  a coordinated up-shift and a down-shift are no longer both rendered as "significant", and
-  the matrix keeps a sub-threshold NES rather than blanking it, because a consistent weak
-  signal across a dose series is itself the observation. `batches.method` is added by the
-  established idempotent PRAGMA-then-ALTER migration, and a NULL — every batch created before
-  this change — reads back as `ora`, so existing batches still open, run, export and compare
-  exactly as they did.
+  The batch form gains the same method selector as the single-analysis form, and the method
+  is stored on the batch rather than per condition so every condition is scored identically.
+  The log2FC and p-value thresholds stay on screen under GSEA: they do not enter the GSEA
+  statistic, but the run still uses them to decide which genes count as significant, and
+  those counts are what the comparison page's per-condition strip and the driver-gene tab
+  are built from — so the form now says that instead of hiding controls whose numbers you
+  are then shown.
+
+  Everything downstream follows the batch's method rather than assuming Fisher:
+
+  - **Comparison view** — heatmap and table switch to NES + FDR. The heatmap colours on the
+    signed NES over a diverging scale centred at zero, so a coordinated up-shift and a
+    down-shift are no longer both rendered as "significant", and the matrix keeps a
+    sub-threshold NES rather than blanking it, because a consistent weak signal across a
+    dose series is itself the observation. Clicking a condition header sorts the largest
+    NES to the top (for FDR it still sorts the smallest to the top).
+  - **Comparison network, delta mode** — the delta slices now show the *change in NES*
+    against the reference condition on a red/blue divergent scale with the shift size in
+    the shading, and the legend says so. Previously a downward shift was drawn the same way
+    a loss of significance is drawn (muted grey), which read as weaker evidence when it
+    meant the opposite direction.
+  - **Matrix export** — NES joins FDR and -log10(FDR) in the export dropdown and in
+    `GET /batch/<uuid>/compare/export?matrix=nes`, so what is on screen can be downloaded.
+  - **Batch report (PDF and HTML)** — the per-condition tables print NES, the permutation
+    FDR and the leading-edge genes, the comparison heatmap and matrix carry NES, and the
+    header states the method. Before this, a GSEA batch's report was rendered through the
+    Fisher columns and printed `0` overlap and `0.00` odds ratio for every Key Event while
+    silently dropping NES and the leading-edge genes.
+
+  `batches.method` is added by the established idempotent PRAGMA-then-ALTER migration.
+  SQLite backfills existing rows with `ora`, and a NULL from any other path is read as `ora`
+  too, so every batch created before this change still opens, runs, exports and compares
+  exactly as it did.
 
 - **The AOP picker can now be populated from the molAOP Builder** (#3). The Builder gained
   `GET /api/v1/aops` (builder #207), which returns whole AOPs — title, KE count, and mapping

--- a/app.py
+++ b/app.py
@@ -2698,7 +2698,9 @@ def batch_compare_export(batch_uuid_str):
 
     Query params:
         fmt:    'csv' (default) or 'xlsx'.
-        matrix: 'fdr' (default, raw FDR) or 'neglog10' (-log10(FDR)).
+        matrix: 'fdr' (default, raw FDR), 'neglog10' (-log10(FDR)) or 'nes'
+                (normalised enrichment score; a GSEA batch only — an ORA batch
+                produces no NES and exports blank cells).
 
     The download is the wide KE x condition table shown on the comparison page.
     """
@@ -2707,8 +2709,8 @@ def batch_compare_export(batch_uuid_str):
     which = request.args.get('matrix', 'fdr').lower()
     if fmt not in ('csv', 'xlsx'):
         abort(400, description="Invalid format (expected csv or xlsx)")
-    if which not in ('fdr', 'neglog10'):
-        abort(400, description="Invalid matrix (expected fdr or neglog10)")
+    if which not in ('fdr', 'neglog10', 'nes'):
+        abort(400, description="Invalid matrix (expected fdr, neglog10 or nes)")
 
     session_db = db_manager.get_session()
     try:
@@ -2716,7 +2718,11 @@ def batch_compare_export(batch_uuid_str):
         if conditions is None:
             return batch  # error response tuple
 
-        matrix_dict = build_comparison_matrix(conditions)
+        # Issue #76: build for the batch's own method, otherwise the NES matrix
+        # is never populated and matrix=nes exports an empty table.
+        matrix_dict = build_comparison_matrix(
+            conditions, method=batch.effective_method()
+        )
         df = comparison_matrix_to_dataframe(matrix_dict, which=which)
 
         stem = f"molAOP_{_safe_filename_part(batch.aop_id)}_{_safe_filename_part(batch.batch_name)}_comparison_{which}"
@@ -2914,7 +2920,12 @@ def batch_report(batch_uuid_str):
 
         # Only include conditions that actually produced results.
         complete_conditions = [c for c in conditions if c.status == 'complete' and c.enrichment_json]
-        comparison_data = build_comparison_matrix(complete_conditions)
+        # Issue #76: the report must be built for the method the batch was run
+        # with. Without this a GSEA batch was tabulated with the Fisher columns,
+        # printing zeros for overlap and odds ratio and dropping NES entirely.
+        comparison_data = build_comparison_matrix(
+            complete_conditions, method=batch.effective_method()
+        )
 
         stem = f"molAOP_{_safe_filename_part(batch.batch_name)}_batch_report"
 

--- a/app.py
+++ b/app.py
@@ -1995,7 +1995,8 @@ def _persist_and_launch_batch(*, batch_uuid, filenames, condition_labels, doses,
                               timepoints, id_col, fc_col, pval_col, aop_id,
                               logfc_threshold, pval_threshold, resources,
                               harmonised_genes, batch_name, owner, description,
-                              min_confidence=DEFAULT_MIN_CONFIDENCE):
+                              min_confidence=DEFAULT_MIN_CONFIDENCE,
+                              method='ora'):
     """Create the BatchRecord + ConditionRecords and launch run_batch in a thread.
 
     Shared by the interactive batch wizard (/batch/analyze) and the one-click
@@ -2013,6 +2014,8 @@ def _persist_and_launch_batch(*, batch_uuid, filenames, condition_labels, doses,
         batch_name/owner/description: batch metadata.
         min_confidence: issue #60 minimum KE-mapping confidence ('all',
             'medium' or 'high'); applied to every condition in the batch.
+        method: issue #76 enrichment method ('ora' or 'gsea'); applied to
+            every condition so the comparison matrix stays comparable.
 
     Returns:
         The new BatchRecord primary key.
@@ -2039,6 +2042,7 @@ def _persist_and_launch_batch(*, batch_uuid, filenames, condition_labels, doses,
             status='pending',
             aop_id=aop_id,
             aop_label=aop_label,
+            method=method,  # Issue #76
             logfc_threshold=logfc_threshold,
             pval_cutoff=pval_threshold,
             selected_resources=", ".join(resources),
@@ -2073,7 +2077,10 @@ def _persist_and_launch_batch(*, batch_uuid, filenames, condition_labels, doses,
 
         session_db.commit()
         batch_id = batch.id
-        logger.info(f'_persist_and_launch_batch: BatchRecord {batch_id} created ({len(filenames)} conditions)')
+        logger.info(
+            f'_persist_and_launch_batch: BatchRecord {batch_id} created '
+            f'({len(filenames)} conditions, method={method})'
+        )
     except Exception:
         session_db.rollback()
         raise
@@ -2128,6 +2135,15 @@ def batch_analyze():
     pval_col = request.form.get('pval_col', '').strip()
     if not (id_col and fc_col and pval_col):
         return jsonify({'error': 'Column mapping (id_col, fc_col, pval_col) is required'}), 400
+
+    # Issue #76: enrichment method, applied to every condition in the batch.
+    # Whitelisted here exactly as /analyze does (T-14-01); a blank field is the
+    # pre-#76 behaviour, ORA.
+    method = (request.form.get('method') or 'ora').strip().lower()
+    if method not in ('ora', 'gsea'):
+        return jsonify({
+            'error': "Invalid method. Choose Fisher's exact or GSEA on the batch form."
+        }), 400
 
     try:
         logfc_threshold = float(request.form.get('logfc_threshold', '0.0'))
@@ -2227,6 +2243,7 @@ def batch_analyze():
             fc_col=fc_col,
             pval_col=pval_col,
             aop_id=aop_id,
+            method=method,  # Issue #76
             logfc_threshold=logfc_threshold,
             pval_threshold=pval_threshold,
             resources=resources,
@@ -2532,7 +2549,10 @@ def batch_compare(batch_uuid_str):
         )
 
         # Build comparison matrix while session is still open (conditions bound to session).
-        comparison_data = build_comparison_matrix(conditions)
+        # Issue #76: a GSEA batch is compared on NES, not on the ORA columns.
+        # effective_method() reads NULL (pre-#76 batches) as 'ora'.
+        batch_method = batch.effective_method()
+        comparison_data = build_comparison_matrix(conditions, method=batch_method)
         comparison_data_json = json.dumps(comparison_data)
 
         # Extract the first complete condition's network_json for the comparison network.
@@ -2552,6 +2572,7 @@ def batch_compare(batch_uuid_str):
             'compare.html',
             batch=batch,
             conditions=conditions,
+            batch_method=batch_method,
             comparison_data_json=comparison_data_json,
             network_json=json.dumps(first_network) if first_network else 'null',
         )

--- a/database.py
+++ b/database.py
@@ -193,6 +193,17 @@ class BatchRecord(Base):
     aop_label = Column(String(500))
 
     # Shared analysis parameters
+    # Issue #76: enrichment method applied to every condition in the batch
+    # ('ora' or 'gsea'). NULL for rows written before #76 — coerced to 'ora'
+    # on read so pre-existing batches keep opening, exporting and comparing
+    # exactly as they did.
+    #
+    # The column deliberately lives here and not on ``batch_conditions``: the
+    # method is a batch-level parameter, like logfc_threshold, pval_cutoff,
+    # selected_resources and min_confidence. Cross-condition comparison is only
+    # meaningful when every condition was scored the same way, so a per-
+    # condition column could only ever encode an invalid state.
+    method = Column(String(20))
     logfc_threshold = Column(Float)
     pval_cutoff = Column(Float)
     # Issue #55: comma-separated gene-set resources used (e.g. "WikiPathways, GO_BP").
@@ -229,6 +240,19 @@ class BatchRecord(Base):
         back_populates='batch',
         order_by='ConditionRecord.position',
     )
+
+    def effective_method(self) -> str:
+        """Return the enrichment method this batch was run with.
+
+        Coerces NULL to ``'ora'`` (issue #76), the behaviour of every batch
+        created before the method column existed. Callers should use this
+        rather than reading ``.method`` directly so a legacy batch never
+        reaches a GSEA-only code path.
+
+        Returns:
+            ``'ora'`` or ``'gsea'``.
+        """
+        return self.method or 'ora'
 
 
 class ConditionRecord(Base):
@@ -314,10 +338,15 @@ def cleanup_expired_batches(session):
 def _ensure_method_column(engine) -> None:
     """Idempotent PRAGMA-then-ALTER migration for the 'method' column.
 
-    Adds ``method TEXT DEFAULT 'ora'`` to both ``experiments`` and
-    ``shared_results`` tables when the column is absent.  Safe to run on
-    every startup — the PRAGMA check makes the ALTER a no-op on databases
-    that already have the column (D-04, D-06).
+    Adds ``method TEXT DEFAULT 'ora'`` to the ``experiments``,
+    ``shared_results`` and ``batches`` tables when the column is absent.
+    Safe to run on every startup — the PRAGMA check makes the ALTER a no-op
+    on databases that already have the column (D-04, D-06, #76).
+
+    ``batches`` joined the list with issue #76, which gave batch runs a
+    method selector. Existing rows keep NULL, read back as ``'ora'`` by
+    :meth:`BatchRecord.effective_method`, so a batch created before the
+    change still opens, runs, exports and compares as ORA.
 
     Security note: both table names and the column literal are module-internal
     constants — no user-supplied input is interpolated into the SQL statements.
@@ -325,7 +354,7 @@ def _ensure_method_column(engine) -> None:
     Args:
         engine: SQLAlchemy engine bound to the target database.
     """
-    for table in ('experiments', 'shared_results'):
+    for table in ('experiments', 'shared_results', 'batches'):
         with engine.connect() as conn:
             result = conn.execute(text(f"PRAGMA table_info({table})"))
             existing_cols = {row[1] for row in result}

--- a/database.py
+++ b/database.py
@@ -344,9 +344,13 @@ def _ensure_method_column(engine) -> None:
     on databases that already have the column (D-04, D-06, #76).
 
     ``batches`` joined the list with issue #76, which gave batch runs a
-    method selector. Existing rows keep NULL, read back as ``'ora'`` by
-    :meth:`BatchRecord.effective_method`, so a batch created before the
-    change still opens, runs, exports and compares as ORA.
+    method selector. SQLite's ``ADD COLUMN … DEFAULT 'ora'`` backfills every
+    existing row with ``'ora'`` rather than leaving it NULL, so a batch created
+    before the change reads back as ORA directly — which is what it was. NULL is
+    still handled (a row written by another path, or an older migration that
+    added the column without a default) and
+    :meth:`BatchRecord.effective_method` coerces it to ``'ora'`` at every read
+    site, so either way such a batch opens, runs, exports and compares as ORA.
 
     Security note: both table names and the column literal are module-internal
     constants — no user-supplied input is interpolated into the SQL statements.

--- a/services/batch_report_service.py
+++ b/services/batch_report_service.py
@@ -43,15 +43,42 @@ _KE_TYPE_COLORS = {
 }
 
 
+def batch_method(batch) -> str:
+    """Return the enrichment method a batch was run with ('ora' or 'gsea').
+
+    Issue #76. Reads ``BatchRecord.effective_method()`` where available so a
+    batch created before the method column existed reads as ORA, and tolerates
+    plain stand-in objects that only carry a ``method`` attribute.
+
+    Args:
+        batch: BatchRecord (or any object exposing ``effective_method`` or
+            ``method``).
+
+    Returns:
+        str: 'gsea' when the batch was run with GSEA, otherwise 'ora'.
+    """
+    getter = getattr(batch, 'effective_method', None)
+    if callable(getter):
+        try:
+            return getter() or 'ora'
+        except Exception:  # pragma: no cover — provenance must never break a report
+            pass
+    return (getattr(batch, 'method', None) or 'ora')
+
+
 def render_heatmap_png(comparison_data: dict) -> Optional[bytes]:
     """Render the cross-condition comparison heatmap as PNG bytes.
 
-    Uses the -log10(FDR) matrix with the same yellow→red colourscale as the
-    interactive compare page. Returns None on any failure (missing data,
-    plotly/kaleido unavailable).
+    Mirrors the interactive compare page: the -log10(FDR) matrix on a
+    yellow→red scale for an ORA batch, and the signed NES on a diverging
+    red/blue scale clamped to ±3 for a GSEA batch (issue #76), so the printed
+    heatmap shows the same quantity the screen does. Returns None on any
+    failure (missing data, plotly/kaleido unavailable).
 
     Args:
-        comparison_data: Dict from build_comparison_matrix.
+        comparison_data: Dict from build_comparison_matrix. Its ``method`` key
+            selects the matrix; a matrix dict written before #76 has no such
+            key and renders as ORA.
 
     Returns:
         PNG bytes, or None if rendering is not possible.
@@ -61,18 +88,32 @@ def render_heatmap_png(comparison_data: dict) -> Optional[bytes]:
     try:
         import plotly.graph_objects as go
 
-        z = comparison_data['neg_log10_matrix']
+        is_gsea = comparison_data.get('method') == 'gsea'
         x = comparison_data['condition_labels']
         y = comparison_data['ke_titles']
 
+        if is_gsea:
+            z = comparison_data.get('nes_matrix') or comparison_data['neg_log10_matrix']
+            heatmap_kwargs = dict(
+                colorscale='RdBu',
+                reversescale=True,  # red = positive NES (coordinated up-shift)
+                zmin=-3, zmax=3, zmid=0,
+                colorbar=dict(title='NES'),
+            )
+        else:
+            z = comparison_data['neg_log10_matrix']
+            heatmap_kwargs = dict(
+                colorscale=[
+                    [0, '#ffffcc'], [0.25, '#feb24c'], [0.5, '#fd8d3c'],
+                    [0.75, '#e31a1c'], [1, '#800026'],
+                ],
+                colorbar=dict(title='-log10(FDR)'),
+            )
+
         fig = go.Figure(data=go.Heatmap(
             z=z, x=x, y=y,
-            colorscale=[
-                [0, '#ffffcc'], [0.25, '#feb24c'], [0.5, '#fd8d3c'],
-                [0.75, '#e31a1c'], [1, '#800026'],
-            ],
-            colorbar=dict(title='-log10(FDR)'),
             hoverongaps=False,
+            **heatmap_kwargs,
         ))
         # Size scales with row/column count, bounded for sane PDFs.
         height = max(300, min(1200, 40 * len(y) + 120))
@@ -230,9 +271,13 @@ def _batch_resource_warnings(batch) -> List[str]:
 def _batch_meta_rows(batch, conditions, comparison_data) -> List[tuple]:
     """Build (label, value) rows describing the batch for the report header."""
     completed = batch.completed_at.strftime('%Y-%m-%d %H:%M') if batch.completed_at else 'N/A'
+    is_gsea = batch_method(batch) == 'gsea'
     return [
         ('AOP', f'{batch.aop_label or ""} ({batch.aop_id or "N/A"})'),
         ('Conditions', str(len(conditions))),
+        # Issue #76: which statistic every number in this report came from.
+        ('Statistical Method',
+         'GSEA (rank-based)' if is_gsea else "Fisher's exact (over-representation)"),
         ('Gene Set Resources (requested)', batch.selected_resources or 'WikiPathways'),
         # Issue #68: what the resources actually resolved to. The requested list
         # cannot show a resource that was skipped or served from bundled files.
@@ -240,8 +285,16 @@ def _batch_meta_rows(batch, conditions, comparison_data) -> List[tuple]:
         # Issue #60: the mapping-confidence threshold the gene sets were built at.
         ('Min. Mapping Confidence',
          MIN_CONFIDENCE_LABELS.get(getattr(batch, 'min_confidence', None) or 'all', 'All mappings')),
-        ('Log2FC Threshold', str(batch.logfc_threshold)),
-        ('P-value Cutoff', str(batch.pval_cutoff)),
+        # Issue #76: under GSEA these thresholds do not enter the enrichment
+        # statistic — they only define the per-condition significant-gene counts
+        # and the driver genes on the comparison page. Say so rather than let
+        # them read as the test's cutoffs.
+        ('Log2FC Threshold',
+         f'{batch.logfc_threshold} (gene counts only; GSEA ranks all genes)'
+         if is_gsea else str(batch.logfc_threshold)),
+        ('P-value Cutoff',
+         f'{batch.pval_cutoff} (gene counts only; GSEA ranks all genes)'
+         if is_gsea else str(batch.pval_cutoff)),
         ('Harmonised Background', f'{batch.harmonised_gene_count or 0:,} genes'),
         ('Owner', batch.owner or 'N/A'),
         ('Completed', completed),
@@ -290,8 +343,16 @@ def generate_batch_html(batch, conditions, comparison_data: dict) -> str:
     else:
         heatmap_html = '<p class="note">Heatmap image unavailable.</p>'
 
-    # Comparison matrix table (FDR, top 30 KEs).
-    df = comparison_matrix_to_dataframe(comparison_data, which='fdr')
+    # Comparison matrix table — NES for a GSEA batch, FDR otherwise (#76).
+    is_gsea = batch_method(batch) == 'gsea'
+    comparison_caption = (
+        'Normalised enrichment score (NES, signed) of each Key Event across '
+        'conditions. Red is a coordinated up-shift, blue a down-shift; the table '
+        'below carries the same NES values.'
+        if is_gsea else
+        'Significance (-log10 FDR) of each Key Event across conditions.'
+    )
+    df = comparison_matrix_to_dataframe(comparison_data, which='nes' if is_gsea else 'fdr')
     if not df.empty:
         comp_table_html = df.head(30).to_html(index=False, na_rep='', border=0,
                                               classes='enrichment-table')
@@ -369,7 +430,7 @@ def generate_batch_html(batch, conditions, comparison_data: dict) -> str:
         </section>
         <section class="comparison-section">
             <h2>Cross-Condition Comparison</h2>
-            <p class="section-description">Significance (-log10 FDR) of each Key Event across conditions.</p>
+            <p class="section-description">{comparison_caption}</p>
             {heatmap_html}
             <div class="table-container">{comp_table_html}</div>
         </section>
@@ -403,7 +464,10 @@ def _condition_report_data(batch, cond, enrichment: List[Dict]) -> ReportData:
         pval_column=batch.pval_column or '',
         id_type='symbol',
         enrichment_results=enrichment,
-        method='ora',
+        # Issue #76: the per-condition table is rendered from this, and reading
+        # a GSEA row through the ORA columns prints 0 overlap / 0.00 odds ratio
+        # and drops NES and the leading-edge genes.
+        method=batch_method(batch),
         selected_resources=batch.selected_resources or 'WikiPathways',
         min_confidence=getattr(batch, 'min_confidence', None) or 'all',  # Issue #60
     )
@@ -480,7 +544,14 @@ def generate_batch_pdf(batch, conditions, comparison_data: dict) -> bytes:
     story.append(Spacer(1, 20))
 
     # Comparison heatmap.
+    is_gsea = batch_method(batch) == 'gsea'
     story.append(Paragraph('Cross-Condition Comparison', heading_style))
+    story.append(Paragraph(
+        'Normalised enrichment score (NES, signed) per Key Event across conditions.'
+        if is_gsea else
+        'Significance (-log10 FDR) per Key Event across conditions.',
+        normal_style,
+    ))
     heatmap_png = render_heatmap_png(comparison_data)
     if heatmap_png:
         try:
@@ -498,15 +569,19 @@ def generate_batch_pdf(batch, conditions, comparison_data: dict) -> bytes:
         story.append(Paragraph('Heatmap image unavailable.', normal_style))
     story.append(Spacer(1, 16))
 
-    # Comparison matrix table (FDR, top 25).
-    df = comparison_matrix_to_dataframe(comparison_data, which='fdr')
+    # Comparison matrix table — NES for a GSEA batch, FDR otherwise (#76).
+    df = comparison_matrix_to_dataframe(comparison_data, which='nes' if is_gsea else 'fdr')
     if not df.empty:
         df = df.head(25)
-        # Format floats compactly; blank for NaN.
+        # Format floats compactly; blank for NaN. NES is a small signed number,
+        # so it is printed with its sign at fixed precision rather than through
+        # the FDR formatter, which would render -1.8 in scientific notation.
         def _fmt(v):
             if v is None or (isinstance(v, float) and v != v):
                 return ''
             if isinstance(v, float):
+                if is_gsea:
+                    return f'{v:+.2f}'
                 return f'{v:.2e}' if v < 0.001 else f'{v:.4f}'
             return str(v)
         header = list(df.columns)
@@ -551,7 +626,11 @@ def generate_batch_pdf(batch, conditions, comparison_data: dict) -> bytes:
         story.append(Spacer(1, 8))
 
         if enrichment:
-            table = report_generator.build_enrichment_table_flowable(enrichment, is_gsea=False, max_rows=15)
+            # Issue #76: GSEA rows have no odds_ratio / num_overlap / Direction,
+            # so the ORA columns printed zeros and dropped NES and lead genes.
+            table = report_generator.build_enrichment_table_flowable(
+                enrichment, is_gsea=is_gsea, max_rows=15
+            )
             if table is not None:
                 story.append(table)
         else:

--- a/services/batch_service.py
+++ b/services/batch_service.py
@@ -264,6 +264,12 @@ def _run_condition(
     Loads the file, applies the harmonised background filter, runs enrichment
     and network building, stores results on the ConditionRecord, and commits.
 
+    The enrichment backend is chosen by the parent batch's method (issue #76):
+    ``'ora'`` runs Fisher's exact over the thresholded gene list, ``'gsea'``
+    runs the rank-based backend over every measured gene. The choice is
+    batch-level, so every condition is scored the same way and the comparison
+    matrix stays internally consistent.
+
     Args:
         cond: ConditionRecord ORM object to process.
         batch: Parent BatchRecord (provides shared parameters).
@@ -277,10 +283,13 @@ def _run_condition(
     """
     from services.data_service import load_and_validate_data, process_gene_expression
     from services.enrichment_service import (
-        run_enrichment_analysis, build_ke_gene_mapping, get_ke_summary,
+        run_enrichment, build_ke_gene_mapping, get_ke_summary,
         assess_background_overlap,
     )
     from services.network_service import build_cytoscape_network
+
+    # Issue #76: NULL method (batch created before the column existed) is ORA.
+    method = batch.effective_method()
 
     cond.status = 'running'
     cond.started_at = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -310,9 +319,12 @@ def _run_condition(
     total_genes = len(df_filtered)
     significant_genes = int(df_filtered['significant'].sum())
 
-    # Run enrichment on the harmonised/filtered data
-    enrichment_results = run_enrichment_analysis(
-        df_filtered, reference_sets, ke_list, ke_title_map
+    # Run enrichment on the harmonised/filtered data, dispatching to Fisher
+    # (ORA) or GSEA per the batch-level method (#76). GSEA ranks the whole
+    # filtered table, so the harmonised background still bounds it identically
+    # across conditions — which is what makes the comparison legitimate.
+    enrichment_results = run_enrichment(
+        method, df_filtered, reference_sets, ke_list, ke_title_map
     )
 
     # Build Cytoscape network. The tested/excluded KE accounting (issue #65)
@@ -322,6 +334,7 @@ def _run_condition(
     cy_network = build_cytoscape_network(
         ke_list, edges, enrichment_results, ke_title_map, ke_type_map,
         reference_sets=reference_sets,
+        method=method,
         excluded_kes=(ke_summary or {}).get('excluded_reasons'),
     )
 
@@ -370,7 +383,7 @@ def _run_condition(
 
     logger.info(
         f'_run_condition: condition {cond.id} ({cond.condition_label}) complete — '
-        f'{total_genes} genes, {significant_genes} significant'
+        f'{total_genes} genes, {significant_genes} significant, method={method}'
     )
 
 
@@ -414,7 +427,10 @@ def run_batch(batch_id: int, db_url: str, reference_sets: Dict) -> None:
 
         batch.status = 'running'
         db_session.commit()
-        logger.info(f'run_batch: starting batch {batch.uuid} ({len(batch.conditions)} conditions)')
+        logger.info(
+            f'run_batch: starting batch {batch.uuid} ({len(batch.conditions)} conditions, '
+            f'method={batch.effective_method()})'
+        )
 
         # Load harmonised background from the stored JSON
         harmonised_genes: Set[str] = set(

--- a/services/comparison_service.py
+++ b/services/comparison_service.py
@@ -28,7 +28,7 @@ CONDITION_PALETTE = [
 ]
 
 
-def build_comparison_matrix(conditions: list) -> dict[str, Any]:
+def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, Any]:
     """Build a comparison matrix from a list of ConditionRecord objects.
 
     Pivots enrichment results for all conditions into a KE × condition matrix
@@ -36,25 +36,39 @@ def build_comparison_matrix(conditions: list) -> dict[str, Any]:
     mean significance (most significant first).  Columns are kept in upload-
     position order (not alphabetical) by explicit reindexing after pivot.
 
+    For a GSEA batch (``method='gsea'``, issue #76) an additional ``nes_matrix``
+    is produced from each condition's normalised enrichment score. NES is the
+    quantity worth comparing across conditions — it is signed, so a coordinated
+    upward shift in one condition and a downward shift in another are
+    distinguishable, which a p-value-derived matrix cannot show. Unlike
+    ``neg_log10_matrix`` it is *not* blanked at the significance cutoff: a
+    consistent sub-threshold NES across a dose series is itself the signal.
+
     Args:
         conditions: List of ConditionRecord ORM objects ordered by position.
                     Each must expose ``condition_label`` and ``enrichment_json``
                     (a JSON-serialised list of enrichment result dicts).
+        method: Enrichment method the batch was run with — ``'ora'`` (default,
+                the value a pre-#76 batch reads back as) or ``'gsea'``.
 
     Returns:
         A dict with keys:
             ke_labels        — list of KE ID strings in row order
             ke_titles        — list of human-readable KE titles
             condition_labels — list of condition label strings in upload order
+            method           — the method string this matrix was built for
             fdr_matrix       — 2-D list (rows=KEs, cols=conditions) of raw FDR
                                floats, None where data is absent
             neg_log10_matrix — 2-D list of -log10(FDR) floats, None where FDR
                                is absent or above Config.SIGNIFICANCE_FDR_CUTOFF
                                (non-significant)
+            nes_matrix       — 2-D list of NES floats (GSEA batches only; all
+                               None for ORA batches, which carry no NES)
             condition_colors — list of hex colour strings from CONDITION_PALETTE
 
         Returns an empty dict ``{}`` if no enrichment rows are found.
     """
+    is_gsea = method == 'gsea'
     rows = []
     ke_title_map: dict[str, str] = {}
 
@@ -76,11 +90,13 @@ def build_comparison_matrix(conditions: list) -> dict[str, Any]:
             title = entry.get('Title', '')
             if ke is None or fdr is None:
                 continue
+            nes = entry.get('NES')
             rows.append({
                 'condition': cond.condition_label,
                 'KE': ke,
                 'Title': title,
                 'FDR': float(fdr),
+                'NES': float(nes) if nes is not None else None,
             })
             # Keep first-seen title per KE
             if ke not in ke_title_map:
@@ -90,7 +106,7 @@ def build_comparison_matrix(conditions: list) -> dict[str, Any]:
         logger.info('build_comparison_matrix: no enrichment rows found — returning empty dict')
         return {}
 
-    df = pd.DataFrame(rows, columns=['condition', 'KE', 'Title', 'FDR'])
+    df = pd.DataFrame(rows, columns=['condition', 'KE', 'Title', 'FDR', 'NES'])
 
     # H-1: a well-formed enrichment table has unique KEs per condition. If a
     # condition's blob contains duplicate (condition, KE) pairs, pivot_table's
@@ -121,12 +137,26 @@ def build_comparison_matrix(conditions: list) -> dict[str, Any]:
 
     neg_log10_pivot = pivot.map(_neg_log10)
 
+    # NES pivot (#76). Built only for GSEA batches — an ORA enrichment table has
+    # no NES column, so the pivot would be all-NaN and only add noise.
+    if is_gsea:
+        nes_pivot = df.pivot_table(
+            index='KE', columns='condition', values='NES', aggfunc='first'
+        ).reindex(columns=condition_labels)
+        # Reindex rows too: a KE whose NES was NaN in every condition is dropped
+        # by pivot_table, and the matrix must stay aligned with `pivot`.
+        nes_pivot = nes_pivot.reindex(index=pivot.index)
+    else:
+        nes_pivot = None
+
     # Sort KE rows by mean -log10(FDR) significance descending (most significant first).
     # Fill NaN with 0 for sorting purposes only.
     mean_sig = neg_log10_pivot.fillna(0).mean(axis=1)
     sort_order = mean_sig.sort_values(ascending=False).index
     pivot = pivot.loc[sort_order]
     neg_log10_pivot = neg_log10_pivot.loc[sort_order]
+    if nes_pivot is not None:
+        nes_pivot = nes_pivot.loc[sort_order]
 
     ke_labels = list(pivot.index)
     ke_titles = [ke_title_map.get(ke, ke) for ke in ke_labels]
@@ -143,6 +173,10 @@ def build_comparison_matrix(conditions: list) -> dict[str, Any]:
 
     fdr_matrix = _to_list(pivot)
     neg_log10_matrix = _to_list(neg_log10_pivot)
+    nes_matrix = (
+        _to_list(nes_pivot) if nes_pivot is not None
+        else [[None] * len(condition_labels) for _ in ke_labels]
+    )
 
     # Assign colours from palette in upload-position order.
     condition_colors = CONDITION_PALETTE[:len(conditions)]
@@ -164,8 +198,10 @@ def build_comparison_matrix(conditions: list) -> dict[str, Any]:
         'ke_labels': ke_labels,
         'ke_titles': ke_titles,
         'condition_labels': condition_labels,
+        'method': 'gsea' if is_gsea else 'ora',  # #76
         'fdr_matrix': fdr_matrix,
         'neg_log10_matrix': neg_log10_matrix,
+        'nes_matrix': nes_matrix,  # #76 — all None for ORA batches
         'condition_colors': condition_colors,
         'condition_gene_counts': condition_gene_counts,
         'condition_sig_gene_counts': condition_sig_gene_counts,
@@ -214,13 +250,15 @@ def comparison_matrix_to_dataframe(
       - ``'fdr'``      raw FDR floats (blank where the KE is absent in a condition)
       - ``'neglog10'`` -log10(FDR) (blank where non-significant or absent,
                        matching the heatmap's null semantics)
+      - ``'nes'``      normalised enrichment score (#76; blank throughout for
+                       an ORA batch, which produces no NES)
 
     Key Event titles are passed through :func:`csv_guard` so a title beginning
     with a formula character cannot be interpreted as a formula on open.
 
     Args:
         matrix_dict: The dict returned by :func:`build_comparison_matrix`.
-        which: ``'fdr'`` or ``'neglog10'``.
+        which: ``'fdr'``, ``'neglog10'`` or ``'nes'``.
 
     Returns:
         A pandas DataFrame with columns ``Key Event ID``, ``Key Event Title``,
@@ -229,10 +267,21 @@ def comparison_matrix_to_dataframe(
     if not matrix_dict or not matrix_dict.get('ke_labels'):
         return pd.DataFrame()
 
-    if which not in ('fdr', 'neglog10'):
-        raise ValueError(f"Unknown matrix selector: {which!r} (expected 'fdr' or 'neglog10')")
+    matrix_keys = {
+        'fdr': 'fdr_matrix',
+        'neglog10': 'neg_log10_matrix',
+        'nes': 'nes_matrix',
+    }
+    if which not in matrix_keys:
+        raise ValueError(
+            f"Unknown matrix selector: {which!r} (expected 'fdr', 'neglog10' or 'nes')"
+        )
 
-    matrix = matrix_dict['fdr_matrix'] if which == 'fdr' else matrix_dict['neg_log10_matrix']
+    # nes_matrix is absent from matrices built before #76; treat it as all-blank.
+    matrix = matrix_dict.get(matrix_keys[which])
+    if matrix is None:
+        matrix = [[None] * len(matrix_dict['condition_labels'])
+                  for _ in matrix_dict['ke_labels']]
     ke_labels = matrix_dict['ke_labels']
     ke_titles = matrix_dict['ke_titles']
     condition_labels = matrix_dict['condition_labels']

--- a/templates/_batch_analysis.html
+++ b/templates/_batch_analysis.html
@@ -165,9 +165,11 @@
         <h3>Statistical Method</h3>
         <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
             Applied equally to all conditions, so the comparison stays like-for-like.
-            Fisher's exact uses the thresholds below. GSEA ignores them, ranks every
-            gene, and reports a signed NES &mdash; which is what makes a coordinated
-            shift visible across a dose or timepoint series.
+            Fisher's exact tests the genes that pass the thresholds below. GSEA ranks
+            every gene instead and reports a signed NES &mdash; which is what makes a
+            coordinated shift visible across a dose or timepoint series &mdash; but the
+            thresholds still define the per-condition significant-gene counts and the
+            driver genes shown on the comparison page.
         </p>
         <div class="settings-subgroup" role="group" aria-labelledby="batch-method-group-label"
              style="margin-bottom: 24px;">
@@ -186,6 +188,14 @@
 
         <!-- Threshold controls -->
         <div id="batch-threshold-inputs">
+        <p id="batch-threshold-gsea-note" style="display:none; font-size:14px; color:#29235C;
+                  background:#f0f4ff; border-left:3px solid #307BBF; padding:8px 12px;
+                  margin-bottom:16px;">
+            GSEA ranks every gene, so these thresholds do not affect the enrichment
+            statistic. They still decide which genes are counted as significant per
+            condition &mdash; the &ldquo;sig genes&rdquo; figures and the driver genes
+            on the comparison page &mdash; so set them to something you would defend.
+        </p>
         <h3>Log2FC Threshold</h3>
         <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
             Minimum absolute log2 fold change for a gene to be considered significant.
@@ -209,8 +219,9 @@
 
         <h3>P-value Threshold</h3>
         <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
-            Genes with a raw p-value below this threshold are flagged as significant for
-            Fisher's exact test. Applied equally to all conditions. Default 0.05.
+            Genes with a raw p-value below this threshold are flagged as significant.
+            Fisher's exact tests on that flag; under GSEA it only drives the reported
+            gene counts. Applied equally to all conditions. Default 0.05.
         </p>
         <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 24px;">
             <label for="pval-threshold" style="font-weight: 600; color: #29235C; font-size: 14px;">
@@ -290,19 +301,20 @@
 <script>
 // Issue #76 — batch statistical-method selector.
 //
-// Mirrors the single-analysis behaviour in _single_analysis_scripts.html:
-// selecting GSEA hides the log2FC / p-value threshold inputs, because a
-// rank-based run ignores them entirely and leaving them visible implies they
-// still bite.
+// The thresholds stay on screen under GSEA. They do not enter the GSEA
+// statistic, but a batch run still applies them to every condition to decide
+// which genes count as significant, and those counts are what the comparison
+// page reports ("N / M sig genes") and what the driver-gene tab is built from.
+// Hiding the inputs would mean reporting numbers derived from thresholds the
+// user was never shown; instead the note below says exactly what they still do.
 //
-// The chosen method is attached to the POST /batch/analyze payload here rather
-// than where the payload is assembled, so the batch wizard's request builder
-// needs no coordinated change; the server defaults a missing field to 'ora'.
+// The method itself is appended to the POST /batch/analyze payload at the call
+// site in _batch_analysis_scripts.html.
 (function () {
     'use strict';
 
     var radios = document.querySelectorAll('input[name="batch_method"]');
-    var thresholds = document.getElementById('batch-threshold-inputs');
+    var note = document.getElementById('batch-threshold-gsea-note');
     if (!radios.length) return;
 
     /** Return the currently selected batch method ('ora' or 'gsea'). */
@@ -311,35 +323,13 @@
         return checked ? checked.value : 'ora';
     }
 
-    /** Show or hide the threshold inputs to match the selected method. */
+    /** Show the GSEA caveat on the threshold inputs when GSEA is selected. */
     function applyMethod() {
-        var isGsea = selectedMethod() === 'gsea';
-        if (!thresholds) return;
-        thresholds.style.display = isGsea ? 'none' : '';
+        if (!note) return;
+        note.style.display = (selectedMethod() === 'gsea') ? '' : 'none';
     }
 
     radios.forEach(function (r) { r.addEventListener('change', applyMethod); });
     applyMethod();
-
-    // Attach the method to the batch-analysis request. Scoped to that one
-    // endpoint and to FormData bodies that do not already carry the field, so
-    // it stays a no-op for every other request on the page.
-    if (!window.__batchMethodHooked) {
-        window.__batchMethodHooked = true;
-        var originalFetch = window.fetch.bind(window);
-        window.fetch = function (input, init) {
-            try {
-                var url = (typeof input === 'string') ? input : (input && input.url) || '';
-                var body = init && init.body;
-                if (url.indexOf('/batch/analyze') !== -1 &&
-                        body instanceof FormData && !body.has('method')) {
-                    body.append('method', selectedMethod());
-                }
-            } catch (e) {
-                // Never let the hook break the request it is decorating.
-            }
-            return originalFetch(input, init);
-        };
-    }
 })();
 </script>

--- a/templates/_batch_analysis.html
+++ b/templates/_batch_analysis.html
@@ -161,7 +161,31 @@
             <ul id="aop-suggestions" class="typeahead-dropdown" hidden></ul>
         </div>
 
+        <!-- Statistical method (#76) — mirrors the single-analysis selector -->
+        <h3>Statistical Method</h3>
+        <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
+            Applied equally to all conditions, so the comparison stays like-for-like.
+            Fisher's exact uses the thresholds below. GSEA ignores them, ranks every
+            gene, and reports a signed NES &mdash; which is what makes a coordinated
+            shift visible across a dose or timepoint series.
+        </p>
+        <div class="settings-subgroup" role="group" aria-labelledby="batch-method-group-label"
+             style="margin-bottom: 24px;">
+            <span class="settings-subgroup__label" id="batch-method-group-label">Statistical method</span>
+            <div class="settings-options">
+                <label>
+                    <input type="radio" name="batch_method" value="ora" checked>
+                    Fisher's exact (over-representation)
+                </label>
+                <label>
+                    <input type="radio" name="batch_method" value="gsea">
+                    GSEA (rank-based)
+                </label>
+            </div>
+        </div>
+
         <!-- Threshold controls -->
+        <div id="batch-threshold-inputs">
         <h3>Log2FC Threshold</h3>
         <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
             Minimum absolute log2 fold change for a gene to be considered significant.
@@ -197,6 +221,7 @@
                    title="Genes with raw p-value below this threshold are flagged as significant for Fisher's exact. Default 0.05."
                    style="width: 80px; display: inline-block; margin: 0; padding: 6px 8px;">
         </div>
+        </div><!-- /#batch-threshold-inputs -->
 
         <h3>Gene Set Resources</h3>
         <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
@@ -261,3 +286,60 @@
         </div>
     </div>
 </div>
+
+<script>
+// Issue #76 — batch statistical-method selector.
+//
+// Mirrors the single-analysis behaviour in _single_analysis_scripts.html:
+// selecting GSEA hides the log2FC / p-value threshold inputs, because a
+// rank-based run ignores them entirely and leaving them visible implies they
+// still bite.
+//
+// The chosen method is attached to the POST /batch/analyze payload here rather
+// than where the payload is assembled, so the batch wizard's request builder
+// needs no coordinated change; the server defaults a missing field to 'ora'.
+(function () {
+    'use strict';
+
+    var radios = document.querySelectorAll('input[name="batch_method"]');
+    var thresholds = document.getElementById('batch-threshold-inputs');
+    if (!radios.length) return;
+
+    /** Return the currently selected batch method ('ora' or 'gsea'). */
+    function selectedMethod() {
+        var checked = document.querySelector('input[name="batch_method"]:checked');
+        return checked ? checked.value : 'ora';
+    }
+
+    /** Show or hide the threshold inputs to match the selected method. */
+    function applyMethod() {
+        var isGsea = selectedMethod() === 'gsea';
+        if (!thresholds) return;
+        thresholds.style.display = isGsea ? 'none' : '';
+    }
+
+    radios.forEach(function (r) { r.addEventListener('change', applyMethod); });
+    applyMethod();
+
+    // Attach the method to the batch-analysis request. Scoped to that one
+    // endpoint and to FormData bodies that do not already carry the field, so
+    // it stays a no-op for every other request on the page.
+    if (!window.__batchMethodHooked) {
+        window.__batchMethodHooked = true;
+        var originalFetch = window.fetch.bind(window);
+        window.fetch = function (input, init) {
+            try {
+                var url = (typeof input === 'string') ? input : (input && input.url) || '';
+                var body = init && init.body;
+                if (url.indexOf('/batch/analyze') !== -1 &&
+                        body instanceof FormData && !body.has('method')) {
+                    body.append('method', selectedMethod());
+                }
+            } catch (e) {
+                // Never let the hook break the request it is decorating.
+            }
+            return originalFetch(input, init);
+        };
+    }
+})();
+</script>

--- a/templates/_batch_analysis_scripts.html
+++ b/templates/_batch_analysis_scripts.html
@@ -589,6 +589,12 @@ document.getElementById('btn-analyze').addEventListener('click', function() {
     payload.append('aop_selection', aopId);
     payload.append('logfc_threshold', document.getElementById('logfc-threshold').value);
     payload.append('pval_threshold', document.getElementById('pval-threshold').value);
+    // Issue #76: the statistical method, applied to every condition in the batch.
+    // Sent from here rather than through a window.fetch wrapper, so changing how
+    // this request is made cannot silently drop the user's selection and leave
+    // the server to default it to 'ora'.
+    const batchMethodEl = document.querySelector('input[name="batch_method"]:checked');
+    payload.append('method', batchMethodEl ? batchMethodEl.value : 'ora');
     document.querySelectorAll('.batch-resource:checked').forEach(function(cb) {
         payload.append('resources', cb.value);
     });

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -29,7 +29,17 @@
 <div class="card card--wide">
   <!-- Page title -->
   <h1>Comparison: {{ batch.batch_name or 'Batch Analysis' }}</h1>
-  <p class="compare-subtitle">{{ batch.aop_label }} &mdash; {{ conditions|length }} condition{{ 's' if conditions|length != 1 else '' }}</p>
+  {# Issue #76: say which statistic the page is showing. batch_method is 'ora'
+     for every batch created before the method selector existed. #}
+  <p class="compare-subtitle">
+    {{ batch.aop_label }} &mdash; {{ conditions|length }} condition{{ 's' if conditions|length != 1 else '' }}
+    &mdash;
+    {% if batch_method == 'gsea' %}
+      GSEA (rank-based) &mdash; cells show NES and FDR
+    {% else %}
+      Fisher's exact (over-representation) &mdash; cells show FDR
+    {% endif %}
+  </p>
 
   <!-- Top control bar: mode toggle, reference condition selector, condition colour legend -->
   <div class="compare-controls">
@@ -99,6 +109,17 @@
 
     <!-- Table panel -->
     <div id="tab-table" class="compare-tab-panel" style="display:none">
+      {# Issue #76: name the statistic in the cells so NES and FDR are not confused. #}
+      <p class="compare-genes-note">
+        {% if batch_method == 'gsea' %}
+          Cells show the normalised enrichment score (NES, signed) with the permutation
+          FDR beneath it. Shading marks FDR &lt; 0.05; an unshaded but consistently
+          signed NES across conditions is still a coordinated shift.
+        {% else %}
+          Cells show the Benjamini&ndash;Hochberg FDR from Fisher's exact test.
+          Shading marks FDR &lt; 0.05.
+        {% endif %}
+      </p>
       <div id="comparison-table-wrap"></div>
     </div>
 
@@ -170,6 +191,22 @@
   // ---------------------------------------------------------------------------
   const comparisonData = {{ comparison_data_json | safe }};
   const batchUuid = {{ batch.uuid | tojson }};
+
+  // Issue #76: GSEA batches are compared on the signed NES rather than on the
+  // ORA FDR columns. Matrices produced before #76 carry no 'method' key, which
+  // reads as ORA — the behaviour those batches were rendered with.
+  const isGsea = comparisonData && comparisonData.method === 'gsea';
+
+  /**
+   * The matrix the heatmap, delta mode and the trend arrows are driven from.
+   * NES for a GSEA batch, -log10(FDR) otherwise.
+   *
+   * @returns {Array<Array<number|null>>}
+   */
+  function valueMatrix() {
+    if (isGsea && Array.isArray(comparisonData.nes_matrix)) return comparisonData.nes_matrix;
+    return comparisonData.neg_log10_matrix;
+  }
 
   // ---------------------------------------------------------------------------
   // Global state
@@ -321,11 +358,13 @@
   /** Return a trend arrow for a KE row across the ordered conditions, or '' if not orderable. */
   function trendArrow(rowIdx) {
     if (!_trendEnabled) return '';
-    var row = comparisonData.neg_log10_matrix[rowIdx] || [];
+    // #76: follow the quantity the page is comparing on — NES under GSEA.
+    var row = valueMatrix()[rowIdx] || [];
     var vals = row.map(function (v) { return v === null || v === undefined ? 0 : v; });
     if (vals.length < 2) return '';
     var delta = vals[vals.length - 1] - vals[0];
-    var eps = 0.3;  // ~2x FDR change on the -log10 scale
+    // ~2x FDR change on the -log10 scale; a comparable NES step under GSEA.
+    var eps = isGsea ? 0.5 : 0.3;
     if (delta > eps) return '↗';
     if (delta < -eps) return '↘';
     return '↔';
@@ -438,15 +477,16 @@
   // ---------------------------------------------------------------------------
 
   /**
-   * Compute the delta -log10(FDR) matrix relative to a reference condition column.
-   * For each KE row: delta[ke][cond] = neg_log10[ke][cond] - neg_log10[ke][refIndex].
+   * Compute the delta matrix relative to a reference condition column.
+   * For each KE row: delta[ke][cond] = value[ke][cond] - value[ke][refIndex],
+   * where value is NES for a GSEA batch and -log10(FDR) otherwise (#76).
    * If either value is null the delta cell is null.
    *
    * @param {number} refIndex - 0-based column index of the reference condition.
    * @returns {Array<Array<number|null>>} Delta matrix (rows=KEs, cols=conditions).
    */
   function computeDeltaMatrix(refIndex) {
-    return comparisonData.neg_log10_matrix.map(function (row) {
+    return valueMatrix().map(function (row) {
       return row.map(function (val, colIdx) {
         var refVal = row[refIndex];
         if (val === null || refVal === null) return null;
@@ -470,7 +510,19 @@
     var zData, xLabels, colorscale, zmin, zmax, zmid, reversescale, hovertmpl;
     var conditionCount = comparisonData.condition_labels.length;
 
-    if (mode === 'absolute') {
+    if (mode === 'absolute' && isGsea) {
+      // GSEA (#76): colour on the signed NES with a diverging scale centred at
+      // zero, so a coordinated upward shift and a downward one are not both
+      // rendered as "significant". Server clamps NES to +/-3; match that here.
+      zData   = comparisonData.nes_matrix;
+      xLabels = comparisonData.condition_labels;
+      colorscale = 'RdBu';
+      reversescale = true; // red = positive NES (coordinated up-regulation)
+      zmin = -3;
+      zmax = 3;
+      zmid = 0;
+      hovertmpl = '<b>%{y}</b><br>%{x}: NES %{z:+.2f}<extra></extra>';
+    } else if (mode === 'absolute') {
       zData   = comparisonData.neg_log10_matrix;
       xLabels = comparisonData.condition_labels;
       colorscale = [
@@ -507,8 +559,16 @@
       zmin = undefined;
       zmax = undefined;
       zmid = 0;
-      hovertmpl = '<b>%{y}</b><br>%{x}: %{z:+.2f} (delta -log10 FDR)<extra></extra>';
+      hovertmpl = isGsea
+        ? '<b>%{y}</b><br>%{x}: %{z:+.2f} (delta NES)<extra></extra>'
+        : '<b>%{y}</b><br>%{x}: %{z:+.2f} (delta -log10 FDR)<extra></extra>';
     }
+
+    // Colourbar label follows the quantity actually plotted (#76).
+    var absoluteLabel = isGsea ? 'NES' : '-log10(FDR)';
+    var colorbarLabel = (mode === 'delta')
+      ? ('delta ' + absoluteLabel)
+      : absoluteLabel;
 
     var trace = {
       type: 'heatmap',
@@ -519,10 +579,16 @@
       connectgaps: false,
       hovertemplate: hovertmpl,
       showscale: true,
-      colorbar: { title: { text: mode === 'delta' ? 'delta -log10(FDR)' : '-log10(FDR)', font: { size: 12 } } }
+      colorbar: { title: { text: colorbarLabel, font: { size: 12 } } }
     };
 
-    if (mode === 'absolute') {
+    if (mode === 'absolute' && isGsea) {
+      // Diverging NES scale: fixed +/-3 domain centred on zero.
+      trace.zmin = zmin;
+      trace.zmax = zmax;
+      trace.zmid = zmid;
+      trace.reversescale = reversescale;
+    } else if (mode === 'absolute') {
       trace.zmin = zmin;
       trace.zmax = zmax;
     } else {
@@ -622,7 +688,8 @@
     });
     // Trend column (Feature D) — only when conditions form a numeric sequence.
     if (_trendEnabled) {
-      headerCells += '<th title="Trend of -log10(FDR) across conditions in order">Trend</th>';
+      headerCells += '<th title="Trend of ' + (isGsea ? 'NES' : '-log10(FDR)')
+        + ' across conditions in order">Trend</th>';
       subHeaderCells += '<th></th>';
     }
 
@@ -635,9 +702,29 @@
 
         var displayVal, sortVal, isSig, cellStyle = '', cellClass = '';
         var fdrVal = comparisonData.fdr_matrix[ke] ? comparisonData.fdr_matrix[ke][col] : null;
-        var neg10Val = comparisonData.neg_log10_matrix[ke] ? comparisonData.neg_log10_matrix[ke][col] : null;
+        var valRow = valueMatrix()[ke] || [];
+        var neg10Val = valRow[col] === undefined ? null : valRow[col];
+        var nesVal = (isGsea && comparisonData.nes_matrix[ke])
+          ? comparisonData.nes_matrix[ke][col] : null;
 
-        if (mode === 'absolute') {
+        if (mode === 'absolute' && isGsea) {
+          // GSEA (#76): NES carries the direction and magnitude, FDR the
+          // confidence — showing only one of them loses half the result.
+          if (nesVal === null || nesVal === undefined) {
+            displayVal = '&mdash;';
+            sortVal = 'Infinity';
+            isSig = false;
+          } else {
+            var fdrText = (fdrVal === null || fdrVal === undefined)
+              ? 'n/a' : fdrVal.toExponential(2);
+            displayVal = (nesVal >= 0 ? '+' : '') + nesVal.toFixed(2)
+              + '<span style="color:#777;font-size:11px;"> q=' + fdrText + '</span>';
+            // Sort on NES descending-friendly magnitude; keep raw NES so the
+            // column sorts by direction as displayed.
+            sortVal = String(nesVal);
+            isSig = (fdrVal !== null && fdrVal !== undefined && fdrVal < 0.05);
+          }
+        } else if (mode === 'absolute') {
           if (fdrVal === null || fdrVal === undefined) {
             displayVal = '&mdash;';
             sortVal = 'Infinity';
@@ -648,8 +735,8 @@
             isSig = fdrVal < 0.05;
           }
         } else {
-          // Delta mode: delta = neg_log10[ke][col] - neg_log10[ke][refIndex]
-          var refNeg10 = comparisonData.neg_log10_matrix[ke] ? comparisonData.neg_log10_matrix[ke][refIndex] : null;
+          // Delta mode: delta of the active value matrix (NES under GSEA).
+          var refNeg10 = valRow[refIndex] === undefined ? null : valRow[refIndex];
           if (neg10Val === null || neg10Val === undefined || refNeg10 === null || refNeg10 === undefined) {
             displayVal = '&mdash;';
             sortVal = 'Infinity';
@@ -1235,16 +1322,18 @@
       xValues = (deltaMatrix[rowIdx] || []).map(function (v) {
         return v === null ? 0 : v;
       });
-      xAxisTitle = 'Delta -log10(FDR)';
+      xAxisTitle = isGsea ? 'Delta NES' : 'Delta -log10(FDR)';
       thresholdX = 0;
       thresholdLabel = 'Reference';
     } else {
-      xValues = (comparisonData.neg_log10_matrix[rowIdx] || []).map(function (v) {
+      // #76: under GSEA the bar is the signed NES, so the reference line is
+      // zero (no coordinated shift) rather than the FDR cutoff.
+      xValues = (valueMatrix()[rowIdx] || []).map(function (v) {
         return v === null ? 0 : v;
       });
-      xAxisTitle = '-log10(FDR)';
-      thresholdX = 1.301;   // -log10(0.05)
-      thresholdLabel = 'FDR=0.05';
+      xAxisTitle = isGsea ? 'NES' : '-log10(FDR)';
+      thresholdX = isGsea ? 0 : 1.301;   // -log10(0.05)
+      thresholdLabel = isGsea ? 'NES=0' : 'FDR=0.05';
     }
 
     var condCount = comparisonData.condition_labels.length;

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -76,6 +76,10 @@
     <div class="compare-actions__group">
       <label for="matrix-export-select">Export matrix:</label>
       <select id="matrix-export-select">
+        {# Issue #76: a GSEA batch shows NES on screen, so it must be exportable. #}
+        {% if batch_method == 'gsea' %}
+        <option value="nes" selected>NES</option>
+        {% endif %}
         <option value="fdr">FDR</option>
         <option value="neglog10">-log10(FDR)</option>
       </select>
@@ -137,6 +141,23 @@
       <!-- Delta mode banner — shows which condition is used as the reference baseline -->
       <div id="delta-mode-banner" class="compare-delta-banner" style="display:none">
         Showing delta vs <strong id="delta-ref-label"></strong>
+        {# Issue #76: the delta slices encode a different quantity per method,
+           so the legend has to say which one. #}
+        {% if batch_method == 'gsea' %}
+        <span>
+          &mdash; slice colour is the change in NES against the reference:
+          <span style="display:inline-block;width:11px;height:11px;background:#d7301f;vertical-align:middle;"></span>
+          higher (more upward),
+          <span style="display:inline-block;width:11px;height:11px;background:#2166ac;vertical-align:middle;"></span>
+          lower (more downward). Deeper shading means a larger shift. This is
+          direction, not significance.
+        </span>
+        {% else %}
+        <span>
+          &mdash; a full slice is a Key Event more significant than in the reference,
+          a muted grey slice one that is less significant.
+        </span>
+        {% endif %}
       </div>
       <div id="cy-compare" style="width:100%;height:600px;border:1px solid #ccc;background:#fafafa;"></div>
     </div>
@@ -282,6 +303,13 @@
 
       var statEl = document.createElement('div');
       statEl.className = 'compare-summary-card__stat';
+      // #76: under GSEA the gene counts come from the log2FC / p-value thresholds
+      // set on the batch form, not from the enrichment statistic. Say so on hover
+      // rather than let them read as GSEA output.
+      statEl.title = isGsea
+        ? 'Significant genes are counted from the batch log2FC and p-value thresholds. '
+          + 'GSEA ranks every gene and does not use them; the significant-KE count is FDR < 0.05.'
+        : 'Significant genes and Key Events at the batch thresholds (KE: FDR < 0.05).';
       var genes = (geneCounts[i] == null) ? '—' : geneCounts[i];
       var sigGenes = (sigGeneCounts[i] == null) ? '—' : sigGeneCounts[i];
       var sigKes = (sigKeCounts[i] == null) ? '—' : sigKeCounts[i];
@@ -791,11 +819,16 @@
     var rows = Array.prototype.slice.call(tbody.querySelectorAll('tr'));
 
     // Toggle sort direction if same column clicked again.
+    // First click puts the most notable Key Events on top, which is not the same
+    // direction for the two methods (#76): FDR cells sort ascending (lowest FDR
+    // first), NES cells descending (largest positive shift first — ascending
+    // would open with the most negative NES and park the missing cells, which
+    // always sort last, right under the highest scores).
     var ascending;
     if (tableSortState.colIdx === colIdx) {
       ascending = !tableSortState.ascending;
     } else {
-      ascending = true; // default: ascending (most significant first = lowest FDR)
+      ascending = !isGsea;
     }
     tableSortState = { colIdx: colIdx, ascending: ascending };
 
@@ -891,28 +924,61 @@
    */
   var singleConditionIndex = 0;
 
+  /** Divergent colours for the GSEA delta view (up-shift / down-shift vs reference). */
+  var DELTA_NES_UP_COLOR = '#d7301f';
+  var DELTA_NES_DOWN_COLOR = '#2166ac';
+
   /**
-   * Compute pie slice size and opacity data for a single KE node.
-   * Implements binary fill: a slice is either fully visible (FDR < 0.05)
-   * or absent (not significant). In delta mode, negative deltas appear as
-   * muted gray slices (opacity 0.25) to preserve that signal rather than
-   * hiding it entirely. The reference condition slice is forced to size 0
-   * in delta mode because the self-referential delta is meaningless.
+   * Colour a KE slice for a given condition, in the condition's own palette
+   * colour everywhere except the GSEA delta view, where the colour has to carry
+   * the sign of the NES shift instead (#76).
    *
-   * @param {number} rowIdx         - KE row index into fdr_matrix and valueMatrix.
+   * @param {number} condIdx - 0-based condition index.
+   * @returns {string} CSS hex colour.
+   */
+  function conditionColor(condIdx) {
+    return comparisonData.condition_colors[condIdx] || '#ccc';
+  }
+
+  /**
+   * Compute pie slice size, opacity and colour data for a single KE node.
+   *
+   * Absolute mode is a binary fill in the condition's colour: a slice is either
+   * fully visible (FDR < 0.05) or absent.
+   *
+   * Delta mode encodes whatever the batch is compared on (#76), and the two
+   * methods mean different things:
+   *
+   *  - ORA: the delta is a change in -log10(FDR), i.e. in significance. A
+   *    positive delta draws a full coloured slice, a negative one a muted grey
+   *    slice (opacity 0.25) so "less significant than the reference" is kept
+   *    rather than hidden.
+   *  - GSEA: the delta is a change in NES, which is *signed direction*, not
+   *    significance. Muting a negative delta would read as "weaker evidence"
+   *    when it means "shifted downward relative to the reference". So the slice
+   *    is drawn on a divergent scale instead: red for a higher NES than the
+   *    reference, blue for a lower one, with opacity carrying the magnitude of
+   *    the shift (saturating at |delta NES| = 2). Nothing is muted for
+   *    significance, matching the fact that NES is never blanked at the FDR
+   *    cutoff.
+   *
+   * The reference condition slice is forced to size 0 in delta mode because the
+   * self-referential delta is meaningless.
+   *
+   * @param {number} rowIdx         - KE row index into fdr_matrix and the value matrix.
    * @param {string} mode           - 'absolute' or 'delta'.
    * @param {number} refIndex       - 0-based reference condition index (delta mode only).
    * @param {number} conditionCount - Total number of conditions.
-   * @param {Array}  valueMatrix    - neg_log10 matrix (absolute) or delta matrix (delta).
-   * @returns {Object} Object with pie_size_N and pie_opacity_N keys for all N conditions.
+   * @param {Array}  matrix         - Absolute value matrix (absolute mode) or delta matrix.
+   * @returns {Object} Object with pie_size_N, pie_opacity_N and pie_color_N keys.
    */
-  function computeSliceData(rowIdx, mode, refIndex, conditionCount, valueMatrix) {
+  function computeSliceData(rowIdx, mode, refIndex, conditionCount, matrix) {
     var sliceMax = Math.round(100 / conditionCount);
     var result = {};
     for (var i = 0; i < conditionCount; i++) {
       var fdrVal = (comparisonData.fdr_matrix[rowIdx] || [])[i];
       var isSig = fdrVal != null && fdrVal < 0.05;
-      var sliceSize, opacity;
+      var sliceSize, opacity, color = conditionColor(i);
 
       if (mode === 'delta') {
         // Reference condition: force to 0 — self-referential delta is meaningless.
@@ -920,9 +986,18 @@
           sliceSize = 0;
           opacity = 1;
         } else {
-          var val = (valueMatrix[rowIdx] || [])[i];
-          if (!isSig || val == null) {
-            // Not significant or missing: no slice.
+          var val = (matrix[rowIdx] || [])[i];
+          if (val == null) {
+            // No delta computable for this condition: no slice.
+            sliceSize = 0;
+            opacity = 1;
+          } else if (isGsea) {
+            // Signed NES divergence — colour carries direction, opacity magnitude.
+            sliceSize = sliceMax;
+            color = val >= 0 ? DELTA_NES_UP_COLOR : DELTA_NES_DOWN_COLOR;
+            opacity = 0.3 + 0.7 * Math.min(1, Math.abs(val) / 2);
+          } else if (!isSig) {
+            // ORA: a KE that is not significant here has no significance delta worth drawing.
             sliceSize = 0;
             opacity = 1;
           } else if (val < 0) {
@@ -943,6 +1018,7 @@
 
       result['pie_size_' + (i + 1)] = sliceSize;
       result['pie_opacity_' + (i + 1)] = opacity;
+      result['pie_color_' + (i + 1)] = color;
     }
     return result;
   }
@@ -963,13 +1039,10 @@
     var nodes = networkData.nodes || [];
     var edges = networkData.edges || [];
 
-    // Determine values to use for sizing: absolute neg-log10 or delta.
-    var valueMatrix;
-    if (mode === 'delta') {
-      valueMatrix = computeDeltaMatrix(refIndex);
-    } else {
-      valueMatrix = comparisonData.neg_log10_matrix;
-    }
+    // Values to drive the slices with: the delta matrix, or the matrix the page
+    // is comparing on (NES under GSEA). Named activeMatrix, not valueMatrix, so
+    // it does not shadow the valueMatrix() helper defined at the top of this file.
+    var activeMatrix = (mode === 'delta') ? computeDeltaMatrix(refIndex) : valueMatrix();
 
     // Build map of KE ID → row index for fast lookup.
     var keIndexMap = {};
@@ -993,12 +1066,13 @@
 
       if (rowIdx !== undefined) {
         // Use shared helper for binary pie logic and opacity data.
-        pieData = computeSliceData(rowIdx, mode, refIndex, conditionCount, valueMatrix);
+        pieData = computeSliceData(rowIdx, mode, refIndex, conditionCount, activeMatrix);
       } else {
         // KE present in the AOP skeleton but absent from enrichment results — all slices off.
         for (var j = 0; j < conditionCount; j++) {
           pieData['pie_size_' + (j + 1)] = 0;
           pieData['pie_opacity_' + (j + 1)] = 1;
+          pieData['pie_color_' + (j + 1)] = conditionColor(j);
         }
       }
 
@@ -1068,9 +1142,12 @@
     // pie-N-background-opacity (up to 16 slices supported).
     // Opacity is driven by data(pie_opacity_N) so that muted gray deltas (opacity 0.25)
     // can be rendered without changing the slice colour.
+    // Colour is driven by data(pie_color_N) rather than pinned to the palette here,
+    // because the GSEA delta view colours the slice by the sign of the NES shift (#76).
+    // computeSliceData falls back to the condition's palette colour everywhere else.
     for (var i = 1; i <= conditionCount; i++) {
       var pieStyle = {};
-      pieStyle['pie-' + i + '-background-color'] = comparisonData.condition_colors[i - 1] || '#ccc';
+      pieStyle['pie-' + i + '-background-color'] = 'data(pie_color_' + i + ')';
       pieStyle['pie-' + i + '-background-size'] = 'data(pie_size_' + i + ')';
       pieStyle['pie-' + i + '-background-opacity'] = 'data(pie_opacity_' + i + ')';
       styles.push({ selector: 'node', style: pieStyle });
@@ -1152,12 +1229,9 @@
     if (!cyInstance || !hasData()) return;
 
     var conditionCount = comparisonData.condition_labels.length;
-    var valueMatrix;
-    if (mode === 'delta') {
-      valueMatrix = computeDeltaMatrix(refIndex);
-    } else {
-      valueMatrix = comparisonData.neg_log10_matrix;
-    }
+    // As in buildComparisonElements: the delta matrix, or the matrix the page
+    // compares on. Named activeMatrix so it does not shadow valueMatrix().
+    var activeMatrix = (mode === 'delta') ? computeDeltaMatrix(refIndex) : valueMatrix();
 
     var keIndexMap = {};
     comparisonData.ke_labels.forEach(function (keId, idx) {
@@ -1170,7 +1244,7 @@
         var rowIdx = keIndexMap[keId];
         if (rowIdx === undefined) return;
         // Use shared helper for binary pie logic and opacity data.
-        var pieData = computeSliceData(rowIdx, mode, refIndex, conditionCount, valueMatrix);
+        var pieData = computeSliceData(rowIdx, mode, refIndex, conditionCount, activeMatrix);
         Object.keys(pieData).forEach(function (key) {
           node.data(key, pieData[key]);
         });

--- a/tests/test_batch_gsea.py
+++ b/tests/test_batch_gsea.py
@@ -149,9 +149,11 @@ class TestBatchMethodColumn:
                 row = c.execute(
                     text("SELECT method FROM batches WHERE uuid = 'legacy-uuid'")
                 ).fetchone()
-            # The pre-existing row survives; its method is the column default.
+            # The pre-existing row survives, and SQLite backfills it with the
+            # column default rather than leaving it NULL — pin that, because
+            # 'either NULL or ora' would pass whatever the migration did.
             assert row is not None
-            assert (row[0] or 'ora') == 'ora'
+            assert row[0] == 'ora'
 
             # Second call is a no-op rather than an error.
             _ensure_method_column(manager.engine)
@@ -410,7 +412,12 @@ class TestBatchAnalyzeMethodWhitelist:
         assert b'Invalid method' in resp.data
 
     def test_valid_methods_pass_the_whitelist(self, flask_client):
-        """'ora'/'gsea' get past the method check (and fail later, on files)."""
+        """'ora'/'gsea'/blank clear the method check and stop at the next one.
+
+        Asserting the *next* error rather than the absence of a string: 'Invalid
+        method' is missing from any 400 or 500, so its absence alone would pass
+        even if the request had blown up for an unrelated reason.
+        """
         for method in ('ora', 'gsea', ''):
             resp = flask_client.post('/batch/analyze', data={
                 'batch_uuid': 'abc',
@@ -418,4 +425,290 @@ class TestBatchAnalyzeMethodWhitelist:
                 'id_col': 'gene', 'fc_col': 'logFC', 'pval_col': 'pval',
                 'method': method,
             })
-            assert b'Invalid method' not in resp.data
+            # No files were specified, which is the check immediately after the
+            # method whitelist — reaching it proves the method was accepted.
+            assert resp.status_code == 400
+            assert resp.get_json() == {'error': 'No files specified'}
+
+
+class TestBatchAnalyzeMethodPersistence:
+    """The selected method survives the whole submit path onto the BatchRecord.
+
+    The whitelist test above only proves the route does not reject a method; it
+    says nothing about the field arriving at all. The batch form used to attach
+    it from a window.fetch wrapper, so any change to how the request was made
+    would have dropped it silently and downgraded the run to ORA.
+    """
+
+    @pytest.fixture
+    def submit_client(self, flask_client, temp_database, upload_root, monkeypatch):
+        """Flask client wired to a temp DB with the background run stubbed out."""
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        monkeypatch.setattr(app_module, 'run_batch', lambda *a, **k: None)
+        monkeypatch.setattr(
+            app_module, 'load_cached_reference_sets',
+            lambda *a, **k: (REFERENCE_SETS, 'mock', []),
+        )
+        return flask_client
+
+    def _submit(self, client, upload_root, method):
+        import uuid as _uuid
+        batch_uuid = str(_uuid.uuid4())
+        batch_dir = os.path.join(upload_root, batch_uuid)
+        os.makedirs(batch_dir, exist_ok=True)
+        _write_dataset(os.path.join(batch_dir, 'cond0.tsv'))
+        _write_dataset(os.path.join(batch_dir, 'cond1.tsv'))
+        data = {
+            'batch_uuid': batch_uuid,
+            'aop_selection': 'AOP:1',
+            'id_col': 'gene', 'fc_col': 'logFC', 'pval_col': 'pval',
+            'logfc_threshold': '1.0', 'pval_threshold': '0.05',
+            'filenames[]': ['cond0.tsv', 'cond1.tsv'],
+            'condition_labels[]': ['Low', 'High'],
+            'batch_name': 'Submit Test',
+        }
+        if method is not None:
+            data['method'] = method
+        resp = client.post('/batch/analyze', data=data)
+        return batch_uuid, resp
+
+    def _stored_method(self, db_manager, batch_uuid):
+        session = db_manager.get_session()
+        try:
+            batch = session.query(BatchRecord).filter_by(uuid=batch_uuid).first()
+            assert batch is not None
+            return batch.method
+        finally:
+            session.close()
+
+    def test_gsea_selection_reaches_the_batch_record(
+        self, submit_client, temp_database, upload_root
+    ):
+        batch_uuid, resp = self._submit(submit_client, upload_root, 'gsea')
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert self._stored_method(temp_database, batch_uuid) == 'gsea'
+
+    def test_ora_selection_reaches_the_batch_record(
+        self, submit_client, temp_database, upload_root
+    ):
+        batch_uuid, resp = self._submit(submit_client, upload_root, 'ora')
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert self._stored_method(temp_database, batch_uuid) == 'ora'
+
+    def test_omitted_method_stores_ora(self, submit_client, temp_database, upload_root):
+        """A client that sends no method at all still produces a runnable ORA batch."""
+        batch_uuid, resp = self._submit(submit_client, upload_root, None)
+
+        assert resp.status_code == 200, resp.get_data(as_text=True)
+        assert self._stored_method(temp_database, batch_uuid) == 'ora'
+
+    def test_batch_form_sends_the_method_from_the_request_builder(self, flask_client):
+        """The field is appended where the payload is built, not via a fetch hook.
+
+        A window.fetch monkeypatch is invisible to any other way of issuing the
+        request (XHR, htmx, a Request object, URLSearchParams), so the method
+        has to be on the payload itself.
+        """
+        body = flask_client.get('/').get_data(as_text=True)
+
+        assert "payload.append('method'" in body
+        assert 'window.fetch =' not in body
+
+
+class TestBatchReportMethod:
+    """The batch report renders the statistic the batch was actually run with."""
+
+    def test_gsea_report_html_uses_gsea_columns(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'gsea', '44444444-4444-4444-4444-444444444444')
+
+        resp = flask_client.get(f'/batch/{uuid}/report?format=html')
+
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        # GSEA columns and values, not the Fisher ones.
+        assert 'GSEA (rank-based)' in body
+        assert 'NES' in body
+        assert 'Lead' in body            # leading-edge gene column
+        assert 'TP53' in body            # the leading-edge genes themselves
+        assert '2.10' in body            # the NES value
+        assert 'Odds Ratio' not in body
+        assert '# Overlap' not in body
+
+    def test_ora_report_html_keeps_the_fisher_columns(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'ora', '55555555-5555-5555-5555-555555555555')
+
+        resp = flask_client.get(f'/batch/{uuid}/report?format=html')
+
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert "Fisher's exact (over-representation)" in body
+        assert 'Odds Ratio' in body
+        assert 'Lead Edge Genes' not in body
+
+    def test_gsea_pdf_report_still_renders(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'gsea', '66666666-6666-6666-6666-666666666666')
+
+        resp = flask_client.get(f'/batch/{uuid}/report?format=pdf')
+
+        assert resp.status_code == 200
+        assert resp.data[:4] == b'%PDF'
+
+    def test_condition_report_data_carries_the_batch_method(self):
+        """The per-condition section is built for the batch's method, not 'ora'."""
+        from services.batch_report_service import _condition_report_data
+
+        batch = BatchRecord(method='gsea', aop_id='AOP:1', logfc_threshold=1.0,
+                            pval_cutoff=0.05)
+        cond = SimpleNamespace(condition_label='C0', filename='c0.tsv',
+                               gene_count=20, significant_genes=6)
+
+        rd = _condition_report_data(batch, cond, [{'KE': 'KE:1', 'NES': 2.0}])
+
+        assert rd.method == 'gsea'
+
+
+class TestCompareExportNesRoute:
+    """GET /batch/<uuid>/compare/export?matrix=nes (#76)."""
+
+    def test_nes_export_is_served_for_a_gsea_batch(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'gsea', '77777777-7777-7777-7777-777777777777')
+
+        resp = flask_client.get(f'/batch/{uuid}/compare/export?fmt=csv&matrix=nes')
+
+        assert resp.status_code == 200
+        text = resp.get_data(as_text=True)
+        assert 'Key Event ID' in text
+        assert '2.1' in text  # the stored NES, not the FDR
+
+    def test_nes_option_offered_on_a_gsea_compare_page(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'gsea', '88888888-8888-8888-8888-888888888888')
+
+        body = flask_client.get(f'/batch/{uuid}/compare').data.decode()
+
+        assert 'value="nes"' in body
+
+    def test_nes_option_absent_on_an_ora_compare_page(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'ora', '99999999-9999-9999-9999-999999999999')
+
+        body = flask_client.get(f'/batch/{uuid}/compare').data.decode()
+
+        assert 'value="nes"' not in body
+
+    def test_unknown_matrix_still_rejected(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'gsea', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+        resp = flask_client.get(f'/batch/{uuid}/compare/export?fmt=csv&matrix=bogus')
+
+        assert resp.status_code == 400
+
+
+class TestCompareDeltaNetworkSemantics:
+    """The delta network must not read a NES shift as a drop in significance.
+
+    These assert on the rendered compare.html script, which is where the pie
+    slices are computed. The delta branch used to mute any negative delta to
+    opacity 0.25 and label it "less significant than reference" — under GSEA a
+    negative delta is a downward coordinated shift, not weaker evidence.
+    """
+
+    def _body(self, flask_client, temp_database, monkeypatch, method, uuid):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        _seed_complete_batch(temp_database, method, uuid)
+        return flask_client.get(f'/batch/{uuid}/compare').data.decode()
+
+    def test_gsea_delta_uses_a_signed_divergent_scale(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        body = self._body(flask_client, temp_database, monkeypatch, 'gsea',
+                          'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+
+        # Divergent colours exist and are chosen by the sign of the delta.
+        assert 'DELTA_NES_UP_COLOR' in body
+        assert 'DELTA_NES_DOWN_COLOR' in body
+        assert 'val >= 0 ? DELTA_NES_UP_COLOR : DELTA_NES_DOWN_COLOR' in body
+        # Slice colour is per-node data, not pinned to the condition palette,
+        # so the divergent colours can actually reach the canvas.
+        assert "'data(pie_color_' + i + ')'" in body
+        # The legend states direction, not significance.
+        assert 'This is' in body and 'direction, not significance' in body
+
+    def test_gsea_delta_does_not_mute_by_significance(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        body = self._body(flask_client, temp_database, monkeypatch, 'gsea',
+                          'cccccccc-cccc-cccc-cccc-cccccccccccc')
+
+        # The muting branch is still there for ORA, but it is now reached only
+        # when the batch is not GSEA.
+        assert '} else if (isGsea) {' in body
+        assert '} else if (!isSig) {' in body
+
+    def test_ora_delta_keeps_the_significance_legend(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        body = self._body(flask_client, temp_database, monkeypatch, 'ora',
+                          'dddddddd-dddd-dddd-dddd-dddddddddddd')
+
+        assert 'a muted grey slice one that is less significant' in body
+        assert 'direction, not significance' not in body
+
+    def test_gsea_table_sorts_the_useful_way_round(
+        self, flask_client, temp_database, monkeypatch
+    ):
+        """First click sorts descending under GSEA (largest NES first)."""
+        body = self._body(flask_client, temp_database, monkeypatch, 'gsea',
+                          'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee')
+
+        assert 'ascending = !isGsea;' in body
+        assert 'ascending = true; // default' not in body
+
+
+class TestBatchFormThresholdsUnderGsea:
+    """Thresholds that still shape reported numbers stay on screen (#76)."""
+
+    def test_threshold_inputs_are_not_hidden_for_gsea(self, flask_client):
+        body = flask_client.get('/').get_data(as_text=True)
+
+        # The old behaviour hid the whole threshold block when GSEA was picked,
+        # while the run kept using it for the significant-gene counts.
+        assert "thresholds.style.display = isGsea ? 'none' : ''" not in body
+        assert 'batch-threshold-gsea-note' in body

--- a/tests/test_batch_gsea.py
+++ b/tests/test_batch_gsea.py
@@ -1,0 +1,421 @@
+"""Tests for GSEA support in batch mode (issue #76).
+
+Covers:
+- the ``batches.method`` column, its idempotent migration and the NULL -> 'ora'
+  coercion that keeps pre-#76 batches working
+- method dispatch in ``_run_condition`` / ``run_batch``
+- NES/FDR shaping in ``build_comparison_matrix`` and the matrix export helper
+- the method whitelist on ``POST /batch/analyze``
+- backward compatibility: a batch row written without a method still runs,
+  compares and exports as ORA
+"""
+import json
+import os
+import sqlite3
+import tempfile
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from sqlalchemy import text
+
+from database import BatchRecord, ConditionRecord, DatabaseManager, _ensure_method_column
+from services.batch_service import run_batch
+from services.comparison_service import (
+    build_comparison_matrix,
+    comparison_matrix_to_dataframe,
+)
+
+
+REFERENCE_SETS = {
+    'KE:115': {f'G{i}' for i in range(1, 11)},    # G1..G10
+    'KE:116': {f'G{i}' for i in range(11, 21)},   # G11..G20
+}
+
+
+def _write_dataset(path):
+    """Write a small TSV: G1..G10 strongly up, G11..G20 flat."""
+    rows = []
+    for i in range(1, 21):
+        sig = i <= 10
+        rows.append({
+            'gene': f'G{i}',
+            'logFC': 2.0 if sig else 0.1,
+            'pval': 0.001 if sig else 0.5,
+        })
+    pd.DataFrame(rows).to_csv(path, sep='\t', index=False)
+
+
+def _seed_batch(db_manager, upload_root, method=None, n_conditions=2):
+    """Create a batch (+ conditions and input files) with the given method.
+
+    ``method=None`` writes the column as NULL, i.e. exactly what a batch
+    created before issue #76 looks like on disk.
+    """
+    import uuid as _uuid
+    batch_uuid = str(_uuid.uuid4())
+    batch_dir = os.path.join(upload_root, batch_uuid)
+    os.makedirs(batch_dir, exist_ok=True)
+
+    harmonised = sorted({f'G{i}' for i in range(1, 21)})
+    session = db_manager.get_session()
+    try:
+        batch = BatchRecord(
+            uuid=batch_uuid, status='pending', aop_id='AOP:1', aop_label='Test AOP',
+            method=method,
+            logfc_threshold=1.0, pval_cutoff=0.05, selected_resources='WikiPathways',
+            id_column='gene', fc_column='logFC', pval_column='pval',
+            harmonised_background=json.dumps(harmonised),
+            harmonised_gene_count=len(harmonised),
+            batch_name='Test Batch',
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=14),
+        )
+        session.add(batch)
+        session.flush()
+        for pos in range(n_conditions):
+            fname = f'cond{pos}.tsv'
+            _write_dataset(os.path.join(batch_dir, fname))
+            session.add(ConditionRecord(
+                batch_id=batch.id, position=pos, filename=fname,
+                condition_label=f'Cond {pos}', status='pending',
+            ))
+        session.commit()
+        batch_id = batch.id
+    finally:
+        session.close()
+    return batch_id, batch_uuid
+
+
+@pytest.fixture
+def aop_stub(monkeypatch):
+    """Stub load_aop_data so run_batch needs no real AOP topology."""
+    def _fake_load_aop_data(aop_id):
+        ke_list = {'KE:115', 'KE:116'}
+        edges = pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID', 'AOP_ID'])
+        ke_type_map = {'KE:115': 'MIE', 'KE:116': 'AO'}
+        ke_title_map = {'KE:115': 'Event 115', 'KE:116': 'Event 116'}
+        return ke_list, edges, ke_type_map, ke_title_map
+    monkeypatch.setattr('services.data_service.load_aop_data', _fake_load_aop_data)
+
+
+@pytest.fixture
+def upload_root(tmp_path, monkeypatch):
+    """Point Config.UPLOAD_FOLDER at a temp dir for the duration of a test."""
+    root = tmp_path / 'uploads'
+    root.mkdir()
+    monkeypatch.setattr('config.Config.UPLOAD_FOLDER', str(root))
+    return str(root)
+
+
+class TestBatchMethodColumn:
+    """Schema, migration and NULL coercion for batches.method."""
+
+    def test_column_exists_on_fresh_database(self, temp_database):
+        with temp_database.engine.connect() as conn:
+            cols = {row[1] for row in conn.execute(text('PRAGMA table_info(batches)'))}
+        assert 'method' in cols
+
+    def test_effective_method_coerces_null_to_ora(self):
+        assert BatchRecord(method=None).effective_method() == 'ora'
+        assert BatchRecord(method='').effective_method() == 'ora'
+        assert BatchRecord(method='gsea').effective_method() == 'gsea'
+        assert BatchRecord(method='ora').effective_method() == 'ora'
+
+    def test_migration_adds_column_to_legacy_database(self):
+        """A batches table without the column gains it on startup, no data loss."""
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = f.name
+        try:
+            # Hand-build a pre-#76 batches table and put a row in it.
+            conn = sqlite3.connect(db_path)
+            conn.execute(
+                'CREATE TABLE batches ('
+                'id INTEGER PRIMARY KEY, uuid TEXT, status TEXT, expires_at TIMESTAMP)'
+            )
+            conn.execute(
+                "INSERT INTO batches (uuid, status, expires_at) "
+                "VALUES ('legacy-uuid', 'complete', '2999-01-01 00:00:00')"
+            )
+            conn.commit()
+            conn.close()
+
+            manager = DatabaseManager(db_url=f'sqlite:///{db_path}')
+            assert manager.initialize() is True
+
+            with manager.engine.connect() as c:
+                cols = {row[1] for row in c.execute(text('PRAGMA table_info(batches)'))}
+                assert 'method' in cols
+                row = c.execute(
+                    text("SELECT method FROM batches WHERE uuid = 'legacy-uuid'")
+                ).fetchone()
+            # The pre-existing row survives; its method is the column default.
+            assert row is not None
+            assert (row[0] or 'ora') == 'ora'
+
+            # Second call is a no-op rather than an error.
+            _ensure_method_column(manager.engine)
+        finally:
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
+
+
+class TestBatchExecutionDispatch:
+    """run_batch honours the batch-level method."""
+
+    def test_gsea_batch_produces_nes_columns(self, temp_database, aop_stub, upload_root):
+        batch_id, _ = _seed_batch(temp_database, upload_root, method='gsea')
+
+        run_batch(batch_id, temp_database.db_url, REFERENCE_SETS)
+
+        session = temp_database.get_session()
+        try:
+            batch = session.query(BatchRecord).filter_by(id=batch_id).first()
+            assert batch.status == 'complete'
+            conditions = session.query(ConditionRecord).filter_by(batch_id=batch_id).all()
+            assert conditions
+            for cond in conditions:
+                assert cond.status == 'complete'
+                enrichment = json.loads(cond.enrichment_json)
+                assert enrichment
+                # GSEA rows carry NES and lead genes; ORA's odds_ratio is absent.
+                for row in enrichment:
+                    assert 'NES' in row
+                    assert 'lead_genes' in row
+                    assert 'odds_ratio' not in row
+        finally:
+            session.close()
+
+    def test_legacy_batch_without_method_runs_as_ora(self, temp_database, aop_stub, upload_root):
+        """Backward compatibility: NULL method must still produce an ORA table."""
+        batch_id, _ = _seed_batch(temp_database, upload_root, method=None)
+
+        run_batch(batch_id, temp_database.db_url, REFERENCE_SETS)
+
+        session = temp_database.get_session()
+        try:
+            batch = session.query(BatchRecord).filter_by(id=batch_id).first()
+            assert batch.status == 'complete'
+            assert batch.method is None  # not silently backfilled
+            conditions = session.query(ConditionRecord).filter_by(batch_id=batch_id).all()
+            for cond in conditions:
+                enrichment = json.loads(cond.enrichment_json)
+                assert enrichment
+                for row in enrichment:
+                    assert 'odds_ratio' in row
+                    assert 'NES' not in row
+        finally:
+            session.close()
+
+    def test_explicit_ora_batch_matches_legacy_output(self, temp_database, aop_stub, upload_root):
+        batch_id, _ = _seed_batch(temp_database, upload_root, method='ora')
+
+        run_batch(batch_id, temp_database.db_url, REFERENCE_SETS)
+
+        session = temp_database.get_session()
+        try:
+            cond = session.query(ConditionRecord).filter_by(batch_id=batch_id).first()
+            enrichment = json.loads(cond.enrichment_json)
+            assert any(r['KE'] == 'KE:115' for r in enrichment)
+            assert all('odds_ratio' in r for r in enrichment)
+        finally:
+            session.close()
+
+
+def _cond(label, entries, dose='', timepoint=''):
+    """Build a stand-in ConditionRecord for comparison-matrix tests."""
+    return SimpleNamespace(
+        condition_label=label,
+        enrichment_json=json.dumps(entries),
+        ke_gene_json=None,
+        gene_count=100,
+        significant_genes=10,
+        dose=dose,
+        timepoint=timepoint,
+    )
+
+
+class TestComparisonMatrixGsea:
+    """build_comparison_matrix NES handling."""
+
+    def _gsea_conditions(self):
+        c1 = _cond('Low', [
+            {'KE': 'KE:1', 'Title': 'DNA damage', 'FDR': 0.01, 'NES': 1.8},
+            {'KE': 'KE:2', 'Title': 'Mito dysfunction', 'FDR': 0.40, 'NES': 0.9},
+        ])
+        c2 = _cond('High', [
+            {'KE': 'KE:1', 'Title': 'DNA damage', 'FDR': 0.001, 'NES': 2.4},
+            {'KE': 'KE:2', 'Title': 'Mito dysfunction', 'FDR': 0.20, 'NES': 1.2},
+        ])
+        return [c1, c2]
+
+    def test_gsea_matrix_exposes_nes(self):
+        m = build_comparison_matrix(self._gsea_conditions(), method='gsea')
+
+        assert m['method'] == 'gsea'
+        assert len(m['nes_matrix']) == len(m['ke_labels'])
+        row = m['nes_matrix'][m['ke_labels'].index('KE:1')]
+        assert row == [1.8, 2.4]
+
+    def test_nes_kept_for_non_significant_kes(self):
+        """A sub-threshold but consistently signed NES is the point of GSEA."""
+        m = build_comparison_matrix(self._gsea_conditions(), method='gsea')
+        idx = m['ke_labels'].index('KE:2')
+        # -log10(FDR) is blanked above the cutoff; NES is not.
+        assert m['neg_log10_matrix'][idx] == [None, None]
+        assert m['nes_matrix'][idx] == [0.9, 1.2]
+
+    def test_ora_matrix_reports_ora_and_blank_nes(self):
+        c1 = _cond('A', [{'KE': 'KE:1', 'Title': 'DNA damage', 'FDR': 0.01}])
+        c2 = _cond('B', [{'KE': 'KE:1', 'Title': 'DNA damage', 'FDR': 0.30}])
+
+        m = build_comparison_matrix([c1, c2])
+
+        assert m['method'] == 'ora'
+        assert m['nes_matrix'] == [[None, None]]
+        # Existing ORA behaviour is untouched.
+        assert m['fdr_matrix'] == [[0.01, 0.30]]
+
+    def test_nes_matrix_row_order_matches_ke_labels(self):
+        m = build_comparison_matrix(self._gsea_conditions(), method='gsea')
+        for idx, ke in enumerate(m['ke_labels']):
+            expected = {'KE:1': [1.8, 2.4], 'KE:2': [0.9, 1.2]}[ke]
+            assert m['nes_matrix'][idx] == expected
+
+
+class TestComparisonExportNes:
+    """comparison_matrix_to_dataframe 'nes' selector."""
+
+    def test_nes_export_columns(self):
+        conds = TestComparisonMatrixGsea()._gsea_conditions()
+        m = build_comparison_matrix(conds, method='gsea')
+
+        df = comparison_matrix_to_dataframe(m, which='nes')
+
+        assert list(df.columns) == ['Key Event ID', 'Key Event Title', 'Low', 'High']
+        assert df.loc[df['Key Event ID'] == 'KE:1', 'High'].iloc[0] == 2.4
+
+    def test_nes_export_blank_for_ora_matrix(self):
+        c1 = _cond('A', [{'KE': 'KE:1', 'Title': 'T', 'FDR': 0.01}])
+        m = build_comparison_matrix([c1])
+
+        df = comparison_matrix_to_dataframe(m, which='nes')
+
+        assert df['A'].isna().all()
+
+    def test_unknown_selector_still_rejected(self):
+        c1 = _cond('A', [{'KE': 'KE:1', 'Title': 'T', 'FDR': 0.01}])
+        m = build_comparison_matrix([c1])
+        with pytest.raises(ValueError):
+            comparison_matrix_to_dataframe(m, which='bogus')
+
+    def test_matrix_without_nes_key_exports_blank(self):
+        """A matrix dict built before #76 has no nes_matrix key at all."""
+        c1 = _cond('A', [{'KE': 'KE:1', 'Title': 'T', 'FDR': 0.01}])
+        m = build_comparison_matrix([c1])
+        m.pop('nes_matrix')
+
+        df = comparison_matrix_to_dataframe(m, which='nes')
+
+        assert df['A'].isna().all()
+
+
+def _seed_complete_batch(db_manager, method, uuid):
+    """Seed a completed batch whose conditions carry method-appropriate rows."""
+    session = db_manager.get_session()
+    try:
+        batch = BatchRecord(
+            uuid=uuid, status='complete', aop_id='AOP:1', aop_label='Test AOP',
+            method=method, logfc_threshold=1.0, pval_cutoff=0.05,
+            selected_resources='WikiPathways', id_column='gene',
+            fc_column='logFC', pval_column='pval',
+            harmonised_background=json.dumps(['G1', 'G2']), harmonised_gene_count=2,
+            batch_name='Compare Test Batch',
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=14),
+        )
+        session.add(batch)
+        session.flush()
+        if method == 'gsea':
+            enrichment = [{'KE': 'KE:1', 'Title': 'Alpha', 'p_value': 0.0005,
+                           'FDR': 0.001, 'NES': 2.1, 'lead_genes': ['TP53'],
+                           'total_KE_genes_in_dataset': 20}]
+        else:
+            enrichment = [{'KE': 'KE:1', 'Title': 'Alpha', 'p_value': 0.0005,
+                           'FDR': 0.001, 'num_overlap': 6, 'odds_ratio': 3.0,
+                           'total_KE_genes_in_dataset': 20, 'Direction': '6up'}]
+        network = {
+            'nodes': [{'data': {'id': 'KE:1', 'label': 'Alpha', 'ke_type': 'MIE'}}],
+            'edges': [],
+        }
+        for pos in range(2):
+            session.add(ConditionRecord(
+                batch_id=batch.id, position=pos, filename=f'c{pos}.tsv',
+                condition_label=f'C{pos}', dose=f'{pos + 1}uM', timepoint='4hr',
+                status='complete', gene_count=20, significant_genes=6,
+                enrichment_json=json.dumps(enrichment),
+                network_json=json.dumps(network),
+                ke_gene_json=json.dumps({}),
+            ))
+        session.commit()
+    finally:
+        session.close()
+    return uuid
+
+
+class TestCompareViewMethod:
+    """The compare page reflects the batch's method."""
+
+    def test_gsea_batch_compare_page_shows_nes(self, flask_client, temp_database, monkeypatch):
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, 'gsea', '22222222-2222-2222-2222-222222222222')
+
+        resp = flask_client.get(f'/batch/{uuid}/compare')
+
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert 'GSEA (rank-based)' in body
+        assert '"method": "gsea"' in body
+        assert '"nes_matrix": [[2.1, 2.1]]' in body
+
+    def test_legacy_batch_compare_page_stays_ora(self, flask_client, temp_database, monkeypatch):
+        """A batch with a NULL method still renders the ORA comparison."""
+        import app as app_module
+        monkeypatch.setattr(app_module, 'db_manager', temp_database)
+        uuid = _seed_complete_batch(
+            temp_database, None, '33333333-3333-3333-3333-333333333333')
+
+        resp = flask_client.get(f'/batch/{uuid}/compare')
+
+        assert resp.status_code == 200
+        body = resp.data.decode()
+        assert "Fisher's exact (over-representation)" in body
+        assert '"method": "ora"' in body
+
+
+class TestBatchAnalyzeMethodWhitelist:
+    """POST /batch/analyze validates the method field."""
+
+    def test_invalid_method_rejected(self, flask_client):
+        resp = flask_client.post('/batch/analyze', data={
+            'batch_uuid': 'abc',
+            'aop_selection': 'AOP:1',
+            'id_col': 'gene', 'fc_col': 'logFC', 'pval_col': 'pval',
+            'method': 'bootstrap',
+        })
+        assert resp.status_code == 400
+        assert b'Invalid method' in resp.data
+
+    def test_valid_methods_pass_the_whitelist(self, flask_client):
+        """'ora'/'gsea' get past the method check (and fail later, on files)."""
+        for method in ('ora', 'gsea', ''):
+            resp = flask_client.post('/batch/analyze', data={
+                'batch_uuid': 'abc',
+                'aop_selection': 'AOP:1',
+                'id_col': 'gene', 'fc_col': 'logFC', 'pval_col': 'pval',
+                'method': method,
+            })
+            assert b'Invalid method' not in resp.data

--- a/tests/test_id_column_detection.py
+++ b/tests/test_id_column_detection.py
@@ -149,6 +149,34 @@ class TestBackgroundOverlap:
         assert assess_background_overlap({'TP53'}, {})['is_suspect'] is False
 
 
+AOP472_KES = ['KE:1115', 'KE:1194', 'KE:1392', 'KE:149', 'KE:177',
+              'KE:1825', 'KE:373', 'KE:1097', 'KE:759']
+
+
+@pytest.fixture
+def offline_aop(monkeypatch):
+    """Serve AOP:472's topology locally instead of querying AOP-Wiki.
+
+    Without this the two /analyze tests below reach the live SPARQL endpoint —
+    Config.SPARQL_TIMEOUT is 30s and fetch_aop_ke_data issues two queries — so
+    on a machine with no route to it the suite stalls for minutes before those
+    tests fail. Nothing here is about SPARQL: the route only needs a KE list and
+    an edge table to run the enrichment against.
+    """
+    def _fake_fetch(aop_ids, *args, **kwargs):
+        ke_set = set(AOP472_KES)
+        edges = pd.DataFrame(columns=['AOP_ID', 'Source_KE', 'Target_KE', 'KER_ID'])
+        ke_type_map = {ke: 'intermediate' for ke in ke_set}
+        ke_type_map['KE:1115'] = 'MIE'
+        ke_type_map['KE:759'] = 'AO'
+        ke_title_map = {ke: f'Event {ke.split(":")[1]}' for ke in ke_set}
+        return ke_set, edges, ke_type_map, ke_title_map
+
+    monkeypatch.setattr(
+        'services.sparql_service.fetch_aop_ke_data_cached', _fake_fetch
+    )
+
+
 @pytest.mark.unit
 class TestAnalyzeRouteBehaviour:
     """The two ways a wrong ID column reaches the user (issue #69)."""
@@ -173,7 +201,7 @@ class TestAnalyzeRouteBehaviour:
             'min_confidence': 'all',
         })
 
-    def test_total_mismatch_gives_an_actionable_error(self, flask_client):
+    def test_total_mismatch_gives_an_actionable_error(self, flask_client, offline_aop):
         """Was 'Analysis error: please check your input data and parameters'."""
         response = self._post(flask_client, [f'ENSG{i:011d}' for i in range(300)])
         assert response.status_code == 400
@@ -181,14 +209,12 @@ class TestAnalyzeRouteBehaviour:
         assert 'matched the reference gene sets' in body
         assert 'HGNC gene symbols' in body
 
-    def test_partial_mismatch_warns_on_the_results_page(self, flask_client):
+    def test_partial_mismatch_warns_on_the_results_page(self, flask_client, offline_aop):
         """Enough overlap to produce results, too little for them to mean anything."""
         from app import load_cached_reference_sets
         reference_sets, _, _ = load_cached_reference_sets(
             ['WikiPathways', 'GO_BP', 'Reactome'], min_confidence='all')
-        aop_kes = ['KE:1115', 'KE:1194', 'KE:1392', 'KE:149', 'KE:177',
-                   'KE:1825', 'KE:373', 'KE:1097', 'KE:759']
-        symbols = sorted({g for k in aop_kes for g in reference_sets.get(k, set())})
+        symbols = sorted({g for k in AOP472_KES for g in reference_sets.get(k, set())})
         if len(symbols) < 20:
             pytest.skip('reference sets unavailable in this environment')
 


### PR DESCRIPTION
Closes #76.

Single analysis has offered Fisher/ORA and GSEA since #52; batch offered only ORA. That is the wrong way round for how the two methods are used. GSEA's value is a coordinated directional shift compared *across* conditions — compound, dose, timepoint — and cross-condition comparison is exactly what batch mode exists for. Getting a GSEA comparison meant running every condition as a separate single analysis and assembling the NES/FDR table by hand, which also threw away the harmonised background that makes batch results comparable in the first place.

On a 9-condition platinum/AOP-472 dataset the two methods disagree informatively rather than contradictorily: KE 1194 (DNA damage) reaches significance in 2/9 conditions by ORA and 7/9 by GSEA, and KE 177 (mitochondrial dysfunction) is called depleted by ORA while GSEA shows coordinated positive enrichment — a gene set of small effect sizes with a consistent upward bias.

## What changed

- Method selector in the batch wizard; `method` stored on `BatchRecord` via the established idempotent PRAGMA-then-ALTER migration, so the deploy migrates on startup with no manual work on the shared database. Existing batches keep running, exporting and comparing as ORA.
- The comparison view, its export and the batch report are method-aware: NES and FDR where the batch ran as GSEA, odds ratios and overlap counts where it ran as ORA. Previously a GSEA batch report would have printed `# Overlap 0` and `Odds Ratio 0.00` on every row and dropped NES and the leading-edge genes entirely — plausible-looking zeros, no warning.
- The comparison network's delta view uses a signed divergent scale under GSEA. Its muting rule reads a negative delta as *less significant*, which is true for FDR and wrong for NES, where negative means a downward shift.
- Column sorting, which put the most negative NES first while claiming "most significant first".

## Verification

520 tests pass. The GSEA report was checked by generating the PDF through the route and reading the text back: NES and leading-edge genes present, `Odds Ratio` / `# Overlap` / `Direction` absent.

Note: `tests/test_flask_routes.py::test_full_workflow_integration` hangs intermittently (a kaleido headless-Chromium process outliving the test). It reproduces on `main` and is not caused by this branch — filed separately.