### PR TITLE
Report the discarded symbol-less rows next to the background size (#103)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1169,6 +1169,10 @@ def analyze():
                 wp_picker_data=wp_picker_data,  # Phase 999.4: pathway view picker (None when no mappings)
                 ke_summary=ke_summary,  # Issue #65: tested/excluded KE accounting
                 background_overlap=background_overlap,  # Issue #69: ID-column sanity check
+                # Issue #103: rows the loader discarded for having no gene
+                # symbol. Reported next to the background so a slightly wrong
+                # ID column shows as a visible loss, not a plausible number.
+                dropped_rows=stats.get('dropped_unidentified_rows'),
             ),
         )
 
@@ -1340,6 +1344,14 @@ def generate_report():
             filename=request.form.get('filename', metadata.get('filename', 'unknown')),
             gene_count=int(request.form.get('gene_count', 0)),
             significant_genes=int(request.form.get('significant_genes', 0)),
+            # Issue #103: blank (or absent, from a page cached before the field
+            # existed) means the count was never recorded, which the report says
+            # rather than printing a zero it cannot vouch for.
+            dropped_rows=(
+                int(request.form['dropped_rows'])
+                if request.form.get('dropped_rows', '').strip().isdigit()
+                else None
+            ),
             aop_id=request.form.get('aop_id', ''),
             aop_label=request.form.get('aop_label', ''),
             logfc_threshold=float(request.form.get('logfc_threshold', 0.0)),
@@ -2635,6 +2647,9 @@ def batch_condition_results(batch_uuid_str, position):
                 # /analyze results page only — shared results and batch-condition
                 # re-renders are explicitly out of scope this phase.
                 wp_picker_data=None,
+                # Issue #103: NULL for conditions run before the count was
+                # persisted, which renders nothing rather than a false zero.
+                dropped_rows=cond.dropped_unidentified_rows,
             ),
         )
     finally:

--- a/database.py
+++ b/database.py
@@ -294,6 +294,11 @@ class ConditionRecord(Base):
     gene_count = Column(Integer)
     significant_genes = Column(Integer)
 
+    # Issue #103: rows in this condition's file that carried no usable gene
+    # identifier and were discarded during loading. NULL on rows written before
+    # the count was persisted — which must render as nothing, not as zero.
+    dropped_unidentified_rows = Column(Integer, nullable=True)
+
     # Issue #69: fraction of this condition's identifiers that matched the
     # reference gene universe. NULL on rows written before the check existed.
     # A low value means the gene ID column was probably not gene symbols and
@@ -455,6 +460,35 @@ def _ensure_id_match_fraction_column(engine) -> None:
             )
 
 
+def _ensure_dropped_rows_column(engine) -> None:
+    """Idempotent PRAGMA-then-ALTER migration for 'dropped_unidentified_rows' (#103).
+
+    Adds ``dropped_unidentified_rows INTEGER`` to ``batch_conditions`` when
+    absent. Existing rows keep NULL, which the summary reads as "not recorded"
+    and renders as nothing — a run from before the count was persisted must not
+    claim that no rows were discarded.
+
+    Security note: table and column names are module-internal constants — no
+    user input is interpolated into the SQL.
+
+    Args:
+        engine: SQLAlchemy engine bound to the target database.
+    """
+    with engine.connect() as conn:
+        result = conn.execute(text("PRAGMA table_info(batch_conditions)"))
+        existing_cols = {row[1] for row in result}
+        if 'dropped_unidentified_rows' not in existing_cols:
+            conn.execute(
+                text("ALTER TABLE batch_conditions "
+                     "ADD COLUMN dropped_unidentified_rows INTEGER")
+            )
+            conn.commit()
+            logger.info(
+                "Added 'dropped_unidentified_rows' column to 'batch_conditions' "
+                "table (#103 migration)"
+            )
+
+
 def _ensure_resource_resolution_column(engine) -> None:
     """Idempotent PRAGMA-then-ALTER migration for 'resource_resolution' (#68).
 
@@ -540,6 +574,10 @@ class DatabaseManager:
             # Idempotent additive migration: add 'resource_resolution' to
             # experiments and batches (#68). No-op on fresh databases.
             _ensure_resource_resolution_column(self.engine)
+
+            # Idempotent additive migration: add 'dropped_unidentified_rows' to
+            # batch_conditions (#103). No-op on fresh databases.
+            _ensure_dropped_rows_column(self.engine)
 
             # Create session factory
             self.SessionLocal = sessionmaker(

--- a/services/batch_report_service.py
+++ b/services/batch_report_service.py
@@ -67,6 +67,26 @@ def batch_method(batch) -> str:
     return (getattr(batch, 'method', None) or 'ora')
 
 
+def _dropped_rows_note(cond) -> str:
+    """Describe the rows a condition's file lost to a missing gene symbol (#103).
+
+    Args:
+        cond: ConditionRecord. ``dropped_unidentified_rows`` is NULL for
+            conditions run before the count was persisted.
+
+    Returns:
+        str: a leading-separator clause ready to append to the condition's
+        gene-count line, or '' when nothing was dropped or nothing was
+        recorded — an unrecorded count must not read as "none dropped".
+    """
+    dropped = getattr(cond, 'dropped_unidentified_rows', None)
+    if not dropped:
+        return ''
+    noun = 'row' if dropped == 1 else 'rows'
+    verb = 'was' if dropped == 1 else 'were'
+    return f' · {dropped:,} {noun} without a gene symbol {verb} excluded'
+
+
 def render_heatmap_png(comparison_data: dict) -> Optional[bytes]:
     """Render the cross-condition comparison heatmap as PNG bytes.
 
