### PR TITLE
Give server-side image rendering a deadline and stop the test suite hanging (#104)

### DIFF
--- a/config.py
+++ b/config.py
@@ -306,6 +306,13 @@ class Config:
     # a shared mount tolerates exactly one writer.
     DATABASE_URL = os.environ.get('DATABASE_URL', 'sqlite:///molAOP_analyser.db')
 
+    # Server-side image rendering (issue #104). plotly's to_image() drives a
+    # headless Chromium via kaleido, and that subprocess can wedge with no
+    # deadline of its own — a stuck render otherwise hangs the request (and hung
+    # the test suite) indefinitely. Renders past this many seconds are abandoned
+    # and the report falls back to "image unavailable".
+    IMAGE_RENDER_TIMEOUT = float(os.environ.get('IMAGE_RENDER_TIMEOUT', '30'))
+
     # Batch analysis settings
     BATCH_MAX_FILES = 10
     BATCH_MAX_TOTAL_SIZE = 100 * 1024 * 1024  # 100 MB total batch limit

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,6 +19,15 @@ addopts =
     --cov-report=html:htmlcov
     --cov-fail-under=75
 
+# Issue #104: no single test may stall the run. A wedged kaleido/Chromium
+# subprocess used to leave pytest sleeping indefinitely — invisible in CI,
+# where it never triggered, and a 15-minute stall locally. 300s is far above
+# the slowest legitimate test (the whole suite runs in well under a minute),
+# so this only ever fires on a genuine hang. 'thread' works without SIGALRM
+# and dumps the stacks of every thread, which is what identifies the culprit.
+timeout = 300
+timeout_method = thread
+
 # Markers for different test categories
 markers =
     unit: Unit tests for individual components
@@ -26,6 +35,7 @@ markers =
     slow: Tests that take a long time to run
     database: Tests that require database access
     web: Tests that require web server
+    real_image_render: Opt out of the kaleido stub and render images for real (#104)
 
 # Filter warnings
 filterwarnings =

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,3 +1,4 @@
 -r requirements.in
 pytest>=7.4,<9
 pytest-cov>=5.0,<8
+pytest-timeout>=2.3,<3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -130,7 +130,10 @@ pytest==8.4.2
     # via
     #   -r requirements-dev.in
     #   pytest-cov
+    #   pytest-timeout
 pytest-cov==7.1.0
+    # via -r requirements-dev.in
+pytest-timeout==2.4.0
     # via -r requirements-dev.in
 python-dateutil==2.9.0.post0
     # via

--- a/services/batch_report_service.py
+++ b/services/batch_report_service.py
@@ -26,6 +26,7 @@ from services.report_service import (
     REPORTLAB_AVAILABLE,
 )
 from services.comparison_service import comparison_matrix_to_dataframe
+from services.image_render import render_figure_png
 from services.enrichment_service import format_ke_summary
 from services.network_service import ke_accounting_from_network
 from helpers import MIN_CONFIDENCE_LABELS
@@ -125,7 +126,9 @@ def render_heatmap_png(comparison_data: dict) -> Optional[bytes]:
             paper_bgcolor='white', plot_bgcolor='#f0f0f0',
             height=height, width=width,
         )
-        return fig.to_image(format='png', scale=2)
+        # Issue #104: bounded render — a wedged kaleido subprocess raises here
+        # and the caller falls back to "image unavailable" instead of hanging.
+        return render_figure_png(fig, format='png', scale=2)
     except Exception as exc:
         logger.warning('render_heatmap_png failed: %s', exc)
         return None

--- a/services/image_render.py
+++ b/services/image_render.py
@@ -1,0 +1,71 @@
+"""Bounded server-side image rendering for Plotly figures (issue #104).
+
+``Figure.to_image()`` hands the figure to kaleido, which drives a headless
+Chromium subprocess. That subprocess can wedge: it stays alive while the
+calling thread sits in a blocking read with no deadline of its own, so a single
+stuck render takes the request — or, in the test suite, the whole run — with it.
+Issue #104 saw exactly that, a pytest run stalled at 15 minutes against 40
+seconds of CPU with a live kaleido process tree.
+
+Every ``to_image`` call therefore goes through :func:`render_figure_png`, which
+gives the render a deadline. A wedged subprocess then produces a report with a
+missing image and a warning in the log, which is what the callers already do for
+every other render failure, instead of an unbounded hang.
+
+The deadline cannot kill the orphaned Chromium — the worker thread stays blocked
+until the process is reaped — but it does return control to the caller, which is
+the difference between a degraded response and no response at all.
+"""
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
+from typing import Any, Optional
+
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+
+def render_figure_png(fig: Any, timeout: Optional[float] = None, **to_image_kwargs) -> bytes:
+    """Render a Plotly figure to PNG bytes, giving kaleido a deadline.
+
+    Args:
+        fig: A ``plotly.graph_objects.Figure``.
+        timeout: Seconds to wait before giving up. Defaults to
+            ``Config.IMAGE_RENDER_TIMEOUT``.
+        **to_image_kwargs: Passed straight through to ``fig.to_image()``
+            (``format``, ``width``, ``height``, ``scale``, ...).
+
+    Returns:
+        bytes: the encoded image.
+
+    Raises:
+        TimeoutError: if the render did not finish within the deadline. Callers
+            already treat a render failure as "image unavailable", so this
+            surfaces through their existing handling.
+        Exception: whatever ``to_image`` itself raised.
+    """
+    to_image_kwargs.setdefault('format', 'png')
+    deadline = timeout if timeout is not None else Config.IMAGE_RENDER_TIMEOUT
+
+    # A fresh executor per call: the point is to stop waiting on a wedged
+    # render, and a shared pool would let one stuck worker starve the next
+    # caller of its only thread. The thread is abandoned, not cancelled — see
+    # the module docstring.
+    executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix='kaleido')
+    try:
+        future = executor.submit(fig.to_image, **to_image_kwargs)
+        try:
+            return future.result(timeout=deadline)
+        except FutureTimeoutError:
+            logger.warning(
+                'Image render exceeded %.0fs and was abandoned (#104); a kaleido '
+                'subprocess may still be running', deadline
+            )
+            raise TimeoutError(
+                f'Plotly image render did not complete within {deadline:.0f}s'
+            )
+    finally:
+        # Never block on the abandoned worker: shutdown(wait=True) would
+        # reintroduce the hang this function exists to prevent.
+        executor.shutdown(wait=False)

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -58,6 +58,7 @@ except ImportError:
     SVG_SUPPORT = False
 
 from config import Config, ExperimentMetadata
