### PR TITLE
Report the batch's own run settings on its condition pages (#74, #75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,10 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   The same page was misstating two more of the run's settings, both of which travel into a
   methods section together with the resources. The mapping-confidence threshold read *"All
   mappings"* on every condition page, even one run at *"High only"* — and even directly above
-  the warning banner that the stricter threshold had raised. And the column mapping shown on
-  an exported report was whatever the browser session last held rather than the columns the
-  batch was run on. Both now come from the batch record, as does the enrichment method, which
-  the page had hardcoded to over-representation.
+  the warning banner that the stricter threshold had raised. And a report exported from a
+  condition page reported no column mapping and a p-value cutoff of `0.05` whatever the batch
+  had actually been run at. All of these now come from the batch record, as does the
+  enrichment method, which the page had hardcoded to over-representation.
 
   **A report exported from a condition page reported the wrong resources too**, which is the
   form the claim is most likely to be quoted in. The report form posted no resource list at
@@ -61,6 +61,11 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   name: a run with nothing recorded reports *"Not recorded"*. The same invented default is
   gone from the stored-experiment JSON. It remains in the **batch report** (the multi-
   condition PDF), which is not covered by this change.
+
+  The dataset identity leaked the same way: the report generator preferred the browser
+  session over the values the page posted, so a PDF exported from a condition page carried
+  the dataset name, stressor, dosing and owner of whatever single analysis had last been run
+  in that session, under a page header naming the condition. The posted values now win.
 
 - **Hub genes on a batch condition page show their p-value** (#75). The hub-gene panel reads
   its "Adj. p-value" from the per-gene data stored with each condition, and the batch runner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,37 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   page now carries both the requested selection (#55) and the per-resource resolution and
   warnings (#68), and the template no longer substitutes a real resource name for an absent
   one — an unrecorded selection reads as *"Not recorded"*.
+
+  The same page was misstating two more of the run's settings, both of which travel into a
+  methods section together with the resources. The mapping-confidence threshold read *"All
+  mappings"* on every condition page, even one run at *"High only"* — and even directly above
+  the warning banner that the stricter threshold had raised. And the column mapping shown on
+  an exported report was whatever the browser session last held rather than the columns the
+  batch was run on. Both now come from the batch record, as does the enrichment method, which
+  the page had hardcoded to over-representation.
+
+  **A report exported from a condition page reported the wrong resources too**, which is the
+  form the claim is most likely to be quoted in. The report form posted no resource list at
+  all, so the generator fell back to the browser session — meaning a PDF exported from a
+  batch condition page named the resources of whatever single analysis had last been run in
+  the same session, and named `WikiPathways` when there was no session to borrow from. The
+  form now posts the run's own selection, always, and the report no longer invents a resource
+  name: a run with nothing recorded reports *"Not recorded"*. The same invented default is
+  gone from the stored-experiment JSON. It remains in the **batch report** (the multi-
+  condition PDF), which is not covered by this change.
+
+- **Hub genes on a batch condition page show their p-value** (#75). The hub-gene panel reads
+  its "Adj. p-value" from the per-gene data stored with each condition, and the batch runner
+  never captured p-values at all — so every hub row of every condition of every batch showed
+  an em dash, while the same file analysed on its own showed a number. Batch runs now capture
+  the raw and adjusted p-value columns from each uploaded file the way a single analysis
+  does, independently of the one column the batch thresholds on, and store them alongside the
+  fold changes. A file that genuinely carries no adjusted p-value column still reads as a
+  dash, which is the honest answer.
+
+  This applies to batches run from now on. Conditions stored before this change hold no
+  p-values and will keep showing a dash; re-run the batch to get them.
+
 - **"No gene set mapped" no longer covers Key Events that are mapped** (#81). The
   per-condition accounting had two exclusion counters, and one of them was answering three
   different questions at once. A Key Event with no curated mapping, a Key Event whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,8 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   the warning banner that the stricter threshold had raised. And a report exported from a
   condition page reported no column mapping and a p-value cutoff of `0.05` whatever the batch
   had actually been run at. All of these now come from the batch record, as does the
-  enrichment method, which the page had hardcoded to over-representation.
+  enrichment method: the page had hardcoded over-representation, so with batch GSEA (#76) it
+  would have shown a GSEA run the ORA colour scale and exported it as ORA.
 
   **A report exported from a condition page reported the wrong resources too**, which is the
   form the claim is most likely to be quoted in. The report form posted no resource list at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Fixed
 
+- **Batch condition pages state the gene-set resources the batch actually used** (#74).
+  `/batch/<uuid>/condition/<n>` re-renders the results page from stored condition data, but
+  never carried the batch's resource selection into that context — and the template
+  defaulted the missing value to `WikiPathways`. A batch run over all three resources
+  therefore reported a single-resource provenance, confidently and wrongly, while the batch
+  summary for the same run reported all three. Which resources contributed gene sets decides
+  which Key Events were testable at all, so the header was misstating the analysis it sat on
+  top of, in the one place a reader would copy from into a methods section. The condition
+  page now carries both the requested selection (#55) and the per-resource resolution and
+  warnings (#68), and the template no longer substitutes a real resource name for an absent
+  one — an unrecorded selection reads as *"Not recorded"*.
+
 - **WikiPathways gene membership no longer comes only from a bundled snapshot** (#79).
   KE→pathway mappings were fetched live from the Builder, but pathway→gene membership was
   resolved against `data/edges_wpid_to_gene.csv` — a snapshot topping out at `WP5452`. Any

--- a/app.py
+++ b/app.py
@@ -1308,6 +1308,22 @@ def generate_report():
                 metadata.get('resource_resolution') if isinstance(metadata, dict) else None
             )
 
+        # Issue #74: the results page always posts its own resource selection,
+        # including when that selection is empty. Trust the posted field on its
+        # presence rather than its truthiness — falling back to the session on
+        # an empty value would let a batch-condition export inherit the resource
+        # list of the last single analysis run in the same browser session, and
+        # falling back to a literal 'WikiPathways' would state a resource that
+        # may never have been used. A page that posts nothing at all (an older
+        # cached page) still falls back to the session, then to unrecorded.
+        if 'selected_resources' in request.form:
+            report_resources = request.form.get('selected_resources', '').strip()
+        else:
+            report_resources = (
+                metadata.get('selected_resources', '') if isinstance(metadata, dict) else ''
+            )
+        report_resources = report_resources or 'Not recorded'
+
         report_data = ReportData(
             metadata=metadata,
             filename=request.form.get('filename', metadata.get('filename', 'unknown')),
@@ -1327,7 +1343,7 @@ def generate_report():
             network_png=network_png_data,
             software_versions=get_software_versions(),
             method=request.form.get('method') or metadata.get('method', 'ora'),  # Phase 14: forward method to report (Plan 04 consumption)
-            selected_resources=request.form.get('selected_resources') or metadata.get('selected_resources', 'WikiPathways'),  # #55: forward resources to report
+            selected_resources=report_resources,  # #55 / #74: forward resources to report
             min_confidence=request.form.get('min_confidence') or metadata.get('min_confidence', DEFAULT_MIN_CONFIDENCE),  # #60: forward confidence threshold to report
             ke_summary=ke_summary,  # Issue #65: tested/excluded KE accounting
             # Issue #68: what the run actually used, posted back by the results
@@ -2522,6 +2538,13 @@ def batch_condition_results(batch_uuid_str, position):
         # selection (#55) and what those resources actually resolved to (#68),
         # exactly as the batch summary page does.
         resolution = _parse_resource_resolution(batch.resource_resolution)
+        batch_min_confidence = batch.min_confidence or DEFAULT_MIN_CONFIDENCE
+
+        # Issue #74: batch runs were ORA-only when this route was written, so
+        # it hardcoded the method. Read it from the batch instead — and tolerate
+        # a BatchRecord that predates the column, which reads as ORA because
+        # that is what every batch before it ran.
+        batch_method = getattr(batch, 'method', None) or 'ora'
 
         # Build metadata dict compatible with results.html template variables
         metadata = {
@@ -2537,8 +2560,24 @@ def batch_condition_results(batch_uuid_str, position):
             'selected_resources': batch.selected_resources or '',
             'resource_resolution': resolution,
             'resource_warnings': resource_resolution_warnings(
-                resolution, batch.min_confidence or DEFAULT_MIN_CONFIDENCE
+                resolution, batch_min_confidence
             ),
+            # Issue #60/#74: the confidence threshold decides which mappings
+            # became gene sets, so the header and the exported report have to
+            # state the batch's own value. Omitting it left the header reading
+            # "All mappings" underneath the warnings raised by a stricter
+            # threshold, and posted `min_confidence=all` into the report.
+            'min_confidence': batch_min_confidence,
+            'min_confidence_label': MIN_CONFIDENCE_LABELS.get(
+                batch_min_confidence, MIN_CONFIDENCE_LABELS[DEFAULT_MIN_CONFIDENCE]
+            ),
+            'method': batch_method,
+            # Column mapping, so a report exported from this page names the
+            # columns the batch was actually run on rather than inheriting
+            # them from whatever single analysis last touched the session.
+            'id_column': batch.id_column or '',
+            'fc_column': batch.fc_column or '',
+            'pval_column': batch.pval_column or '',
             # Pass batch context so results.html renders the "Back to batch summary" breadcrumb
             'batch_uuid': batch_uuid_str,
             'batch_name': batch.batch_name,
@@ -2557,7 +2596,7 @@ def batch_condition_results(batch_uuid_str, position):
                 ke_type_map=ke_type_map,
                 ke_title_map=ke_title_map,
                 metadata=metadata,
-                method='ora',  # batch runs are ORA-only; BatchRecord has no method column
+                method=batch_method,
                 pval_threshold=batch.pval_cutoff,
                 # Issue #65: ConditionRecord has no field for the accounting, so
                 # recover it from the stored network exactly as the shared-result

--- a/app.py
+++ b/app.py
@@ -1224,7 +1224,18 @@ def generate_report():
                 'description': request.form.get('description', '')
             }
             logger.info(f"Created metadata from form data: {metadata}")
-        
+
+        # Issue #74: the results page always posts the dataset identity, so the
+        # posted values win over the session's. Without this a report exported
+        # from a batch condition page carried the dataset name, stressor,
+        # dosing and owner of whatever single analysis the browser last ran —
+        # the page described one run and its PDF described another. Keyed on
+        # presence rather than truth so an intentionally blank field stays blank.
+        metadata = dict(metadata)
+        for field in ('dataset_id', 'stressor', 'dosing', 'owner', 'description'):
+            if field in request.form:
+                metadata[field] = request.form.get(field, '')
+
         # Extract report data from form/session
         try:
             enrichment_results_str = request.form.get('enrichment_results', '[]')

--- a/app.py
+++ b/app.py
@@ -2435,6 +2435,15 @@ def batch_condition_results(batch_uuid_str, position):
         ke_type_map = json.loads(cond.ke_type_map_json) if cond.ke_type_map_json else {}
         ke_title_map = json.loads(cond.ke_title_map_json) if cond.ke_title_map_json else {}
 
+        # Issue #74: the gene-set resources are a property of the batch, and
+        # every condition in it was analysed against the same selection. Without
+        # them the header fell back to naming WikiPathways, so a three-resource
+        # run reported a one-resource provenance — a claim that would travel
+        # into a figure legend or a methods section. Carry both the requested
+        # selection (#55) and what those resources actually resolved to (#68),
+        # exactly as the batch summary page does.
+        resolution = _parse_resource_resolution(batch.resource_resolution)
+
         # Build metadata dict compatible with results.html template variables
         metadata = {
             'dataset_id': cond.condition_label,
@@ -2446,6 +2455,11 @@ def batch_condition_results(batch_uuid_str, position):
             'significant_genes': cond.significant_genes,
             'analysis_date': cond.completed_at.strftime('%Y-%m-%d %H:%M') if cond.completed_at else '',
             'data_source': 'batch',
+            'selected_resources': batch.selected_resources or '',
+            'resource_resolution': resolution,
+            'resource_warnings': resource_resolution_warnings(
+                resolution, batch.min_confidence or DEFAULT_MIN_CONFIDENCE
+            ),
             # Pass batch context so results.html renders the "Back to batch summary" breadcrumb
             'batch_uuid': batch_uuid_str,
             'batch_name': batch.batch_name,

--- a/database.py
+++ b/database.py
@@ -81,7 +81,11 @@ class ExperimentRecord(Base):
             'id_column': self.id_column,
             'fc_column': self.fc_column,
             'pval_column': self.pval_column,
-            'selected_resources': self.selected_resources or 'WikiPathways',  # coerce NULL (pre-#55 rows)
+            # Issue #74: a row written before #55 recorded no selection. Report
+            # that as an absent value rather than naming WikiPathways — the run
+            # may have used something else, and a consumer cannot tell an
+            # invented default from a recorded one.
+            'selected_resources': self.selected_resources or None,
             'min_confidence': self.min_confidence or 'all',  # coerce NULL (pre-#60 rows)
             'enrichment_results': json.loads(self.enrichment_results) if self.enrichment_results else None,
             'gene_count': self.gene_count,

--- a/services/batch_service.py
+++ b/services/batch_service.py
@@ -354,8 +354,78 @@ def _run_condition(
             cond.id, cond.condition_label, overlap['matched'], overlap['total'],
             overlap['fraction'] * 100,
         )
+    # Issue #75: the hub-gene panel on a batch condition page reads its
+    # "Adj. p-value" straight out of the stored KE-gene payload. The batch
+    # runner never built the per-gene p-value maps, so every hub row on every
+    # condition page rendered an em dash while the same file analysed on its
+    # own showed a p-value. Detect the raw and adjusted p-value columns on the
+    # uploaded file the way the single analysis does, rather than reusing the
+    # one column the batch thresholds on — a batch thresholded on a raw
+    # p-value still has an adjusted column worth reporting.
+    #
+    # Failure here is non-fatal: the maps stay None, build_ke_gene_mapping
+    # emits its pre-#75 three-key shape and the panel reads as it did before.
+    gene_pvalue_raw_map = None
+    gene_pvalue_adj_map = None
+    try:
+        from scipy.stats import combine_pvalues
+        from services.column_detector import ColumnDetector, column_detector
+
+        df_raw_for_pvalues = pd.read_csv(filepath, sep=None, engine='python')
+        suggestions = column_detector.detect_columns(df_raw_for_pvalues)
+        raw_col = suggestions.best_pvalue.column_name if suggestions.best_pvalue else None
+        adj_col = (
+            suggestions.best_pvalue_adj.column_name if suggestions.best_pvalue_adj else None
+        )
+
+        # Same disambiguation as the single analysis: when both slots resolve
+        # to one column and its name reads as adjusted, treat it as adjusted
+        # only rather than emitting the same number twice.
+        if raw_col and adj_col and raw_col == adj_col:
+            if any(
+                re.search(pattern, raw_col, re.IGNORECASE)
+                for pattern in ColumnDetector.PVALUE_ADJ_PATTERNS
+            ):
+                raw_col = None
+
+        if batch.id_column in df_raw_for_pvalues.columns:
+            ids = df_raw_for_pvalues[batch.id_column].astype(str).str.strip().str.upper()
+
+            def _combine_per_gene(series):
+                """Fisher-combine a p-value column per gene symbol.
+
+                Mirrors data_service.process_gene_expression: a naive
+                dict(zip(...)) would keep the last probe per duplicated gene
+                and report a p-value that disagrees with the significance flag.
+                """
+                frame = pd.DataFrame(
+                    {'ID': ids, 'val': pd.to_numeric(series, errors='coerce')}
+                ).dropna()
+                out = {}
+                for gene, group in frame.groupby('ID'):
+                    values = group['val'].astype(float).values
+                    if len(values) == 1:
+                        out[gene] = float(values[0])
+                    else:
+                        _, combined = combine_pvalues(values, method='fisher')
+                        out[gene] = float(combined)
+                return out
+
+            if raw_col and raw_col in df_raw_for_pvalues.columns:
+                gene_pvalue_raw_map = _combine_per_gene(df_raw_for_pvalues[raw_col])
+            if adj_col and adj_col in df_raw_for_pvalues.columns:
+                gene_pvalue_adj_map = _combine_per_gene(df_raw_for_pvalues[adj_col])
+    except Exception as exc:
+        logger.warning(
+            '_run_condition: per-gene p-value capture failed for condition %s '
+            '(non-fatal, hub p-values will be blank): %s',
+            cond.id, exc,
+        )
+
     ke_gene_map = build_ke_gene_mapping(
-        reference_sets, ke_list, gene_logfc_map, gene_significance_map
+        reference_sets, ke_list, gene_logfc_map, gene_significance_map,
+        gene_pvalue_raw_map=gene_pvalue_raw_map,
+        gene_pvalue_adj_map=gene_pvalue_adj_map,
     )
 
     # Convert enrichment DataFrame to JSON-serialisable list

--- a/templates/results.html
+++ b/templates/results.html
@@ -64,8 +64,11 @@
             <div class="metadata-summary__item">
                 <span class="metadata-summary__label">Gene Set Resources</span>
                 {# Issue #68: this is the REQUESTED selection; what actually
-                   loaded is on the provenance line below the table. #}
-                <span class="metadata-summary__value">{{ metadata.get('selected_resources', 'WikiPathways') }}</span>
+                   loaded is on the provenance line below the table.
+                   Issue #74: no resource default. A route that fails to pass
+                   the selection must not make the page name a real resource —
+                   an unrecorded selection has to read as unrecorded. #}
+                <span class="metadata-summary__value">{{ metadata.get('selected_resources') or 'Not recorded' }}</span>
             </div>
             {# Issue #60: the mapping-confidence threshold the gene sets were built at. #}
             <div class="metadata-summary__item">

--- a/templates/results.html
+++ b/templates/results.html
@@ -604,7 +604,7 @@
             <input type="hidden" name="aop_id" value="{{ metadata.get('aop_id', '') }}">
             <input type="hidden" name="aop_label" value="{{ metadata.get('aop_label', '') }}">
             <input type="hidden" name="logfc_threshold" value="{{ threshold }}">
-            <input type="hidden" name="pval_cutoff" value="0.05">
+            <input type="hidden" name="pval_cutoff" value="{{ metadata.get('pval_cutoff', 0.05) }}">
             <input type="hidden" name="method" value="{{ method or 'ora' }}">
             <input type="hidden" name="id_column" value="{{ metadata.get('id_column', '') }}">
             <input type="hidden" name="fc_column" value="{{ metadata.get('fc_column', '') }}">

--- a/templates/results.html
+++ b/templates/results.html
@@ -613,6 +613,14 @@
             {# Issue #60: carry the confidence threshold explicitly so the report
                is correct even if the session has been lost. #}
             <input type="hidden" name="min_confidence" value="{{ metadata.get('min_confidence', 'all') }}">
+            {# Issue #74: the requested resource list, posted explicitly for the
+               same reason. Without it the report fell back to the session, so a
+               PDF exported from a batch condition page reported the resources of
+               whatever single analysis the browser had last run — or, with no
+               session at all, "WikiPathways". The field is always posted, even
+               empty, so an unrecorded selection reaches the report as unrecorded
+               rather than being filled in from another run. #}
+            <input type="hidden" name="selected_resources" value="{{ metadata.get('selected_resources', '') }}">
             {# Issue #68: gene-set provenance for the report, carried explicitly
                for the same reason as the threshold above. #}
             <textarea name="resource_resolution" style="display: none;">{{ metadata.get('resource_resolution') | tojson }}</textarea>

--- a/tests/test_batch_condition_results.py
+++ b/tests/test_batch_condition_results.py
@@ -58,13 +58,14 @@ def _gene(symbol, log2fc, significant, pvalue_adj=None):
 
 
 def _seed(db_manager, *, selected_resources='WikiPathways, GO_BP, Reactome',
-          resolution=_RESOLUTION, min_confidence='all'):
+          resolution=_RESOLUTION, min_confidence='all', pval_cutoff=0.05):
     """Create one complete batch with a single complete condition."""
     session = db_manager.get_session()
     try:
         batch = BatchRecord(
             uuid='22222222-2222-2222-2222-222222222222', status='complete',
-            aop_id='AOP:1', aop_label='Test AOP', logfc_threshold=1.0, pval_cutoff=0.05,
+            aop_id='AOP:1', aop_label='Test AOP', logfc_threshold=1.0,
+            pval_cutoff=pval_cutoff,
             selected_resources=selected_resources,
             min_confidence=min_confidence,
             resource_resolution=json.dumps(resolution) if resolution else None,
@@ -220,6 +221,16 @@ class TestRunSettingsProvenance:
         assert _hidden_field(html, 'fc_column') == 'logFC'
         assert _hidden_field(html, 'pval_column') == 'adj.P.Val'
 
+    def test_pvalue_cutoff_posted_to_the_report_is_the_batch_cutoff(
+        self, condition_client
+    ):
+        """The field was the literal 0.05, so a stricter batch exported a
+        report claiming a cutoff it had never been run at."""
+        client, uuid = condition_client(pval_cutoff=0.01)
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert _metadata_value(html, 'P-value Cutoff') == '0.01'
+        assert _hidden_field(html, 'pval_cutoff') == '0.01'
+
 
 class TestConditionMethod:
     """The page must render and export the method the batch actually ran."""
@@ -313,3 +324,30 @@ class TestReportResourceProvenance:
     def test_absent_field_and_empty_session_is_not_wikipathways(self, flask_client):
         report = self._capture(flask_client, dict(self._BASE_FORM))
         assert report.selected_resources == 'Not recorded'
+
+    def test_posted_dataset_identity_wins_over_the_session(self, flask_client):
+        """The identity fields leaked exactly as the resource list did.
+
+        The generator preferred ``session['experiment_metadata']`` whenever it
+        was non-empty, so a report exported from a condition page named the
+        dataset, stressor, dosing and owner of the last single analysis run in
+        the same browser session.
+        """
+        with flask_client.session_transaction() as sess:
+            sess['experiment_metadata'] = {
+                'dataset_id': 'PREVIOUS RUN',
+                'stressor': 'Previous stressor',
+                'dosing': 'Previous dosing',
+                'owner': 'Someone else',
+                'selected_resources': 'GO_BP',
+            }
+        form = dict(
+            self._BASE_FORM, selected_resources='WikiPathways',
+            dataset_id='THIS CONDITION', stressor='Cisplatin',
+            dosing='10uM, 24hr', owner='Batch owner',
+        )
+        report = self._capture(flask_client, form)
+        assert report.metadata['dataset_id'] == 'THIS CONDITION'
+        assert report.metadata['stressor'] == 'Cisplatin'
+        assert report.metadata['dosing'] == '10uM, 24hr'
+        assert report.metadata['owner'] == 'Batch owner'

--- a/tests/test_batch_condition_results.py
+++ b/tests/test_batch_condition_results.py
@@ -58,7 +58,8 @@ def _gene(symbol, log2fc, significant, pvalue_adj=None):
 
 
 def _seed(db_manager, *, selected_resources='WikiPathways, GO_BP, Reactome',
-          resolution=_RESOLUTION, min_confidence='all', pval_cutoff=0.05):
+          resolution=_RESOLUTION, min_confidence='all', pval_cutoff=0.05,
+          method='ora'):
     """Create one complete batch with a single complete condition."""
     session = db_manager.get_session()
     try:
@@ -67,7 +68,7 @@ def _seed(db_manager, *, selected_resources='WikiPathways, GO_BP, Reactome',
             aop_id='AOP:1', aop_label='Test AOP', logfc_threshold=1.0,
             pval_cutoff=pval_cutoff,
             selected_resources=selected_resources,
-            min_confidence=min_confidence,
+            min_confidence=min_confidence, method=method,
             resource_resolution=json.dumps(resolution) if resolution else None,
             id_column='gene', fc_column='logFC', pval_column='adj.P.Val',
             harmonised_background=json.dumps(['TP53', 'EGFR']), harmonised_gene_count=2,
@@ -235,25 +236,16 @@ class TestRunSettingsProvenance:
 class TestConditionMethod:
     """The page must render and export the method the batch actually ran."""
 
-    def test_method_defaults_to_ora_without_the_column(self, condition_client):
-        client, uuid = condition_client()
+    def test_method_defaults_to_ora_when_unrecorded(self, condition_client):
+        """Batches created before #76 carry no method; they are ORA runs."""
+        client, uuid = condition_client(method=None)
         html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
         assert _hidden_field(html, 'method') == 'ora'
         assert 'Gene Expression Scale' in html
 
-    def test_gsea_batch_renders_and_exports_gsea(self, condition_client, monkeypatch):
-        """A BatchRecord carrying method='gsea' must not be reported as ORA.
-
-        BatchRecord has no ``method`` column on this branch, so the attribute is
-        planted on the model the route queries. That is the shape
-        ``getattr(batch, 'method', None) or 'ora'`` has to cope with once the
-        column lands on the other branch.
-        """
-        client, uuid = condition_client()
-
-        # Make the batch look like a GSEA run without adding a column this
-        # branch does not own.
-        monkeypatch.setattr(BatchRecord, 'method', 'gsea', raising=False)
+    def test_gsea_batch_renders_and_exports_gsea(self, condition_client):
+        """A batch run as GSEA must not have its condition page report ORA."""
+        client, uuid = condition_client(method='gsea')
         html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
         assert _hidden_field(html, 'method') == 'gsea'
         assert 'KE NES Scale' in html

--- a/tests/test_batch_condition_results.py
+++ b/tests/test_batch_condition_results.py
@@ -1,0 +1,178 @@
+"""Route tests for /batch/<uuid>/condition/<n> (issues #74, #75).
+
+The batch-condition page re-renders results.html from stored ConditionRecord
+blobs. Everything the header states about the run therefore has to be carried
+over from the BatchRecord explicitly — anything the route forgets is either
+silently absent or, worse, replaced by a template default that names a real
+resource. Issue #74 was the latter: a run over all three gene-set resources
+reported "WikiPathways", which is a provenance claim a reader would carry into
+a methods section.
+
+The hub-gene assertions pin the other half of the contract (#75): whatever
+per-gene adjusted p-values the stored ke_gene_json carries must reach the hub
+table unaltered.
+"""
+import json
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import app as app_module
+from database import BatchRecord, ConditionRecord
+
+
+def _expiry():
+    return datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=14)
+
+
+_NETWORK = {
+    'nodes': [
+        {'data': {'id': 'KE:1', 'label': 'Alpha', 'ke_type': 'MIE'}, 'classes': 'significant'},
+        {'data': {'id': 'KE:2', 'label': 'Beta', 'ke_type': 'KE'}, 'classes': ''},
+        {'data': {'id': 'KE:3', 'label': 'Gamma', 'ke_type': 'AO'}, 'classes': ''},
+    ],
+    'edges': [{'data': {'source': 'KE:1', 'target': 'KE:2', 'id': 'KER:1'}}],
+}
+
+_RESOLUTION = [
+    {'resource': 'WikiPathways', 'status': 'loaded', 'source': 'api',
+     'ke_count': 42, 'confidence_applied': True, 'error': None},
+    {'resource': 'GO_BP', 'status': 'loaded', 'source': 'api',
+     'ke_count': 7, 'confidence_applied': False, 'error': None},
+    {'resource': 'Reactome', 'status': 'loaded', 'source': 'api',
+     'ke_count': 5, 'confidence_applied': False, 'error': None},
+]
+
+
+def _gene(symbol, log2fc, significant, pvalue_adj=None):
+    entry = {'id': symbol, 'log2FC': log2fc, 'significant': significant}
+    if pvalue_adj is not None:
+        entry['pvalue_raw'] = pvalue_adj / 2
+        entry['pvalue_adj'] = pvalue_adj
+    return entry
+
+
+def _seed(db_manager, *, selected_resources='WikiPathways, GO_BP, Reactome',
+          resolution=_RESOLUTION, with_pvalues=True):
+    """Create one complete batch with a single complete condition."""
+    session = db_manager.get_session()
+    try:
+        batch = BatchRecord(
+            uuid='22222222-2222-2222-2222-222222222222', status='complete',
+            aop_id='AOP:1', aop_label='Test AOP', logfc_threshold=1.0, pval_cutoff=0.05,
+            selected_resources=selected_resources,
+            min_confidence='all',
+            resource_resolution=json.dumps(resolution) if resolution else None,
+            id_column='gene', fc_column='logFC', pval_column='adj.P.Val',
+            harmonised_background=json.dumps(['TP53', 'EGFR']), harmonised_gene_count=2,
+            batch_name='Condition Route Batch', expires_at=_expiry(),
+        )
+        session.add(batch)
+        session.flush()
+
+        adj = 0.0004 if with_pvalues else None
+        # TP53 sits in all three KEs, so it clears the hub threshold (3 KEs).
+        ke_gene = {
+            'KE:1': [_gene('TP53', 2.0, True, adj), _gene('EGFR', 0.1, False, 0.42 if with_pvalues else None)],
+            'KE:2': [_gene('TP53', 2.0, True, adj)],
+            'KE:3': [_gene('TP53', 2.0, True, adj)],
+        }
+        session.add(ConditionRecord(
+            batch_id=batch.id, position=0, filename='c0.tsv',
+            condition_label='C0', dose='1uM', timepoint='4hr', status='complete',
+            gene_count=20, significant_genes=6,
+            completed_at=datetime.now(timezone.utc).replace(tzinfo=None),
+            enrichment_json=json.dumps([{
+                'KE': 'KE:1', 'Title': 'Alpha', 'p_value': 0.0005, 'FDR': 0.001,
+                'num_overlap': 6, 'odds_ratio': 3.0, 'total_KE_genes_in_dataset': 20,
+                'Direction': '6↑', 'Representation': 'enriched',
+            }]),
+            network_json=json.dumps(_NETWORK),
+            ke_gene_json=json.dumps(ke_gene),
+            ke_type_map_json=json.dumps({'KE:1': 'MIE', 'KE:2': 'KE', 'KE:3': 'AO'}),
+            ke_title_map_json=json.dumps({'KE:1': 'Alpha', 'KE:2': 'Beta', 'KE:3': 'Gamma'}),
+        ))
+        session.commit()
+        return batch.uuid
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def condition_client(flask_client, temp_database, monkeypatch):
+    monkeypatch.setattr(app_module, 'db_manager', temp_database)
+
+    def _make(**kwargs):
+        uuid = _seed(temp_database, **kwargs)
+        return flask_client, uuid
+
+    return _make
+
+
+def _resource_header_value(html):
+    """Extract the rendered 'Gene Set Resources' metadata value."""
+    match = re.search(
+        r'Gene Set Resources</span>.*?metadata-summary__value">(.*?)</span>',
+        html, re.DOTALL,
+    )
+    assert match, 'Gene Set Resources header not found on the page'
+    return match.group(1).strip()
+
+
+class TestResourceProvenance:
+    """Issue #74: the header must state the batch's real resource selection."""
+
+    def test_all_selected_resources_are_reported(self, condition_client):
+        client, uuid = condition_client()
+        r = client.get(f'/batch/{uuid}/condition/0')
+        assert r.status_code == 200
+        value = _resource_header_value(r.get_data(as_text=True))
+        assert value == 'WikiPathways, GO_BP, Reactome'
+
+    def test_resolution_provenance_line_is_rendered(self, condition_client):
+        client, uuid = condition_client()
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert 'Gene set provenance' in html
+        for resource in ('WikiPathways', 'GO_BP', 'Reactome'):
+            assert resource in html
+
+    def test_skipped_resource_raises_a_warning(self, condition_client):
+        resolution = [
+            dict(_RESOLUTION[0]),
+            {'resource': 'Reactome', 'status': 'error', 'source': None,
+             'ke_count': 0, 'confidence_applied': False, 'error': 'timeout'},
+        ]
+        client, uuid = condition_client(
+            selected_resources='WikiPathways, Reactome', resolution=resolution
+        )
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert 'unavailable, skipped' in html
+        assert 'Fewer Key Events were testable' in html
+
+    def test_missing_selection_is_not_reported_as_wikipathways(self, condition_client):
+        """A batch predating #55 recorded no selection — say so, do not invent one."""
+        client, uuid = condition_client(selected_resources=None, resolution=None)
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        value = _resource_header_value(html)
+        assert value == 'Not recorded'
+        assert 'WikiPathways' not in value
+
+
+class TestHubGenePvalues:
+    """Issue #75: stored per-gene adjusted p-values must reach the hub table."""
+
+    def test_adjusted_pvalue_is_rendered_for_hub_genes(self, condition_client):
+        client, uuid = condition_client(with_pvalues=True)
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        row = re.search(r'<td>TP53</td>.*?</tr>', html, re.DOTALL)
+        assert row, 'TP53 hub row not rendered'
+        assert '4.00e-04' in row.group(0)
+        assert '&mdash;' not in row.group(0)
+
+    def test_absent_pvalue_renders_as_a_dash(self, condition_client):
+        """The em dash is only correct when the stored map genuinely has none."""
+        client, uuid = condition_client(with_pvalues=False)
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        row = re.search(r'<td>TP53</td>.*?</tr>', html, re.DOTALL)
+        assert row and '&mdash;' in row.group(0)

--- a/tests/test_batch_condition_results.py
+++ b/tests/test_batch_condition_results.py
@@ -1,4 +1,4 @@
-"""Route tests for /batch/<uuid>/condition/<n> (issues #74, #75).
+"""Route tests for /batch/<uuid>/condition/<n> and its report export (#74).
 
 The batch-condition page re-renders results.html from stored ConditionRecord
 blobs. Everything the header states about the run therefore has to be carried
@@ -8,13 +8,17 @@ resource. Issue #74 was the latter: a run over all three gene-set resources
 reported "WikiPathways", which is a provenance claim a reader would carry into
 a methods section.
 
-The hub-gene assertions pin the other half of the contract (#75): whatever
-per-gene adjusted p-values the stored ke_gene_json carries must reach the hub
-table unaltered.
+The same applies to the report exported from that page: a hidden field the form
+does not post is a value the generator silently borrows from the session.
+
+Per-gene p-values on the condition page (#75) are covered end-to-end in
+tests/test_batch_hub_pvalues.py — asserting them against a hand-seeded
+ke_gene_json would only exercise the renderer, which was never at fault.
 """
 import json
 import re
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
 
@@ -54,7 +58,7 @@ def _gene(symbol, log2fc, significant, pvalue_adj=None):
 
 
 def _seed(db_manager, *, selected_resources='WikiPathways, GO_BP, Reactome',
-          resolution=_RESOLUTION, with_pvalues=True):
+          resolution=_RESOLUTION, min_confidence='all'):
     """Create one complete batch with a single complete condition."""
     session = db_manager.get_session()
     try:
@@ -62,7 +66,7 @@ def _seed(db_manager, *, selected_resources='WikiPathways, GO_BP, Reactome',
             uuid='22222222-2222-2222-2222-222222222222', status='complete',
             aop_id='AOP:1', aop_label='Test AOP', logfc_threshold=1.0, pval_cutoff=0.05,
             selected_resources=selected_resources,
-            min_confidence='all',
+            min_confidence=min_confidence,
             resource_resolution=json.dumps(resolution) if resolution else None,
             id_column='gene', fc_column='logFC', pval_column='adj.P.Val',
             harmonised_background=json.dumps(['TP53', 'EGFR']), harmonised_gene_count=2,
@@ -71,12 +75,11 @@ def _seed(db_manager, *, selected_resources='WikiPathways, GO_BP, Reactome',
         session.add(batch)
         session.flush()
 
-        adj = 0.0004 if with_pvalues else None
         # TP53 sits in all three KEs, so it clears the hub threshold (3 KEs).
         ke_gene = {
-            'KE:1': [_gene('TP53', 2.0, True, adj), _gene('EGFR', 0.1, False, 0.42 if with_pvalues else None)],
-            'KE:2': [_gene('TP53', 2.0, True, adj)],
-            'KE:3': [_gene('TP53', 2.0, True, adj)],
+            'KE:1': [_gene('TP53', 2.0, True, 0.0004), _gene('EGFR', 0.1, False, 0.42)],
+            'KE:2': [_gene('TP53', 2.0, True, 0.0004)],
+            'KE:3': [_gene('TP53', 2.0, True, 0.0004)],
         }
         session.add(ConditionRecord(
             batch_id=batch.id, position=0, filename='c0.tsv',
@@ -110,14 +113,28 @@ def condition_client(flask_client, temp_database, monkeypatch):
     return _make
 
 
-def _resource_header_value(html):
-    """Extract the rendered 'Gene Set Resources' metadata value."""
+def _metadata_value(html, label):
+    """Extract a rendered value from the metadata-summary header by its label."""
     match = re.search(
-        r'Gene Set Resources</span>.*?metadata-summary__value">(.*?)</span>',
+        re.escape(label) + r'</span>.*?metadata-summary__value">(.*?)</span>',
         html, re.DOTALL,
     )
-    assert match, 'Gene Set Resources header not found on the page'
+    assert match, f'{label!r} header not found on the page'
     return match.group(1).strip()
+
+
+def _resource_header_value(html):
+    """Extract the rendered 'Gene Set Resources' metadata value."""
+    return _metadata_value(html, 'Gene Set Resources')
+
+
+def _hidden_field(html, name):
+    """Extract the value a report-form hidden input posts."""
+    match = re.search(
+        r'<input type="hidden" name="' + re.escape(name) + r'" value="(.*?)">', html
+    )
+    assert match, f'hidden field {name!r} not present in the report form'
+    return match.group(1)
 
 
 class TestResourceProvenance:
@@ -131,11 +148,22 @@ class TestResourceProvenance:
         assert value == 'WikiPathways, GO_BP, Reactome'
 
     def test_resolution_provenance_line_is_rendered(self, condition_client):
+        """The provenance line itself must name every resource and its KE count.
+
+        Asserting each resource name appears *somewhere* on the page proves
+        nothing — the header fixed above already lists all three. Scope the
+        assertions to the provenance paragraph.
+        """
         client, uuid = condition_client()
         html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
-        assert 'Gene set provenance' in html
-        for resource in ('WikiPathways', 'GO_BP', 'Reactome'):
-            assert resource in html
+        line = re.search(
+            r'<strong>Gene set provenance:</strong>(.*?)</p>', html, re.DOTALL
+        )
+        assert line, 'Gene set provenance line not rendered'
+        provenance = line.group(1)
+        for resource, ke_count in (('WikiPathways', 42), ('GO_BP', 7), ('Reactome', 5)):
+            assert resource in provenance
+            assert f'({ke_count} KEs)' in provenance
 
     def test_skipped_resource_raises_a_warning(self, condition_client):
         resolution = [
@@ -159,20 +187,129 @@ class TestResourceProvenance:
         assert 'WikiPathways' not in value
 
 
-class TestHubGenePvalues:
-    """Issue #75: stored per-gene adjusted p-values must reach the hub table."""
+class TestRunSettingsProvenance:
+    """Issues #60/#74: the header must state the batch's own run settings."""
 
-    def test_adjusted_pvalue_is_rendered_for_hub_genes(self, condition_client):
-        client, uuid = condition_client(with_pvalues=True)
+    def test_confidence_threshold_is_the_batch_threshold(self, condition_client):
+        client, uuid = condition_client(min_confidence='high')
         html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
-        row = re.search(r'<td>TP53</td>.*?</tr>', html, re.DOTALL)
-        assert row, 'TP53 hub row not rendered'
-        assert '4.00e-04' in row.group(0)
-        assert '&mdash;' not in row.group(0)
+        assert _metadata_value(html, 'Min. Mapping Confidence') == 'High only'
 
-    def test_absent_pvalue_renders_as_a_dash(self, condition_client):
-        """The em dash is only correct when the stored map genuinely has none."""
-        client, uuid = condition_client(with_pvalues=False)
+    def test_confidence_threshold_reaches_the_report_form(self, condition_client):
+        client, uuid = condition_client(min_confidence='medium')
         html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
-        row = re.search(r'<td>TP53</td>.*?</tr>', html, re.DOTALL)
-        assert row and '&mdash;' in row.group(0)
+        assert _hidden_field(html, 'min_confidence') == 'medium'
+
+    def test_selected_resources_are_posted_to_the_report(self, condition_client):
+        """Without this field the report falls back to the session (#74)."""
+        client, uuid = condition_client()
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert _hidden_field(html, 'selected_resources') == 'WikiPathways, GO_BP, Reactome'
+
+    def test_unrecorded_selection_is_posted_as_empty_not_wikipathways(
+        self, condition_client
+    ):
+        client, uuid = condition_client(selected_resources=None, resolution=None)
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert _hidden_field(html, 'selected_resources') == ''
+
+    def test_column_mapping_comes_from_the_batch(self, condition_client):
+        client, uuid = condition_client()
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert _hidden_field(html, 'id_column') == 'gene'
+        assert _hidden_field(html, 'fc_column') == 'logFC'
+        assert _hidden_field(html, 'pval_column') == 'adj.P.Val'
+
+
+class TestConditionMethod:
+    """The page must render and export the method the batch actually ran."""
+
+    def test_method_defaults_to_ora_without_the_column(self, condition_client):
+        client, uuid = condition_client()
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert _hidden_field(html, 'method') == 'ora'
+        assert 'Gene Expression Scale' in html
+
+    def test_gsea_batch_renders_and_exports_gsea(self, condition_client, monkeypatch):
+        """A BatchRecord carrying method='gsea' must not be reported as ORA.
+
+        BatchRecord has no ``method`` column on this branch, so the attribute is
+        planted on the model the route queries. That is the shape
+        ``getattr(batch, 'method', None) or 'ora'`` has to cope with once the
+        column lands on the other branch.
+        """
+        client, uuid = condition_client()
+
+        # Make the batch look like a GSEA run without adding a column this
+        # branch does not own.
+        monkeypatch.setattr(BatchRecord, 'method', 'gsea', raising=False)
+        html = client.get(f'/batch/{uuid}/condition/0').get_data(as_text=True)
+        assert _hidden_field(html, 'method') == 'gsea'
+        assert 'KE NES Scale' in html
+        assert 'Gene Expression Scale' not in html
+
+
+class TestReportResourceProvenance:
+    """Issue #74: an exported report must not inherit another run's resources.
+
+    ``generate_report`` fell back to ``session['experiment_metadata']`` when the
+    form carried no resource list, and to the literal ``'WikiPathways'`` when
+    the session was empty too. A PDF exported from a batch condition page
+    therefore reported the resources of whatever single analysis the same
+    browser session had last run.
+    """
+
+    _BASE_FORM = {
+        'format': 'html',
+        'filename': 'test.csv',
+        'gene_count': '100',
+        'significant_genes': '10',
+        'aop_id': 'AOP:1',
+        'aop_label': 'Test AOP',
+        'logfc_threshold': '1.0',
+        'pval_cutoff': '0.05',
+        'id_column': 'gene',
+        'fc_column': 'logFC',
+        'pval_column': 'adj.P.Val',
+        'id_type': 'HGNC',
+        'enrichment_results': '[]',
+    }
+
+    def _capture(self, client, form):
+        """POST the report form and return the ReportData the generator saw."""
+        captured = {}
+
+        def _fake_html_report(report_data):
+            captured['data'] = report_data
+            return '<html><body>Report</body></html>'
+
+        with patch('app.report_generator.generate_html_report', _fake_html_report):
+            response = client.post('/generate_report', data=form)
+        assert response.status_code == 200, response.data[:200]
+        return captured['data']
+
+    def test_posted_resources_win_over_the_session(self, flask_client):
+        with flask_client.session_transaction() as sess:
+            sess['experiment_metadata'] = {
+                'dataset_id': 'PREVIOUS RUN',
+                'selected_resources': 'GO_BP',
+            }
+        form = dict(self._BASE_FORM, selected_resources='WikiPathways, Reactome')
+        report = self._capture(flask_client, form)
+        assert report.selected_resources == 'WikiPathways, Reactome'
+
+    def test_empty_posted_resources_do_not_fall_back_to_the_session(self, flask_client):
+        """A batch predating #55 posts an empty field. That is not consent to
+        report the last single analysis's resources."""
+        with flask_client.session_transaction() as sess:
+            sess['experiment_metadata'] = {
+                'dataset_id': 'PREVIOUS RUN',
+                'selected_resources': 'GO_BP, Reactome',
+            }
+        form = dict(self._BASE_FORM, selected_resources='')
+        report = self._capture(flask_client, form)
+        assert report.selected_resources == 'Not recorded'
+
+    def test_absent_field_and_empty_session_is_not_wikipathways(self, flask_client):
+        report = self._capture(flask_client, dict(self._BASE_FORM))
+        assert report.selected_resources == 'Not recorded'

--- a/tests/test_batch_hub_pvalues.py
+++ b/tests/test_batch_hub_pvalues.py
@@ -1,0 +1,167 @@
+"""End-to-end coverage for per-gene p-values in a batch run (issue #75).
+
+The hub-gene panel on a batch condition page reads its "Adj. p-value" out of
+the KE-gene payload stored on the ConditionRecord. The batch runner never built
+the per-gene p-value maps, so every hub row on every condition page rendered an
+em dash while the same file analysed on its own showed a p-value.
+
+Seeding a ConditionRecord with p-values already in its ``ke_gene_json`` only
+exercises the renderer, which was never broken. These tests run the real batch
+pipeline over a real upload and then read the page, so the assertion is on the
+producer.
+"""
+import json
+import os
+import re
+import uuid as uuid_lib
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+
+import app as app_module
+from database import BatchRecord, ConditionRecord
+from services.batch_service import run_batch
+
+
+# Ten genes per KE so Fisher's test is actually computed (MIN_KE_GENES = 5).
+REFERENCE_SETS = {
+    'KE:115': {f'G{i}' for i in range(1, 11)},
+    'KE:116': {f'G{i}' for i in range(11, 21)},
+}
+
+
+def _write_dataset(path, *, adj_column=True):
+    """Write a limma-shaped TSV: G1..G10 significant, G11..G20 not.
+
+    ``adj.P.Val`` carries a value distinct from ``P.Value`` so a test can tell
+    which column reached the panel.
+    """
+    rows = []
+    for i in range(1, 21):
+        sig = i <= 10
+        row = {
+            'gene': f'G{i}',
+            'logFC': 2.0 if sig else 0.1,
+            'P.Value': 0.0001 if sig else 0.5,
+        }
+        if adj_column:
+            row['adj.P.Val'] = 0.0004 if sig else 0.8
+        rows.append(row)
+    pd.DataFrame(rows).to_csv(path, sep='\t', index=False)
+
+
+@pytest.fixture
+def aop_stub(monkeypatch):
+    """Stub load_aop_data so the batch needs no real AOP topology."""
+    def _fake_load_aop_data(aop_id):
+        ke_list = {'KE:115', 'KE:116'}
+        edges = pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID', 'AOP_ID'])
+        return ke_list, edges, {'KE:115': 'MIE', 'KE:116': 'AO'}, \
+            {'KE:115': 'Event 115', 'KE:116': 'Event 116'}
+    monkeypatch.setattr('services.data_service.load_aop_data', _fake_load_aop_data)
+
+
+@pytest.fixture
+def upload_root(tmp_path, monkeypatch):
+    root = tmp_path / 'uploads'
+    root.mkdir()
+    monkeypatch.setattr('config.Config.UPLOAD_FOLDER', str(root))
+    return str(root)
+
+
+@pytest.fixture
+def ran_batch(temp_database, aop_stub, upload_root, monkeypatch):
+    """Run a real one-condition batch and hand back the client and its UUID."""
+    monkeypatch.setattr(app_module, 'db_manager', temp_database)
+
+    def _run(*, adj_column=True, pval_column='adj.P.Val'):
+        batch_uuid = str(uuid_lib.uuid4())
+        batch_dir = os.path.join(upload_root, batch_uuid)
+        os.makedirs(batch_dir, exist_ok=True)
+        _write_dataset(os.path.join(batch_dir, 'cond0.tsv'), adj_column=adj_column)
+
+        harmonised = sorted({f'G{i}' for i in range(1, 21)})
+        session = temp_database.get_session()
+        try:
+            batch = BatchRecord(
+                uuid=batch_uuid, status='pending', aop_id='AOP:1', aop_label='Test AOP',
+                logfc_threshold=1.0, pval_cutoff=0.05,
+                selected_resources='WikiPathways', min_confidence='all',
+                id_column='gene', fc_column='logFC', pval_column=pval_column,
+                harmonised_background=json.dumps(harmonised),
+                harmonised_gene_count=len(harmonised),
+                batch_name='Hub p-value batch',
+                expires_at=datetime.now(timezone.utc).replace(tzinfo=None)
+                + timedelta(days=14),
+            )
+            session.add(batch)
+            session.flush()
+            session.add(ConditionRecord(
+                batch_id=batch.id, position=0, filename='cond0.tsv',
+                condition_label='Cond 0', status='pending',
+            ))
+            session.commit()
+            batch_id = batch.id
+        finally:
+            session.close()
+
+        run_batch(batch_id, temp_database.db_url, REFERENCE_SETS)
+        return batch_id, batch_uuid
+
+    return _run
+
+
+def _stored_ke_gene_map(db_manager, batch_id):
+    session = db_manager.get_session()
+    try:
+        cond = session.query(ConditionRecord).filter_by(
+            batch_id=batch_id, position=0
+        ).first()
+        assert cond.status == 'complete', cond.error_message
+        return json.loads(cond.ke_gene_json)
+    finally:
+        session.close()
+
+
+class TestStoredPvalues:
+    """The batch runner must persist per-gene p-values, not just fold changes."""
+
+    def test_condition_record_carries_adjusted_pvalues(self, ran_batch, temp_database):
+        batch_id, _ = ran_batch()
+        ke_gene_map = _stored_ke_gene_map(temp_database, batch_id)
+        entries = {g['id']: g for g in ke_gene_map['KE:115']}
+        assert entries['G1']['pvalue_adj'] == pytest.approx(0.0004)
+        assert entries['G1']['pvalue_raw'] == pytest.approx(0.0001)
+
+    def test_raw_only_upload_stores_the_raw_pvalue(self, ran_batch, temp_database):
+        """A batch with no adjusted column must not pass a raw value off as FDR."""
+        batch_id, _ = ran_batch(adj_column=False, pval_column='P.Value')
+        ke_gene_map = _stored_ke_gene_map(temp_database, batch_id)
+        entries = {g['id']: g for g in ke_gene_map['KE:115']}
+        assert entries['G1']['pvalue_raw'] == pytest.approx(0.0001)
+        assert entries['G1']['pvalue_adj'] is None
+
+
+class TestHubPanelRendering:
+    """The stored p-values must reach the hub table on the condition page."""
+
+    def test_hub_row_shows_the_adjusted_pvalue(self, ran_batch, flask_client):
+        _, batch_uuid = ran_batch()
+        html = flask_client.get(
+            f'/batch/{batch_uuid}/condition/0'
+        ).get_data(as_text=True)
+        row = re.search(r'<td>G1</td>.*?</tr>', html, re.DOTALL)
+        assert row, 'G1 hub row not rendered'
+        assert '4.00e-04' in row.group(0)
+        assert '&mdash;' not in row.group(0)
+
+    def test_hub_row_dashes_only_when_there_is_no_adjusted_column(
+        self, ran_batch, flask_client
+    ):
+        _, batch_uuid = ran_batch(adj_column=False, pval_column='P.Value')
+        html = flask_client.get(
+            f'/batch/{batch_uuid}/condition/0'
+        ).get_data(as_text=True)
+        row = re.search(r'<td>G1</td>.*?</tr>', html, re.DOTALL)
+        assert row and '&mdash;' in row.group(0)


### PR DESCRIPTION
Closes #74 and #75.

## #74 — the condition page named a resource list the run never used

`/batch/<uuid>/condition/<n>` re-renders the results page from stored condition data but never carried the batch's resource selection into that context, and the template defaulted the missing value to `WikiPathways`. A batch run over all three resources reported single-resource provenance — confidently and wrongly — while the batch summary for the same run reported all three. Which resources contributed gene sets decides which Key Events were testable at all, so the header was misstating the analysis it sat on top of, in the one place a reader would copy into a methods section.

Three further settings had the same shape, and they travel into a methods section together:

- the mapping-confidence threshold read *"All mappings"* on every condition page, even one run at *"High only"* — directly above the warning banner that stricter threshold had raised;
- a report exported from the page reported no column mapping at all and a p-value cutoff of `0.05` whatever the batch was run at;
- the dataset identity leaked across runs: the report generator preferred the browser session over the values the page posts, so a PDF exported from a condition page carried the dataset name, stressor, dosing and owner of whatever single analysis had last been run in the same session, under a header naming the condition.

All of these now come from the batch record, as does the enrichment method — the page had hardcoded over-representation, so with batch GSEA (#76) it would have shown a GSEA run the ORA colour scale and exported it as ORA. The invented `WikiPathways` default is gone; an unrecorded selection reads *"Not recorded"*.

## #75 — hub genes had no adjusted p-value in batch mode

The hub-gene panel reads its "Adj. p-value" from the per-gene data stored with each condition, and the batch runner never captured p-values at all — so every hub row of every condition of every batch showed an em dash, while the same file analysed on its own showed a number. Batch mode is when conditions are compared, which is when hub genes matter most, and it read as *"these genes have no adjusted p-value"* rather than *"this page failed to load them"*.

Batch runs now capture the raw and adjusted p-value columns from each uploaded file the way a single analysis does, independently of the column the batch thresholds on. This applies to **new** batches; conditions stored before this change have no p-values to show and keep the em dash.

## Verification

540 tests pass. New tests were checked to fail against the pre-fix code.