### PR TITLE
Count GO and Reactome towards an AOP's gene-set coverage (#105)

### DIFF
--- a/services/aop_discovery_service.py
+++ b/services/aop_discovery_service.py
@@ -17,7 +17,13 @@ Each AOP entry has the shape::
         "title":          "Some title",
         "ke_count":       12,
         "mapped_ke_count": 4,
+        "mapped_ke_by_resource": {"WikiPathways": 4, "GO_BP": 1, "Reactome": 0},
     }
+
+``mapped_ke_count`` is the number of KEs with a gene set in *any* resource —
+the union, not the WikiPathways count (issue #105) — and
+``mapped_ke_by_resource`` breaks that down. Note the union is generally smaller
+than the sum: one KE often carries mappings in several resources.
 
 Mapped AOPs (mapped_ke_count > 0) are sorted first by mapped_ke_count descending;
 unmapped AOPs follow sorted by aop_id.
@@ -32,8 +38,16 @@ from SPARQLWrapper import JSON, SPARQLWrapper
 
 logger = logging.getLogger(__name__)
 
-# Disk-cache key for the full AOP list.
-AOP_LIST_CACHE_KEY = "aop_discovery_list_v1"
+# Disk-cache key for the full AOP list. Bumped to v2 with issue #105: the
+# meaning of mapped_ke_count changed (WikiPathways-only -> union across
+# resources) and the TTL is a week, so a v1 entry would keep serving the old,
+# under-reported counts long after the deploy.
+AOP_LIST_CACHE_KEY = "aop_discovery_list_v2"
+
+# Gene-set resources whose KE mappings count towards a KE being "mapped".
+# Mirrors app.VALID_RESOURCES — the resources an analysis can actually be run
+# with — and is defined here to keep this service free of an app-level import.
+MAPPING_RESOURCES = ("WikiPathways", "GO_BP", "Reactome")
 
 # 1-week TTL in seconds
 AOP_LIST_CACHE_TTL = 7 * 24 * 3600
@@ -206,11 +220,14 @@ WHERE {
 # ---------------------------------------------------------------------------
 
 def fetch_mapped_ke_ids_from_builder(config) -> Set[str]:
-    """Fetch all KE IDs that have Builder API gene-set mappings.
+    """Fetch the KE IDs that have a Builder WikiPathways gene-set mapping.
 
     Uses the existing ``api_service._make_api_session`` and
     ``api_service.fetch_all_ke_wp_mappings`` to retrieve all KE-WP
     mapping records, then extracts and normalises the KE IDs.
+
+    This covers WikiPathways only; :func:`fetch_mapped_ke_ids_by_resource` is
+    the function that answers "which KEs have a gene set at all" (issue #105).
 
     If ``config.BUILDER_API_URL`` is empty, returns an empty set
     (graceful degradation — all AOPs will appear unmapped).
@@ -256,6 +273,61 @@ def fetch_mapped_ke_ids_from_builder(config) -> Set[str]:
     except Exception as exc:
         logger.warning("Builder API fetch for mapped KEs failed: %s", exc)
         return set()
+
+
+def fetch_mapped_ke_ids_by_resource(config) -> Dict[str, Set[str]]:
+    """Fetch mapped KE IDs per gene-set resource (issue #105).
+
+    The picker's coverage figure used to come from
+    :func:`fetch_mapped_ke_ids_from_builder` alone, which is the WikiPathways
+    mapping endpoint. GO Biological Process and Reactome mappings were never
+    consulted, so a Key Event carrying only a GO term counted as unmapped — on
+    AOP:472 that hid KE:1097 (``GO:0097300``) and the picker read "6/9" for an
+    AOP with seven mapped KEs. Worse, an AOP mapped *only* through GO and/or
+    Reactome scored zero and was filtered out of the picker's mapped list
+    entirely, though it would analyse perfectly well.
+
+    GO and Reactome gene sets are resolved Builder-side and served as GMT
+    exports, so their KE IDs are simply the keys of the parsed export — the
+    same call the analysis itself uses (``api_service.fetch_gmt_reference_sets``).
+
+    Each resource is fetched independently and a failure degrades that resource
+    to an empty set: a Reactome outage must not erase WikiPathways coverage.
+
+    Args:
+        config: Application config object (``BUILDER_API_URL``,
+                ``BUILDER_API_TIMEOUT``).
+
+    Returns:
+        ``{resource: {KE IDs}}`` for every resource in ``MAPPING_RESOURCES``,
+        always with all keys present (empty sets where nothing resolved).
+    """
+    by_resource: Dict[str, Set[str]] = {r: set() for r in MAPPING_RESOURCES}
+    by_resource["WikiPathways"] = fetch_mapped_ke_ids_from_builder(config)
+
+    if not config.BUILDER_API_URL:
+        return by_resource
+
+    from services.api_service import fetch_gmt_reference_sets
+
+    for resource in MAPPING_RESOURCES:
+        if resource == "WikiPathways":
+            continue
+        try:
+            by_resource[resource] = set(fetch_gmt_reference_sets(config, resource))
+            logger.info(
+                "Builder GMT export: %d mapped KE IDs for %s",
+                len(by_resource[resource]),
+                resource,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Builder GMT fetch for %s failed (%s); its coverage will read 0",
+                resource,
+                exc,
+            )
+
+    return by_resource
 
 
 def fetch_aops_from_builder(config) -> List[Dict]:
@@ -326,8 +398,8 @@ def build_aop_list(config) -> List[Dict]:
     """Build the complete AOP list with mapping coverage annotations.
 
     Fetches AOPs and KE membership from SPARQL and mapped KE IDs from
-    the Builder API in parallel, then cross-references to compute
-    ``mapped_ke_count`` for each AOP.
+    the Builder (all three gene-set resources) in parallel, then
+    cross-references to compute ``mapped_ke_count`` for each AOP.
 
     Sorting:
         - Mapped AOPs (``mapped_ke_count > 0``) first, sorted by
@@ -339,7 +411,8 @@ def build_aop_list(config) -> List[Dict]:
 
     Returns:
         List of AOP dicts with keys ``aop_id``, ``title``, ``ke_count``,
-        ``mapped_ke_count``.
+        ``mapped_ke_count`` (union across resources) and
+        ``mapped_ke_by_resource``.
 
     Raises:
         Exception: If the SPARQL fetch fails (Builder API failure is
@@ -348,12 +421,12 @@ def build_aop_list(config) -> List[Dict]:
     # Fetch SPARQL data and Builder API data in parallel
     aops: List[Dict] = []
     ke_to_aop: Dict[str, List[str]] = {}
-    mapped_ke_ids: Set[str] = set()
+    mapped_by_resource: Dict[str, Set[str]] = {r: set() for r in MAPPING_RESOURCES}
 
     with ThreadPoolExecutor(max_workers=3) as executor:
         future_aops = executor.submit(fetch_all_aops_from_sparql)
         future_ke_map = executor.submit(_build_ke_to_aop_map)
-        future_builder = executor.submit(fetch_mapped_ke_ids_from_builder, config)
+        future_builder = executor.submit(fetch_mapped_ke_ids_by_resource, config)
 
         for future in as_completed([future_aops, future_ke_map, future_builder]):
             if future is future_aops:
@@ -365,20 +438,34 @@ def build_aop_list(config) -> List[Dict]:
                     logger.warning("KE->AOP map fetch failed: %s", exc)
             else:
                 try:
-                    mapped_ke_ids = future.result()
+                    mapped_by_resource = future.result()
                 except Exception as exc:
                     logger.warning("Builder API fetch failed: %s", exc)
 
-    # Build AOP -> mapped KE count index from the KE->AOP membership map
-    aop_to_mapped_count: Dict[str, int] = {}
-    for ke_id, aop_ids in ke_to_aop.items():
-        if ke_id in mapped_ke_ids:
-            for aop_id in aop_ids:
-                aop_to_mapped_count[aop_id] = aop_to_mapped_count.get(aop_id, 0) + 1
+    # A KE counts as mapped if ANY resource has a gene set for it (#105).
+    mapped_ke_ids: Set[str] = set().union(*mapped_by_resource.values())
 
-    # Annotate each AOP with its mapped KE count
+    # Build AOP -> mapped KE counts from the KE->AOP membership map: the union
+    # count that drives the picker, plus the per-resource breakdown behind it.
+    aop_to_mapped_count: Dict[str, int] = {}
+    aop_to_resource_counts: Dict[str, Dict[str, int]] = {}
+    for ke_id, aop_ids in ke_to_aop.items():
+        for aop_id in aop_ids:
+            if ke_id in mapped_ke_ids:
+                aop_to_mapped_count[aop_id] = aop_to_mapped_count.get(aop_id, 0) + 1
+            counts = aop_to_resource_counts.setdefault(
+                aop_id, {r: 0 for r in MAPPING_RESOURCES}
+            )
+            for resource, ke_ids in mapped_by_resource.items():
+                if ke_id in ke_ids:
+                    counts[resource] += 1
+
+    # Annotate each AOP with its mapped KE counts
     for aop in aops:
         aop["mapped_ke_count"] = aop_to_mapped_count.get(aop["aop_id"], 0)
+        aop["mapped_ke_by_resource"] = aop_to_resource_counts.get(
+            aop["aop_id"], {r: 0 for r in MAPPING_RESOURCES}
+        )
 
     # Merge in configured AOPs from Config that are absent from SPARQL results
     from config import Config  # local import to avoid circular deps
@@ -404,7 +491,9 @@ def build_aop_list(config) -> List[Dict]:
                 "title": entry.get("label", aop_id),
                 "ke_count": ke_count,
                 # Treat configured AOPs as fully mapped so the typeahead shows
-                # them on focus with a meaningful "N/N KEs mapped" badge.
+                # them on focus with a meaningful "N/N" coverage badge. No
+                # per-resource breakdown is claimed for them — the number is a
+                # placeholder, not a measurement, so the tooltip stays absent.
                 "mapped_ke_count": ke_count or 1,
             })
             logger.info("Merged configured AOP %s into discovery list (%d KEs)", aop_id, ke_count)

--- a/templates/_batch_analysis_scripts.html
+++ b/templates/_batch_analysis_scripts.html
@@ -701,9 +701,34 @@ document.getElementById('btn-cancel-batch').addEventListener('click', function()
 
     var debounceTimer;
 
+    // Human-readable resource names for the coverage breakdown (#105).
+    var RESOURCE_LABELS = [
+        ['WikiPathways', 'WikiPathways'],
+        ['GO_BP', 'GO BP'],
+        ['Reactome', 'Reactome']
+    ];
+
+    /**
+     * Describe which resources contribute an AOP's KE coverage (#105).
+     * Empty string when the entry carries no breakdown (Builder-only and
+     * configured-AOP tiers), where per-resource numbers would be invented.
+     */
+    function coverageBreakdown(aop) {
+        var counts = aop.mapped_ke_by_resource;
+        if (!counts) return '';
+        return RESOURCE_LABELS
+            .filter(function (pair) { return counts[pair[0]] !== undefined; })
+            .map(function (pair) { return pair[1] + ' ' + counts[pair[0]]; })
+            .join(', ');
+    }
+
+    // #105: the coverage figure counts KEs with a gene set in any resource
+    // (WikiPathways, GO BP, Reactome), not WikiPathways alone — and says
+    // "have gene sets", not "mapped" and not "testable": no dataset has been
+    // uploaded yet, so nothing here knows which of a KE's genes were measured.
     function formatLabel(aop) {
         var mappedInfo = aop.mapped_ke_count > 0
-            ? ' -- ' + aop.mapped_ke_count + '/' + aop.ke_count + ' KEs mapped'
+            ? ' -- ' + aop.mapped_ke_count + '/' + aop.ke_count + ' KEs have gene sets'
             : '';
         return aop.aop_id + ': ' + aop.title + ' (' + aop.ke_count + ' KEs' + mappedInfo + ')';
     }
@@ -735,7 +760,11 @@ document.getElementById('btn-cancel-batch').addEventListener('click', function()
             if (aop.mapped_ke_count > 0) {
                 var info = document.createElement('span');
                 info.className = 'mapped-info';
-                info.textContent = ' -- ' + aop.mapped_ke_count + '/' + aop.ke_count + ' KEs mapped';
+                info.textContent = ' -- ' + aop.mapped_ke_count + '/' + aop.ke_count + ' KEs have gene sets';
+                var breakdown = coverageBreakdown(aop);
+                if (breakdown) {
+                    info.title = 'Key Events with gene sets, by resource: ' + breakdown;
+                }
                 li.appendChild(info);
             }
 

--- a/templates/_single_analysis_scripts.html
+++ b/templates/_single_analysis_scripts.html
@@ -421,13 +421,49 @@ function setPercentageThreshold(percentage) {
     let debounceTimer;
 
     /**
+     * Human-readable resource names for the coverage breakdown (#105).
+     */
+    const RESOURCE_LABELS = {
+        WikiPathways: 'WikiPathways',
+        GO_BP: 'GO BP',
+        Reactome: 'Reactome'
+    };
+
+    /**
+     * Describe which resources contribute an AOP's KE coverage (#105).
+     *
+     * The headline number is the union across WikiPathways, GO BP and
+     * Reactome, so it cannot show that (say) a single KE is covered by GO
+     * alone. This breakdown does. Returns '' for entries with no breakdown —
+     * the Builder-only and configured-AOP tiers, where per-resource numbers
+     * would be invented rather than measured.
+     *
+     * @param {Object} aop - AOP dict from /api/aops
+     * @returns {string} e.g. "WikiPathways 6, GO BP 1, Reactome 0"
+     */
+    function coverageBreakdown(aop) {
+        const counts = aop.mapped_ke_by_resource;
+        if (!counts) return '';
+        return Object.keys(RESOURCE_LABELS)
+            .filter(key => counts[key] !== undefined)
+            .map(key => `${RESOURCE_LABELS[key]} ${counts[key]}`)
+            .join(', ');
+    }
+
+    /**
      * Format a single AOP object into a human-readable label.
+     *
+     * #105: the coverage figure counts KEs with a gene set in any resource,
+     * not just WikiPathways, and says "have gene sets" rather than "mapped" —
+     * and deliberately not "testable", since no dataset has been uploaded yet
+     * and so nothing here knows how many of a KE's genes were measured.
+     *
      * @param {Object} aop - AOP dict from /api/aops
      * @returns {string}
      */
     function formatLabel(aop) {
         const mappedInfo = aop.mapped_ke_count > 0
-            ? ` -- ${aop.mapped_ke_count}/${aop.ke_count} KEs mapped`
+            ? ` -- ${aop.mapped_ke_count}/${aop.ke_count} KEs have gene sets`
             : '';
         return `${aop.aop_id}: ${aop.title} (${aop.ke_count} KEs${mappedInfo})`;
     }
@@ -475,11 +511,16 @@ function setPercentageThreshold(percentage) {
             mainText.textContent = `${aop.aop_id}: ${aop.title} (${aop.ke_count} KEs)`;
             li.appendChild(mainText);
 
-            // Mapping info badge
+            // Mapping info badge. The per-resource breakdown rides along as a
+            // tooltip so the union count can be traced to its sources (#105).
             if (aop.mapped_ke_count > 0) {
                 const info = document.createElement('span');
                 info.className = 'mapped-info';
-                info.textContent = ` -- ${aop.mapped_ke_count}/${aop.ke_count} KEs mapped`;
+                info.textContent = ` -- ${aop.mapped_ke_count}/${aop.ke_count} KEs have gene sets`;
+                const breakdown = coverageBreakdown(aop);
+                if (breakdown) {
+                    info.title = `Key Events with gene sets, by resource: ${breakdown}`;
+                }
                 li.appendChild(info);
             }
 

--- a/tests/test_aop_discovery.py
+++ b/tests/test_aop_discovery.py
@@ -150,6 +150,136 @@ class TestFetchMappedKeIds:
         assert "KE:709" in result
 
 
+class TestFetchMappedKeIdsByResource:
+    """Issue #105: coverage must count GO BP and Reactome, not WikiPathways alone."""
+
+    def _patch_builder(self, wp_ids, gmt_sets):
+        """Patch both Builder fetch paths.
+
+        Args:
+            wp_ids: KE IDs the WikiPathways mapping endpoint reports.
+            gmt_sets: {resource: reference-set dict or Exception to raise}.
+        """
+        import services.api_service as api_svc
+        from services import aop_discovery_service as svc
+
+        def _fake_gmt(config, resource):
+            value = gmt_sets[resource]
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        return (
+            patch.object(svc, "fetch_mapped_ke_ids_from_builder", return_value=set(wp_ids)),
+            patch.object(api_svc, "fetch_gmt_reference_sets", side_effect=_fake_gmt),
+        )
+
+    def test_go_and_reactome_ke_ids_are_included(self):
+        """A KE mapped only through GO must appear — the AOP:472 / KE:1097 case."""
+        from services.aop_discovery_service import fetch_mapped_ke_ids_by_resource
+
+        config = _make_config(builder_url="https://builder.example.com")
+        p1, p2 = self._patch_builder(
+            wp_ids={"KE:1194", "KE:177"},
+            gmt_sets={"GO_BP": {"KE:1097": {"TP53"}}, "Reactome": {"KE:177": {"MYC"}}},
+        )
+        with p1, p2:
+            result = fetch_mapped_ke_ids_by_resource(config)
+
+        assert result["WikiPathways"] == {"KE:1194", "KE:177"}
+        assert result["GO_BP"] == {"KE:1097"}
+        assert result["Reactome"] == {"KE:177"}
+
+    def test_one_failing_resource_does_not_erase_the_others(self):
+        """A Reactome outage must not cost WikiPathways its coverage."""
+        from services.aop_discovery_service import fetch_mapped_ke_ids_by_resource
+
+        config = _make_config(builder_url="https://builder.example.com")
+        p1, p2 = self._patch_builder(
+            wp_ids={"KE:55"},
+            gmt_sets={"GO_BP": {"KE:99": {"EGFR"}}, "Reactome": RuntimeError("HTTP 502")},
+        )
+        with p1, p2:
+            result = fetch_mapped_ke_ids_by_resource(config)
+
+        assert result["WikiPathways"] == {"KE:55"}
+        assert result["GO_BP"] == {"KE:99"}
+        assert result["Reactome"] == set()
+
+    def test_empty_url_returns_all_resources_empty(self):
+        """No Builder configured: every resource is present and empty."""
+        from services.aop_discovery_service import (
+            MAPPING_RESOURCES,
+            fetch_mapped_ke_ids_by_resource,
+        )
+
+        result = fetch_mapped_ke_ids_by_resource(_make_config(builder_url=""))
+
+        assert set(result) == set(MAPPING_RESOURCES)
+        assert all(v == set() for v in result.values())
+
+
+class TestBuildAopListCoverage:
+    """Issue #105: mapped_ke_count is the union across resources."""
+
+    def _build(self, mapped_by_resource):
+        """Run build_aop_list over a fixed two-AOP world."""
+        from services import aop_discovery_service as svc
+
+        aops = [
+            {"aop_id": "AOP:472", "title": "DNA adducts", "ke_count": 3},
+            {"aop_id": "AOP:900", "title": "GO-only AOP", "ke_count": 1},
+        ]
+        ke_to_aop = {
+            "KE:1194": ["AOP:472"],
+            "KE:1097": ["AOP:472"],
+            "KE:999": ["AOP:472"],
+            "KE:777": ["AOP:900"],
+        }
+        with patch.object(svc, "fetch_all_aops_from_sparql", return_value=aops), \
+             patch.object(svc, "_build_ke_to_aop_map", return_value=ke_to_aop), \
+             patch.object(svc, "fetch_mapped_ke_ids_by_resource",
+                          return_value=mapped_by_resource):
+            built = svc.build_aop_list(_make_config(builder_url="https://b.example"))
+        return {a["aop_id"]: a for a in built}
+
+    def test_union_counts_a_go_only_ke(self):
+        """KE:1097 carries only a GO term but still counts as covered."""
+        by_id = self._build({
+            "WikiPathways": {"KE:1194"},
+            "GO_BP": {"KE:1097"},
+            "Reactome": set(),
+        })
+
+        assert by_id["AOP:472"]["mapped_ke_count"] == 2
+        assert by_id["AOP:472"]["mapped_ke_by_resource"] == {
+            "WikiPathways": 1, "GO_BP": 1, "Reactome": 0
+        }
+
+    def test_ke_mapped_in_several_resources_counts_once(self):
+        """The headline number is a union, not a sum."""
+        by_id = self._build({
+            "WikiPathways": {"KE:1194"},
+            "GO_BP": {"KE:1194"},
+            "Reactome": {"KE:1194"},
+        })
+
+        assert by_id["AOP:472"]["mapped_ke_count"] == 1
+        assert by_id["AOP:472"]["mapped_ke_by_resource"] == {
+            "WikiPathways": 1, "GO_BP": 1, "Reactome": 1
+        }
+
+    def test_go_only_aop_is_not_treated_as_unmapped(self):
+        """An AOP mapped only via GO used to score 0 and be filtered out of the picker."""
+        by_id = self._build({
+            "WikiPathways": set(),
+            "GO_BP": {"KE:777"},
+            "Reactome": set(),
+        })
+
+        assert by_id["AOP:900"]["mapped_ke_count"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Integration: three-tier fallback
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #105.

Based on #109 (the test-suite fix) — merge that first; this diff is one commit.

`build_aop_list()` derived `mapped_ke_count` from `fetch_mapped_ke_ids_from_builder()`, which reads the Builder's **WikiPathways** mapping endpoint. GO BP and Reactome mappings were never consulted, so the picker under-reported coverage wherever they contribute: AOP:472 read "6/9 KEs mapped" though seven of its KEs carry mappings — the missing one, KE:1097, has only `GO:0097300`.

The label was also wrong as worded, and the number did more than label. The picker filters on `mapped_ke_count > 0`, so an AOP whose KEs are mapped only through GO and/or Reactome scored zero and was dropped from the mapped list and sorted with the unmapped ones, despite analysing perfectly well. Sorting by the same field carried the same bias.

## What changed

`fetch_mapped_ke_ids_by_resource()` returns KE IDs per resource — the GMT exports already serving GO BP and Reactome supply theirs as their keys, the same call the analysis itself makes — and each resource fails independently, so a Reactome outage cannot erase WikiPathways coverage. `mapped_ke_count` becomes the union across resources (a KE mapped three ways still counts once) and `mapped_ke_by_resource` carries the breakdown.

Both pickers now say **"7/9 KEs have gene sets"** and expose the breakdown as a tooltip. Not "mapped", which was never what was counted, and deliberately not "testable": no dataset has been uploaded at that point, so nothing there can know how many of a KE's genes were measured.

The disk-cache key moves to `v2` — the meaning of the number changed and the TTL is a week, so a v1 entry would keep serving the old counts long after deploy.

## Verification

Against the live Builder, AOP:472 now reports `mapped_ke_count: 7`, `ke_count: 9`, breakdown `WikiPathways 6, GO_BP 4, Reactome 4`. Per-resource KE coverage confirmed as WikiPathways 95, GO_BP 7, Reactome 5, union 98; KE:1097 resolves through GO_BP alone, as the issue reports. Full suite green (552 passed), including new tests for the union count, the one-failing-resource case and the GO-only AOP that used to be filtered out.