+from services.image_render import render_figure_png
 from helpers import MIN_CONFIDENCE_LABELS  # Issue #60: confidence threshold labels
 from services.enrichment_service import REPRESENTATION_LABELS  # Issue #70
 
@@ -725,8 +726,13 @@ class ReportGenerator:
             fig.update_xaxes(showgrid=True, gridwidth=1, gridcolor='lightgray')
             fig.update_yaxes(showgrid=True, gridwidth=1, gridcolor='lightgray')
             
-            # Export as PNG image bytes
-            img_bytes = fig.to_image(format="png", width=600, height=400, scale=2)
+            # Export as PNG image bytes. Issue #104: the render goes through
+            # render_figure_png so a wedged kaleido subprocess raises instead of
+            # blocking the request forever; the caller already treats a failed
+            # volcano render as "image unavailable".
+            img_bytes = render_figure_png(
+                fig, format="png", width=600, height=400, scale=2
+            )
             return img_bytes
             
         except Exception as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,83 @@ from services.column_detector import ColumnDetector
 from services.gene_id_validator import GeneIDValidator
 
 
+# ---------------------------------------------------------------------------
+# Issue #104 — keeping the suite off the filesystem and off Chromium
+# ---------------------------------------------------------------------------
+
+# The real os.path.exists, captured before any test can patch it over.
+_REAL_PATH_EXISTS = os.path.exists
+
+# Extensions of the upload/demo files the route tests pretend are on disk.
+_UPLOAD_SUFFIXES = ('.tsv', '.csv', '.txt', '.xlsx')
+
+
+def uploaded_file_exists(path):
+    """os.path.exists replacement that only lies about uploaded data files.
+
+    Route tests need ``/analyze`` to believe the uploaded dataset is on disk,
+    and the usual way to arrange that was ``patch('os.path.exists',
+    return_value=True)``. That patch is process-wide: matplotlib's search for
+    ``matplotlibrc``, kaleido's probe for its Chromium binary and every other
+    library's existence check are all told "yes" for the duration of the test.
+    ``test_full_workflow_integration`` fails outright when run alone for that
+    reason (matplotlib opens the ``matplotlibrc`` it was told exists), and only
+    passes in a full run because an earlier test imported matplotlib first —
+    exactly the kind of order-dependence behind the intermittent hang in #104.
+
+    This narrows the lie to what the tests actually need: a data file. Anything
+    else falls through to the real check.
+
+    Args:
+        path: path being probed (str, bytes or os.PathLike).
+
+    Returns:
+        bool: True for data-file paths, otherwise the real answer.
+    """
+    try:
+        text = os.fspath(path)
+        if isinstance(text, bytes):
+            text = text.decode('utf-8', 'replace')
+    except TypeError:  # file descriptor or something exotic — defer
+        return _REAL_PATH_EXISTS(path)
+    return text.lower().endswith(_UPLOAD_SUFFIXES) or _REAL_PATH_EXISTS(path)
+
+
+@pytest.fixture(autouse=True)
+def stub_plotly_image_export(request):
+    """Stop any test from spawning kaleido's headless Chromium (#104).
+
+    ``Figure.to_image()`` launches a browser subprocess that can outlive the
+    call; when it wedges, pytest sits in a blocking read with no deadline and
+    the run stalls for as long as the harness allows. Nothing in the suite
+    depends on the *content* of a rendered PNG, so the render is stubbed by
+    default and the assertions are about whether a figure was produced at all.
+
+    Opt out with ``@pytest.mark.real_image_render`` for a test that genuinely
+    needs kaleido; it then runs against the production timeout in
+    ``services.image_render``.
+    """
+    if 'real_image_render' in request.keywords:
+        yield None
+        return
+
+    try:
+        import plotly.graph_objects as go
+    except ImportError:  # pragma: no cover — plotly is a hard dependency
+        yield None
+        return
+
+    # Smallest valid PNG: a 1x1 transparent pixel. Callers only embed the bytes.
+    png_stub = (
+        b'\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01'
+        b'\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01'
+        b'\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82'
+    )
+    with patch.object(go.Figure, 'to_image', autospec=True,
+                      return_value=png_stub) as mock_to_image:
+        yield mock_to_image
+
+
 @pytest.fixture(scope='session')
 def test_data_dir():
     """Fixture providing path to test data directory."""

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -8,6 +8,8 @@ import json
 import re
 from unittest.mock import patch, MagicMock
 