@@ -398,6 +418,7 @@ def generate_batch_html(batch, conditions, comparison_data: dict) -> str:
             <p class="section-description">
                 {meta_line}{' — ' if meta_line else ''}
                 {cond.significant_genes or 0:,} significant of {cond.gene_count or 0:,} genes
+                {_dropped_rows_note(cond)}
             </p>
             {f'<p class="note">Key Events: {ke_accounting}</p>' if ke_accounting else ''}
             {enrichment_html}
@@ -458,6 +479,10 @@ def _condition_report_data(batch, cond, enrichment: List[Dict]) -> ReportData:
         filename=cond.filename or cond.condition_label,
         gene_count=cond.gene_count or 0,
         significant_genes=cond.significant_genes or 0,
+        # Issue #103: NULL on conditions run before the count was persisted.
+        # getattr, as elsewhere in this module, so a plain stand-in object with
+        # only the fields a caller cares about still produces a report.
+        dropped_rows=getattr(cond, 'dropped_unidentified_rows', None),
         aop_id=batch.aop_id or '',
         aop_label=batch.aop_label or '',
         logfc_threshold=batch.logfc_threshold,
@@ -619,7 +644,8 @@ def generate_batch_pdf(batch, conditions, comparison_data: dict) -> bytes:
         story.append(Paragraph(f'Condition: {cond.condition_label}', heading_style))
         story.append(Paragraph(
             f"{meta_line}{' — ' if meta_line else ''}"
-            f"{cond.significant_genes or 0:,} significant of {cond.gene_count or 0:,} genes",
+            f"{cond.significant_genes or 0:,} significant of {cond.gene_count or 0:,} genes"
+            f"{_dropped_rows_note(cond)}",
             normal_style,
         ))
         # Issue #65: state the multiple-testing denominator for this condition.

--- a/services/batch_service.py
+++ b/services/batch_service.py
@@ -312,7 +312,7 @@ def _run_condition(
     )
 
     # Process gene expression (applies significance flags)