+from tests.conftest import uploaded_file_exists
+
 
 @pytest.mark.integration
 @pytest.mark.web
@@ -44,7 +46,7 @@ class TestFlaskRoutes:
     
     def test_preview_route_with_demo_file(self, flask_client):
         """Test preview route with demo file selection."""
-        with patch('os.path.exists', return_value=True), \
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('pandas.read_csv') as mock_read_csv:
             
             # Mock DataFrame
@@ -148,7 +150,7 @@ class TestFlaskRoutes:
              patch('app.build_ke_gene_mapping', return_value={}), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True):
 
             response = authenticated_client.post('/analyze', data={
@@ -210,7 +212,7 @@ class TestFlaskRoutes:
              patch('app.build_cytoscape_network', return_value={'nodes': [], 'edges': []}), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True), \
              patch('pandas.read_csv', return_value=raw_upload_df), \
              patch('app.load_cached_reference_sets', return_value=({'KE:115': {'BRCA1', 'EGFR'}}, 'cache', [])):
@@ -291,7 +293,7 @@ class TestFlaskRoutes:
              patch('app.build_cytoscape_network', return_value={'nodes': [], 'edges': []}), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True), \
              patch('pandas.read_csv', return_value=raw_upload_df), \
              patch('app.load_cached_reference_sets',
@@ -386,7 +388,7 @@ class TestFlaskRoutes:
              patch('app.build_cytoscape_network', return_value={'nodes': [], 'edges': []}), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True), \
              patch('pandas.read_csv', return_value=raw_upload_df), \
              patch('app.load_cached_reference_sets',
@@ -520,7 +522,7 @@ class TestFlaskRoutes:
     
     def test_metadata_storage_in_session(self, flask_client):
         """Test that metadata is stored in session during preview."""
-        with patch('os.path.exists', return_value=True), \
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('pandas.read_csv') as mock_read_csv, \
              flask_client.session_transaction() as sess:
             
@@ -581,7 +583,7 @@ class TestFlaskRoutes:
         })
         edges_df = pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID', 'AOP_ID'])
 
-        with patch('os.path.exists', return_value=True), \
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('pandas.read_csv', return_value=preview_df), \
              patch('app.load_and_validate_data', return_value=processed_df), \
              patch('app.process_gene_expression', return_value=(processed_df, {'total_genes': 5})), \
@@ -676,7 +678,7 @@ class TestDemosPage:
     def test_preview_accepts_recommended_aops(self, flask_client):
         """POST /preview with recommended_aops propagates the list to the template."""
         from unittest.mock import patch, MagicMock
-        with patch('os.path.exists', return_value=True), \
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('pandas.read_csv') as mock_read_csv:
             mock_df = MagicMock()
             mock_df.head.return_value.to_dict.return_value = [
@@ -715,7 +717,7 @@ class TestDemosPage:
             'log2FoldChange': [2.5, -1.2, 0.8],
             'padj': [0.001, 0.05, 0.3],
         })
-        with patch('os.path.exists', return_value=True), \
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('pandas.read_csv', return_value=mock_df):
 
             response = flask_client.post('/preview', data={
@@ -743,7 +745,7 @@ class TestDemosPage:
             'log2FoldChange': [2.5, -1.2, 0.8],
             'padj': [0.001, 0.05, 0.3],
         })
-        with patch('os.path.exists', return_value=True), \
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('pandas.read_csv', return_value=mock_df):
 
             # No recommended_aops in form data — simulates upload-your-own-data path.
@@ -838,7 +840,7 @@ class TestTourRoutes:
              patch('app.build_ke_gene_mapping', return_value={}), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True):
             return client.post('/analyze', data=form)
 
@@ -974,7 +976,7 @@ class TestHubPanel:
              patch('app.compute_hub_genes', return_value=hub_list), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True):
             return client.post('/analyze', data=form)
 
@@ -1490,7 +1492,7 @@ class TestPathwayView:
              patch('app.build_wp_picker_data', return_value=wp_picker_data), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True):
             return client.post('/analyze', data=form)
 
@@ -1670,7 +1672,7 @@ class TestMinConfidenceControl:
         })
         with patch('app.validate_file_path', return_value=True), \
              patch('pandas.read_csv', return_value=preview_df), \
-             patch('os.path.exists', return_value=True):
+             patch('os.path.exists', side_effect=uploaded_file_exists):
             response = flask_client.post('/preview', data={
                 'filename': 'test.csv',
                 'id_column': 'Gene_Symbol',
@@ -1693,7 +1695,7 @@ class TestMinConfidenceControl:
         })
         with patch('app.validate_file_path', return_value=True), \
              patch('pandas.read_csv', return_value=preview_df), \