-    df_processed, _ = process_gene_expression(
+    df_processed, stats = process_gene_expression(
         df_raw, batch.logfc_threshold or 0.0, pval_threshold=batch.pval_cutoff
     )
 
@@ -461,6 +461,11 @@ def _run_condition(
     cond.ke_title_map_json = json.dumps(ke_title_map)
     cond.gene_count = total_genes
     cond.significant_genes = significant_genes
+    # Issue #103: rows this file lost to a missing gene identifier, counted
+    # before harmonisation because they never reached the analysis at all. A
+    # condition whose file is annotation-poor is otherwise indistinguishable
+    # from one that simply measured fewer genes.
+    cond.dropped_unidentified_rows = int(stats.get('dropped_unidentified_rows', 0))
     cond.status = 'complete'
     cond.completed_at = datetime.now(timezone.utc).replace(tzinfo=None)
     db_session.commit()

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -114,6 +114,12 @@ class ReportData:
     resource_resolution_text: str = ''
     resource_warnings: Optional[List[str]] = None
 
+    # Issue #103: upload rows discarded for carrying no usable gene identifier.
+    # None means "not recorded" (a run from before the count existed) and is
+    # reported as such — distinct from a recorded zero, which is a real claim
+    # that every row had an identifier.
+    dropped_rows: Optional[int] = None
+
     # Issue #65: tested/excluded Key Event accounting from the enrichment run
     # (see enrichment_service.run_enrichment_analysis). Defaulted to None so
     # existing ReportData(...) constructions remain compatible; when None the
@@ -322,6 +328,11 @@ class ReportGenerator:
                 <div class="stat-item">
                     <label>Total Genes:</label>
                     <span>{report_data.gene_count:,}</span>
+                </div>
+                <div class="stat-item">
+                    <label>Rows Without Gene Symbol:</label>
+                    <span>{'not recorded' if report_data.dropped_rows is None
+                           else f'{report_data.dropped_rows:,} (excluded)'}</span>
                 </div>
                 <div class="stat-item">
                     <label>Significant Genes:</label>
@@ -1102,6 +1113,10 @@ class ReportGenerator:
             ['Minimum Mapping Confidence', report_data.min_confidence_label],  # Issue #60
             ['Filename', report_data.filename],
             ['Total Genes', f"{report_data.gene_count:,}"],
+            # Issue #103: the silent loss, made explicit next to the background.
+            ['Rows Without Gene Symbol',
+             'not recorded' if report_data.dropped_rows is None
+             else f"{report_data.dropped_rows:,} (excluded)"],
             ['Significant Genes', f"{report_data.significant_genes:,}"],
             ['Gene ID Type', report_data.id_type],
         ] + threshold_rows

--- a/services/results_context.py
+++ b/services/results_context.py
@@ -60,6 +60,7 @@ def build_results_context(
     wp_picker_data: Any = None,
     ke_summary: Optional[Dict[str, Any]] = None,
     background_overlap: Any = None,
+    dropped_rows: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Assemble the full template context for ``results.html``.
 
@@ -84,6 +85,10 @@ def build_results_context(
         ke_summary: Issue #65 tested/excluded accounting. ``None`` omits the
             accounting line rather than failing.
         background_overlap: Issue #69 ID-column sanity-check result.
+        dropped_rows: Issue #103 count of upload rows discarded for carrying no
+            usable gene identifier. ``None`` means "not recorded" — a stored run
+            that predates the counter — and renders nothing, which is distinct
+            from a recorded zero.
 
     Returns:
         Keyword arguments for ``render_template('results.html', **context)``.
@@ -113,4 +118,5 @@ def build_results_context(
         "fdr_cutoff": Config.SIGNIFICANCE_FDR_CUTOFF,
         "fdr_choices": Config.SIGNIFICANCE_FDR_CHOICES,
         "background_overlap": background_overlap,
+        "dropped_rows": dropped_rows,
     }

--- a/templates/batch_summary.html
+++ b/templates/batch_summary.html
@@ -62,6 +62,15 @@
         {% if cond.timepoint %}<p><strong>Timepoint:</strong> {{ cond.timepoint }}</p>{% endif %}
         {% if cond.status == 'complete' %}
         <p><strong>Genes:</strong> {{ cond.gene_count }} ({{ cond.significant_genes }} significant)</p>
+        {# Issue #103: rows this file lost for carrying no gene symbol. NULL
+           means the run predates the count — render nothing rather than claim
+           none were dropped. #}
+        {% if cond.dropped_unidentified_rows %}
+        <p style="font-size: 13px; color: #555;">
+          {{ cond.dropped_unidentified_rows }} row{{ '' if cond.dropped_unidentified_rows == 1 else 's' }}
+          in this file had no gene symbol and {{ 'was' if cond.dropped_unidentified_rows == 1 else 'were' }} excluded.
+        </p>
+        {% endif %}
         {# Issue #69: a condition whose identifiers did not match the gene sets
            completes normally and looks fine — say so here, or it is invisible
            across a nine-condition batch. NULL means the run predates the check. #}

--- a/templates/documentation.html
+++ b/templates/documentation.html
@@ -199,6 +199,15 @@ CYP3A4         3.21             0.00001   0.0001
             <strong>Important:</strong> The background is NOT the entire human genome, but rather the genes you provide
             in your input file. This makes the test more appropriate for platform-specific data (e.g., RNA-seq, microarray).
         </div>
+
+        <p>
+            Rows whose gene identifier is blank or a missing-value placeholder
+            (<code>NA</code>, <code>NaN</code>, <code>null</code>, <code>-</code> and similar) cannot be matched to any
+            gene set, so they are discarded during loading and do not count towards the background. The number
+            discarded is reported next to the background size on the results page, in the batch summary and in the
+            generated report &mdash; a large figure usually means the wrong identifier column was chosen, or that the
+            file is poorly annotated.
+        </p>
     </div>
 
     <!-- Section 3: Interpreting Results -->

--- a/templates/results.html
+++ b/templates/results.html
@@ -147,7 +147,13 @@
                     <span class="tooltiptext">The statistical test uses all genes in your dataset (not the entire genome) as background. This accounts for which genes were actually measured in your experiment.</span>
                 </span>.
             </p>
-            <p><strong>Background gene set size:</strong> {{ background_size }}</p>
+            {# Issue #103: the loader drops rows with no usable gene identifier
+               and counts them. Reporting the discard alongside the background
+               turns a silent loss (6% of a real DESeq2 table) into a visible
+               one. `dropped_rows` is None for runs recorded before the count
+               existed — say nothing rather than claim zero. #}
+            <p><strong>Background gene set size:</strong> {{ background_size }} measured genes{% if dropped_rows %}
+                <span style="color: #555;">({{ dropped_rows }} row{{ '' if dropped_rows == 1 else 's' }} had no gene symbol and {{ 'was' if dropped_rows == 1 else 'were' }} excluded)</span>{% endif %}</p>
             {# Issue #68: per-resource provenance. The old single line collapsed
                every non-API case into "Local reference files" and could not
                represent a mixed-resource run at all. #}
@@ -601,6 +607,11 @@
             <input type="hidden" name="filename" value="{{ metadata.get('filename', 'unknown') }}">
             <input type="hidden" name="gene_count" value="{{ background_size }}">
             <input type="hidden" name="significant_genes" value="{{ metadata.get('significant_genes', 0) }}">
+            {# Issue #103: the discarded symbol-less row count belongs in the
+               methods section next to the background size. Posted explicitly,
+               as with the fields below, so the report is right even when the
+               session has been lost. Empty means "not recorded". #}
+            <input type="hidden" name="dropped_rows" value="{{ dropped_rows if dropped_rows is not none else '' }}">
             <input type="hidden" name="aop_id" value="{{ metadata.get('aop_id', '') }}">
             <input type="hidden" name="aop_label" value="{{ metadata.get('aop_label', '') }}">
             <input type="hidden" name="logfc_threshold" value="{{ threshold }}">

--- a/tests/test_batch_report_service.py
+++ b/tests/test_batch_report_service.py
@@ -140,3 +140,38 @@ class TestKeAccountingSection:
         build_cytoscape_network derives from FDR."""
         png = brs.render_ke_network_png(json.dumps(self._NETWORK_WITH_REASONS))
         assert png is not None and png[:4] == b'\x89PNG'
+
+
+class TestDroppedRowsNote:
+    """Issue #103: a condition's discarded symbol-less rows reach the report."""
+
+    def test_note_reads_in_the_plural(self):
+        cond = SimpleNamespace(dropped_unidentified_rows=875)
+
+        assert brs._dropped_rows_note(cond) == (
+            ' · 875 rows without a gene symbol were excluded'
+        )
+
+    def test_note_reads_in_the_singular(self):
+        cond = SimpleNamespace(dropped_unidentified_rows=1)
+
+        assert brs._dropped_rows_note(cond) == (
+            ' · 1 row without a gene symbol was excluded'
+        )
+
+    @pytest.mark.parametrize('value', [0, None])
+    def test_nothing_dropped_or_nothing_recorded_says_nothing(self, value):
+        """An unrecorded count must not be reported as "none dropped"."""
+        assert brs._dropped_rows_note(SimpleNamespace(dropped_unidentified_rows=value)) == ''
+
+    def test_condition_predating_the_field_does_not_break_the_report(self):
+        """The report is assembled from stand-in objects too — no attribute, no crash."""
+        assert brs._dropped_rows_note(SimpleNamespace()) == ''
+
+    def test_html_states_the_discard_for_the_condition(self):
+        conditions = _conditions()
+        conditions[0].dropped_unidentified_rows = 875
+
+        html = brs.generate_batch_html(_batch(), conditions, _comparison_data())
+
+        assert '875 rows without a gene symbol were excluded' in html

--- a/tests/test_batch_service.py
+++ b/tests/test_batch_service.py
@@ -207,3 +207,74 @@ class TestBatchMinConfidencePersistence:
             assert batch.min_confidence == 'all'
         finally:
             session.close()
+
+
+class TestConditionDroppedRows:
+    """Issue #103: each condition records the rows its file lost to a missing symbol."""
+
+    def _write_file(self, path, symbol_less=2):
+        """Write a small TSV where `symbol_less` rows carry no gene identifier."""
+        rows = [{'Gene': f'G{i}', 'logFC': 2.0, 'pval': 0.001} for i in range(1, 6)]
+        for _ in range(symbol_less):
+            rows.append({'Gene': None, 'logFC': 1.0, 'pval': 0.01})
+        pd.DataFrame(rows).to_csv(path, sep='\t', index=False)
+
+    def _run(self, tmp_path, monkeypatch, temp_database, symbol_less):
+        """Run one condition end-to-end and return its stored ConditionRecord."""
+        import json
+        from datetime import datetime, timedelta, timezone
+
+        from config import Config
+        from database import BatchRecord, ConditionRecord
+        from services import batch_service
+
+        upload_root = tmp_path / 'uploads'
+        (upload_root / 'batch-103').mkdir(parents=True)
+        monkeypatch.setattr(Config, 'UPLOAD_FOLDER', str(upload_root))
+        self._write_file(upload_root / 'batch-103' / 'cond.tsv', symbol_less)
+
+        session = temp_database.get_session()
+        try:
+            batch = BatchRecord(
+                uuid='batch-103', status='running', aop_id='AOP:1',
+                logfc_threshold=1.0, pval_cutoff=0.05,
+                id_column='Gene', fc_column='logFC', pval_column='pval',
+                expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=1),
+            )
+            session.add(batch)
+            session.flush()
+            cond = ConditionRecord(
+                batch_id=batch.id, position=0, filename='cond.tsv',
+                condition_label='Cond', status='pending',
+            )
+            session.add(cond)
+            session.commit()
+
+            batch_service._run_condition(
+                cond, batch,
+                harmonised_genes={f'G{i}' for i in range(1, 6)},
+                reference_sets={'KE:115': {f'G{i}' for i in range(1, 6)}},
+                ke_list={'KE:115'},
+                edges=pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID', 'AOP_ID']),
+                ke_type_map={'KE:115': 'MIE'},
+                ke_title_map={'KE:115': 'Event 115'},
+                db_session=session,
+            )
+            session.refresh(cond)
+            return cond.status, cond.dropped_unidentified_rows
+        finally:
+            session.close()
+
+    def test_discarded_rows_are_persisted(self, tmp_path, monkeypatch, temp_database):
+        """The loader's count reaches the record, so the summary can show it."""
+        status, dropped = self._run(tmp_path, monkeypatch, temp_database, symbol_less=2)
+
+        assert status == 'complete'
+        assert dropped == 2
+
+    def test_clean_file_records_zero(self, tmp_path, monkeypatch, temp_database):
+        """A recorded zero is a real claim — every row had an identifier."""
+        status, dropped = self._run(tmp_path, monkeypatch, temp_database, symbol_less=0)
+
+        assert status == 'complete'
+        assert dropped == 0

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -278,3 +278,61 @@ class TestMinConfidencePersistence:
             assert stored.min_confidence == 'medium'
         finally:
             session.close()
+
+class TestDroppedRowsColumn:
+    """Issue #103: the discarded symbol-less row count is persisted per condition."""
+
+    def test_migration_adds_the_column_to_a_legacy_table(self, tmp_path):
+        """PRAGMA-then-ALTER, additive and idempotent, as with #68/#69."""
+        from sqlalchemy import create_engine, text
+        from database import _ensure_dropped_rows_column
+
+        db_path = tmp_path / 'legacy.db'
+        engine = create_engine(f'sqlite:///{db_path}')
+        with engine.connect() as conn:
+            conn.execute(text('CREATE TABLE batch_conditions (id INTEGER PRIMARY KEY)'))
+            conn.commit()
+
+        _ensure_dropped_rows_column(engine)
+        _ensure_dropped_rows_column(engine)  # second run must be a no-op
+
+        with engine.connect() as conn:
+            cols = [row[1] for row in conn.execute(text('PRAGMA table_info(batch_conditions)'))]
+        assert cols.count('dropped_unidentified_rows') == 1
+
+    def test_condition_defaults_to_null_not_zero(self, temp_database):
+        """A condition run before the count existed must read as unrecorded.
+
+        NULL and 0 are different claims: 0 says every row carried an identifier,
+        NULL says nobody looked. The summary renders the former and not the
+        latter, so the distinction has to survive storage.
+        """
+        from datetime import datetime, timedelta, timezone
+        from database import BatchRecord, ConditionRecord
+
+        session = temp_database.get_session()
+        try:
+            batch = BatchRecord(
+                uuid='dropped-rows-batch',
+                aop_id='AOP:1',
+                expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=1),
+            )
+            session.add(batch)
+            session.commit()
+
+            legacy = ConditionRecord(
+                batch_id=batch.id, position=0, condition_label='legacy',
+            )
+            counted = ConditionRecord(
+                batch_id=batch.id, position=1, condition_label='counted',
+                dropped_unidentified_rows=875,
+            )
+            session.add_all([legacy, counted])
+            session.commit()
+
+            stored = {c.condition_label: c.dropped_unidentified_rows
+                      for c in session.query(ConditionRecord).all()}
+            assert stored['legacy'] is None
+            assert stored['counted'] == 875
+        finally:
+            session.close()

--- a/tests/test_results_context.py
+++ b/tests/test_results_context.py
@@ -114,3 +114,45 @@ def test_results_template_renders_from_builder_output_alone():
         html = render_template("results.html", **_minimal_batch_context())
 
     assert "Increase, Mitochondrial dysfunction" in html
+
+
+# ---------------------------------------------------------------------------
+# Issue #103 — the discarded symbol-less row count
+# ---------------------------------------------------------------------------
+
+def _render(**overrides):
+    """Render results.html from a batch-shaped context with overrides applied."""
+    from app import app
+
+    ctx = _minimal_batch_context()
+    ctx.update(overrides)
+    with app.test_request_context():
+        from flask import render_template
+        return render_template("results.html", **ctx)
+
+
+def test_dropped_rows_defaults_to_not_recorded():
+    """A caller that says nothing gets None — 'not recorded', not zero."""
+    assert _minimal_batch_context()["dropped_rows"] is None
+
+
+def test_discarded_rows_are_reported_next_to_the_background():
+    """The count the loader already had must be visible on the page (#103)."""
+    html = _render(background_size=12914, dropped_rows=875)
+
+    assert "12914 measured genes" in html
+    assert "875 rows had no gene symbol and were excluded" in html
+
+
+def test_single_discarded_row_reads_in_the_singular():
+    html = _render(dropped_rows=1)
+
+    assert "1 row had no gene symbol and was excluded" in html
+
+
+@pytest.mark.parametrize("value", [0, None])
+def test_nothing_is_claimed_when_nothing_was_dropped_or_recorded(value):
+    """Zero needs no clause, and an unrecorded count must not read as zero."""
+    html = _render(dropped_rows=value)
+
+    assert "had no gene symbol" not in html


### PR DESCRIPTION
Closes #103. Follow-up to #80.

Based on #109 (the test-suite fix) — merge that first; this diff is one commit.

The loader has counted rows with no usable gene identifier since #80, but the number appeared nowhere in the interface. On the DESeq2 table in #80 that was 875 of 13814 rows — 6% of the file dropped in silence. A user who picks a slightly wrong ID column, or uploads an annotation-poor table, saw only a background size that looked plausible.

## What changed

The count now travels with the background it qualifies:

- `build_results_context` gains `dropped_rows`, so the live run and the batch-condition re-render both get it from one place. The results page reads *"Background gene set size: 22070 measured genes (37 rows had no gene symbol and were excluded)"*.
- Batch conditions persist their own count — new nullable `batch_conditions` column with an idempotent PRAGMA-then-ALTER migration, following `_ensure_resource_resolution_column` (#68) exactly — and the summary card shows it.
- Both reports carry it in the input-data section.
- The documentation's background chapter now says which rows are discarded and why a large figure usually means the wrong column was chosen.

**NULL and 0 are kept apart throughout**: 0 says every row carried an identifier, NULL says nobody counted. Only the former is rendered — a run recorded before the count existed must not read as a clean file.

## Verification

End-to-end against the dev server with a 30,473-row table carrying 37 symbol-less rows (blank, `NA` and `-`):

- results page: `Background gene set size: 22070 measured genes (37 rows had no gene symbol and were excluded)`
- generated HTML report: `Rows Without Gene Symbol: 37 (excluded)`

Full suite green (561 passed), with new tests for the singular/plural wording, the zero and unrecorded cases, the migration's idempotence, and the NULL-vs-0 distinction surviving storage.