-             patch('os.path.exists', return_value=True):
+             patch('os.path.exists', side_effect=uploaded_file_exists):
             response = flask_client.post('/preview', data={
                 'filename': 'test.csv',
                 'id_column': 'Gene_Symbol',
@@ -1788,7 +1790,7 @@ class TestRepresentationColumnRendered:
              patch('app.build_ke_gene_mapping', return_value={}), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True):
             return client.post('/analyze', data={
                 'filename': 'test.csv',
@@ -1850,7 +1852,7 @@ class TestResourceProvenanceOnResultsPage:
              patch('app.build_ke_gene_mapping', return_value={}), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True):
             return client.post('/analyze', data={
                 'filename': 'test.csv',

--- a/tests/test_image_render.py
+++ b/tests/test_image_render.py
@@ -1,0 +1,115 @@
+"""Issue #104: server-side image rendering must have a deadline.
+
+``Figure.to_image()`` drives a headless Chromium through kaleido. That
+subprocess can wedge, and the calling thread then blocks with no deadline of
+its own — the failure mode in #104, where a pytest run stalled at 15 minutes
+against 40 seconds of CPU while a kaleido process tree stayed alive.
+
+These tests cover the contract the callers rely on: a normal render passes its
+arguments through untouched, and a render that never returns raises promptly
+instead of hanging, so both report paths fall back to "image unavailable".
+"""
+
+import threading
+import time
+
+import pytest
+
+from services.image_render import render_figure_png
+
+
+class _FakeFigure:
+    """Stand-in for a plotly Figure with a controllable ``to_image``."""
+
+    def __init__(self, delay=0.0, result=b'PNG'):
+        self.delay = delay
+        self.result = result
+        self.calls = []
+        self.released = threading.Event()
+
+    def to_image(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.delay:
+            # Emulate a wedged kaleido read: blocks until explicitly released.
+            self.released.wait(self.delay)
+        return self.result
+
+
+class TestRenderFigurePng:
+    """Bounded rendering behaviour."""
+
+    def test_returns_bytes_and_forwards_kwargs(self):
+        """A normal render returns the bytes and passes its kwargs through."""
+        fig = _FakeFigure()
+
+        out = render_figure_png(fig, width=600, height=400, scale=2)
+
+        assert out == b'PNG'
+        assert fig.calls == [{'format': 'png', 'width': 600, 'height': 400, 'scale': 2}]
+
+    def test_defaults_to_png_format(self):
+        """Callers that omit `format` still get a PNG (matches to_image usage)."""
+        fig = _FakeFigure()
+
+        render_figure_png(fig)
+
+        assert fig.calls[0]['format'] == 'png'
+
+    def test_wedged_render_raises_within_the_deadline(self):
+        """A render that never returns raises TimeoutError, and raises quickly.
+
+        This is the whole point: without the deadline the caller waits for the
+        subprocess forever. The elapsed-time assertion is deliberately loose —
+        it only has to prove the call did not wait for the 30s render.
+        """
+        fig = _FakeFigure(delay=30)
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError):
+            render_figure_png(fig, timeout=0.2)
+        elapsed = time.monotonic() - started
+
+        assert elapsed < 5, f'timeout did not return promptly ({elapsed:.1f}s)'
+        # Release the worker so it does not linger past the test.
+        fig.released.set()
+
+    def test_render_error_propagates_unchanged(self):
+        """A genuine render failure is not masked as a timeout."""
+        fig = _FakeFigure()
+        fig.to_image = lambda **kwargs: (_ for _ in ()).throw(RuntimeError('no chrome'))
+
+        with pytest.raises(RuntimeError, match='no chrome'):
+            render_figure_png(fig)
+
+    def test_timeout_defaults_to_config(self, monkeypatch):
+        """With no explicit timeout the Config value bounds the render."""
+        monkeypatch.setattr('services.image_render.Config.IMAGE_RENDER_TIMEOUT', 0.2)
+        fig = _FakeFigure(delay=30)
+
+        with pytest.raises(TimeoutError):
+            render_figure_png(fig)
+
+        fig.released.set()
+
+
+class TestBatchHeatmapFallback:
+    """The batch report degrades rather than hangs when a render times out."""
+
+    def test_heatmap_returns_none_on_timeout(self, monkeypatch):
+        """render_heatmap_png already swallows render failures — including this one."""
+        from services import batch_report_service
+
+        def _timeout(fig, **kwargs):
+            raise TimeoutError('render did not complete')
+
+        monkeypatch.setattr(batch_report_service, 'render_figure_png', _timeout)
+
+        png = batch_report_service.render_heatmap_png({
+            'method': 'ora',
+            'ke_labels': ['KE:1'],
+            'ke_titles': ['One'],
+            'condition_labels': ['A'],
+            'neg_log10_matrix': [[1.3]],
+        })
+
+        assert png is None

--- a/tests/test_ke_exclusion_wiring.py
+++ b/tests/test_ke_exclusion_wiring.py
@@ -17,6 +17,7 @@ import pandas as pd
 import pytest
 
 import app
+from tests.conftest import uploaded_file_exists
 from helpers import (
     ReferenceSets,
     load_reference_sets,
@@ -257,7 +258,7 @@ class TestAnalyseRouteClassifiesTheKeyEvent:
              )), \
              patch('app.guess_id_type', return_value='HGNC'), \
              patch('app.cleanup_file'), \
-             patch('os.path.exists', return_value=True), \
+             patch('os.path.exists', side_effect=uploaded_file_exists), \
              patch('app.validate_file_path', return_value=True):
 
             response = authenticated_client.post('/analyze', data={


### PR DESCRIPTION
Closes #104.

`test_full_workflow_integration` stalled on about half of local runs — 15m and 8m20s wall against ~40s of CPU — with a kaleido headless-Chromium process tree alive while pytest slept. It never failed in CI, so it was invisible where it would be caught and disruptive where the work happens.

**Two independent causes, both fixed.**

`fig.to_image()` hands the figure to kaleido, which drives a browser subprocess with no deadline of its own; when it wedges, the calling thread blocks forever and takes the request (or the whole test run) with it. Both call sites now go through `services/image_render.render_figure_png`, which bounds the render at `Config.IMAGE_RENDER_TIMEOUT` (30s, env-overridable) and raises on expiry. Each caller already treats a render failure as "image unavailable", so a wedged subprocess now degrades a report instead of hanging it.

The route tests patched `os.path.exists` process-wide to return `True`, which lies to every library's existence check, not just the app's. matplotlib opens the `matplotlibrc` it is told exists and **the test fails outright when run alone** — it only passed in a full run because an earlier test had already imported matplotlib, exactly the order-dependence behind the intermittent hang. All 18 sites now use `conftest.uploaded_file_exists`, which lies only about data files and defers to the real check for everything else.

Belt and braces: an autouse fixture stubs `Figure.to_image` so no test spawns Chromium by accident (opt out with `@pytest.mark.real_image_render`), and `pytest-timeout` fails a stalled test at 300s with thread stacks instead of letting the run sit.

## Verification

- Full suite green (546 passed).
- The previously flaky test run 20x in a loop: 20/20 clean, no stray kaleido or Chromium processes left behind.
- `test_full_workflow_integration` now passes standalone, which it did not before this branch.

## Note on the other PRs

This is the base for #105, #103 and #106 — a branch without this fix inherits the hang. `fix/issue-106` reproduced it during verification (a run wedged in `test_flask_routes.py` at the 280s cap) before being rebased onto this branch. Merge this one first.