### PR TITLE
Say how old a cached gene set is on the provenance line (#106)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1488,6 +1488,56 @@ def _confidence_cache_key(base_key, min_confidence):
     return f"{base_key}:minconf={min_confidence}"
 
 
+# Issue #106: when each reference-set cache entry was filled, recorded by the
+# loader at the moment it reads that entry and keyed by the same cache key.
+# Keeping it here rather than deriving it later means the age reported always
+# belongs to the gene sets actually loaded, and it costs no change to the
+# cached payload shapes (already carrying compatibility history from #79/#81).
+_CACHE_FILL_TIMES = {}
+
+
+def _record_cache_fill_time(cache_key, expire_at):
+    """Note when a cache entry was written, from its expiry (#106).
+
+    diskcache stores an expiry per entry and every reference-set entry is
+    written with the same ``Config.CACHE_TTL``, so the fill time is the expiry
+    minus that TTL. The one assumption: change CACHE_TTL while an entry is warm
+    and that entry's reported age is off by the difference until it expires — a
+    timestamp stale by that much still beats the "no age at all" it replaces.
+
+    Args:
+        cache_key: the threshold-scoped key the entry was read from.
+        expire_at: epoch seconds from ``cache.get(..., expire_time=True)``, or
+            None for an entry written without an expiry.
+    """
+    if not expire_at:
+        _CACHE_FILL_TIMES.pop(cache_key, None)
+        return
+    filled_at = datetime.datetime.fromtimestamp(
+        expire_at - Config.CACHE_TTL, tz=datetime.timezone.utc
+    )
+    _CACHE_FILL_TIMES[cache_key] = filled_at.strftime('%Y-%m-%d %H:%M UTC')
+
+
+def _cache_fill_time(resource, min_confidence):
+    """Report when this resource's loaded gene sets were cached (#106).
+
+    Args:
+        resource: resource key from VALID_RESOURCES.
+        min_confidence: the threshold the entry was keyed by.
+
+    Returns:
+        str: UTC timestamp to the minute, or None when the load did not come
+        from the cache or its age could not be established. A caller must
+        render None as "age unknown", never as a guess.
+    """
+    base_key = (REFERENCE_CACHE_KEY if resource == "WikiPathways"
+                else _GMT_RESOURCE_CACHE_KEYS.get(resource))
+    if not base_key:
+        return None
+    return _CACHE_FILL_TIMES.get(_confidence_cache_key(base_key, min_confidence))
+
+
 def _load_wikipathways_reference_sets(min_confidence=DEFAULT_MIN_CONFIDENCE):
     """Load WikiPathways KE->gene sets (disk cache -> Builder API -> local CSV).
 
@@ -1513,8 +1563,11 @@ def _load_wikipathways_reference_sets(min_confidence=DEFAULT_MIN_CONFIDENCE):
         ``.unresolved_ke_pathways`` (see ``helpers.ReferenceSets``).
     """
     cache_key = _confidence_cache_key(REFERENCE_CACHE_KEY, min_confidence)
-    cached = _reference_cache.get(cache_key)
+    # Issue #106: read the expiry alongside the value so the provenance line can
+    # say how old the cached gene sets are, not merely that they were cached.
+    cached, expire_at = _reference_cache.get(cache_key, expire_time=True)
     if cached is not None:
+        _record_cache_fill_time(cache_key, expire_at)
         # Entries written before #79 are 2-tuples and before #81 3-tuples;
         # treat them as "nothing known to be unresolved" rather than
         # invalidating a warm cache on deploy.
@@ -1602,8 +1655,10 @@ def _load_gmt_resource_reference_sets(resource, min_confidence=DEFAULT_MIN_CONFI
         is still reported (issue #68).
     """
     cache_key = _confidence_cache_key(_GMT_RESOURCE_CACHE_KEYS[resource], min_confidence)
-    cached = _reference_cache.get(cache_key)
+    # Issue #106: the expiry gives the cache fill time for the provenance line.
+    cached, expire_at = _reference_cache.get(cache_key, expire_time=True)
     if cached is not None:
+        _record_cache_fill_time(cache_key, expire_at)
         reference_sets, original_source = cached
         logger.info(
             f"Loaded {len(reference_sets)} {resource} KE sets from disk cache"
@@ -1714,7 +1769,14 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
              'confidence_applied': False,   # issue #67
              'unresolved_pathways': ['WP5477'],          # issue #79
              'unresolved_ke_pathways': {'KE:1115': ['WP5477']},  # issue #81
+             'cached_at': '2026-07-22 09:14 UTC',        # issue #106
              'error': 'HTTP 502' or None}
+
+        ``cached_at`` is set only when the sets came from the disk cache, and
+        says when that cache was filled — "cached" with no age cannot tell a
+        set fetched minutes ago from one fetched weeks ago, which is precisely
+        what a reproducibility claim needs. None means live, or an age that
+        could not be established.
 
         Recording resolution rather than selection is the point: a run where
         Reactome was skipped, or where WikiPathways fell back to the bundled
@@ -1758,6 +1820,7 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
                 'confidence_applied': False,
                 'unresolved_pathways': [],
                 'unresolved_ke_pathways': {},
+                'cached_at': None,
                 'error': str(exc),
             })
             continue
@@ -1783,6 +1846,14 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
             # Issue #81: the same pathways attributed to their Key Events, so a
             # stored resolution can say which KE was misreported as unmapped.
             'unresolved_ke_pathways': unresolved_ke,
+            # Issue #106: when the sets came from the cache, when that cache was
+            # filled. "cached" alone carries no age, so two runs minutes apart
+            # could be served gene sets of different vintages with nothing in
+            # either output distinguishing them — and the provenance line is
+            # exactly what a methods section cites to say which gene sets
+            # produced a result. None for a live load or an unknowable age.
+            'cached_at': _cache_fill_time(resource, min_confidence) if str(
+                source).startswith('cache(') else None,
             'error': None,
         })
 
@@ -1813,9 +1884,16 @@ def describe_resource_resolution(resolution):
         resolution: list produced by ``load_cached_reference_sets``.
 
     Returns:
-        str: e.g. ``"WikiPathways (Builder API, cached); Reactome — unavailable,
-        skipped"``. Empty string when there is nothing to describe (legacy
-        records that predate the resolution table).
+        str: e.g. ``"WikiPathways (Builder API, cached 2026-07-22 09:14 UTC);
+        Reactome — unavailable, skipped"``. Empty string when there is nothing
+        to describe (legacy records that predate the resolution table).
+
+        Issue #106: a cached entry states when the cache was filled, because
+        "cached" on its own cannot distinguish gene sets fetched minutes ago
+        from ones fetched weeks ago — and this line is what a methods section
+        quotes to say which gene sets produced a result. An entry whose age is
+        unknown (stored before the timestamp existed, or a cache that could not
+        be read) keeps the bare wording rather than inventing a time.
     """
     if not resolution:
         return ''
@@ -1826,6 +1904,9 @@ def describe_resource_resolution(resolution):
             parts.append(f"{name} — unavailable, skipped")
             continue
         label = RESOURCE_SOURCE_LABELS.get(entry.get('source'), entry.get('source') or '?')
+        cached_at = entry.get('cached_at')
+        if cached_at:
+            label = f"{label} {cached_at}"
         parts.append(f"{name} ({label})")
     return '; '.join(parts)
 

--- a/templates/results.html
+++ b/templates/results.html
@@ -160,7 +160,13 @@
                         {% if entry.status != 'loaded' %}
                             <span style="color: #EB5B25; font-weight: 500;">unavailable, skipped</span>
                         {% else %}
-                            <span style="color: {{ '#009FE3' if entry.source == 'api' else ('#EB5B25' if entry.source in ['csv', 'cache(csv)'] else '#45A6B2') }}; font-weight: 500;">{{ resource_source_labels.get(entry.source, entry.source) }}</span>
+                            <span style="color: {{ '#009FE3' if entry.source == 'api' else ('#EB5B25' if entry.source in ['csv', 'cache(csv)'] else '#45A6B2') }}; font-weight: 500;">{{ resource_source_labels.get(entry.source, entry.source) }}{#
+                               Issue #106: how old the cache is. Without it, two
+                               runs minutes apart can be served gene sets of
+                               different vintages and say the same thing. Absent
+                               for a live load, and for a stored run recorded
+                               before the timestamp existed — say nothing rather
+                               than guess a time. #}{% if entry.cached_at %} {{ entry.cached_at }}{% endif %}</span>
                             ({{ entry.ke_count }} KEs){% endif %}</span>{% if not loop.last %}; {% endif %}
                 {% endfor %}
             </p>

--- a/tests/test_ke_exclusion_wiring.py
+++ b/tests/test_ke_exclusion_wiring.py
@@ -130,7 +130,8 @@ class TestReferenceSetsCarryTheMap:
 def _fake_reference_cache(monkeypatch):
     store = {}
     fake = MagicMock()
-    fake.get.side_effect = lambda key: store.get(key)
+    fake.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), None) if expire_time else store.get(key))
     fake.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
     monkeypatch.setattr(app, '_reference_cache', fake)
     return store

--- a/tests/test_reference_resources.py
+++ b/tests/test_reference_resources.py
@@ -191,7 +191,8 @@ class TestGmtResourcesUnaffectedByConfidence:
     def test_gmt_sets_identical_at_every_threshold(self, threshold, monkeypatch):
         store = {}
         fake_cache = MagicMock()
-        fake_cache.get.side_effect = lambda key: store.get(key)
+        fake_cache.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), None) if expire_time else store.get(key))
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
@@ -250,7 +251,8 @@ class TestConfidenceScopedCacheKeys:
         """An 'all' entry in the disk cache must not satisfy a 'high' request."""
         store = {app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all"): ({"KE:1": {"A", "B"}}, "api")}
         fake_cache = MagicMock()
-        fake_cache.get.side_effect = lambda key: store.get(key)
+        fake_cache.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), None) if expire_time else store.get(key))
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
@@ -270,7 +272,8 @@ class TestConfidenceScopedCacheKeys:
         """And the reverse: a 'high' entry must not satisfy an 'all' request."""
         store = {app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "high"): ({"KE:1": {"A"}}, "api")}
         fake_cache = MagicMock()
-        fake_cache.get.side_effect = lambda key: store.get(key)
+        fake_cache.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), None) if expire_time else store.get(key))
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
@@ -281,7 +284,8 @@ class TestConfidenceScopedCacheKeys:
     def test_gmt_loader_caches_per_threshold(self, monkeypatch):
         store = {}
         fake_cache = MagicMock()
-        fake_cache.get.side_effect = lambda key: store.get(key)
+        fake_cache.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), None) if expire_time else store.get(key))
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
@@ -300,7 +304,8 @@ class TestCachePreservesOriginalSource:
     @staticmethod
     def _fake_cache(monkeypatch, store):
         fake_cache = MagicMock()
-        fake_cache.get.side_effect = lambda key: store.get(key)
+        fake_cache.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), None) if expire_time else store.get(key))
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
         return fake_cache
@@ -550,7 +555,8 @@ class TestCacheFormatUpgrade:
 
     def _cache(self, monkeypatch, store):
         fake = MagicMock()
-        fake.get.side_effect = lambda key: store.get(key)
+        fake.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), None) if expire_time else store.get(key))
         fake.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake)
 
@@ -572,3 +578,109 @@ class TestCacheFormatUpgrade:
 
         assert unresolved == ["WP5477"]
         assert source == "cache(api)"
+
+
+class TestCacheAgeIsReported:
+    """Issue #106: "cached" without an age cannot support a reproducibility claim."""
+
+    TTL = 3600
+
+    @staticmethod
+    def _cache_with_expiry(monkeypatch, store, expiry_by_key):
+        """A cache double that answers expire_time, as diskcache does."""
+        fake = MagicMock()
+        fake.get.side_effect = lambda key, expire_time=False: (
+            (store.get(key), expiry_by_key.get(key)) if expire_time else store.get(key))
+        fake.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
+        monkeypatch.setattr(app, "_reference_cache", fake)
+
+    @pytest.fixture(autouse=True)
+    def _clear_recorded_times(self):
+        """The fill-time record is module state; keep tests independent."""
+        app._CACHE_FILL_TIMES.clear()
+        yield
+        app._CACHE_FILL_TIMES.clear()
+
+    def test_cache_hit_records_the_fill_time(self, monkeypatch):
+        """Fill time is the entry's expiry less the TTL it was written with."""
+        import datetime as dt
+
+        filled = dt.datetime(2026, 7, 22, 9, 14, tzinfo=dt.timezone.utc)
+        key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
+        self._cache_with_expiry(
+            monkeypatch,
+            {key: ({"KE:1": {"A"}}, "api")},
+            {key: filled.timestamp() + app.Config.CACHE_TTL},
+        )
+
+        app._load_wikipathways_reference_sets("all")
+
+        assert app._cache_fill_time("WikiPathways", "all") == "2026-07-22 09:14 UTC"
+
+    def test_provenance_line_states_the_age(self, monkeypatch):
+        """The line a methods section quotes must carry the vintage."""
+        import datetime as dt
+
+        filled = dt.datetime(2026, 7, 22, 9, 14, tzinfo=dt.timezone.utc)
+        key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
+        self._cache_with_expiry(
+            monkeypatch,
+            {key: ({"KE:1": {"A"}}, "api")},
+            {key: filled.timestamp() + app.Config.CACHE_TTL},
+        )
+
+        _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
+
+        assert resolution[0]["cached_at"] == "2026-07-22 09:14 UTC"
+        assert app.describe_resource_resolution(resolution) == (
+            "WikiPathways (Builder API, cached 2026-07-22 09:14 UTC)"
+        )
+
+    def test_a_live_load_claims_no_cache_age(self):
+        """Nothing was cached, so there is nothing to date."""
+        wp = {"KE:1": {"A"}}
+        with patch.object(app, "_load_wikipathways_reference_sets",
+                          return_value=(wp, "api", [], {})):
+            _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
+
+        assert resolution[0]["cached_at"] is None
+        assert app.describe_resource_resolution(resolution) == (
+            "WikiPathways (Builder API, live)"
+        )
+
+    def test_unknown_age_keeps_the_bare_wording(self, monkeypatch):
+        """An entry written without an expiry dates to nothing — don't invent one."""
+        key = app._confidence_cache_key(app.REFERENCE_CACHE_KEY, "all")
+        self._cache_with_expiry(monkeypatch, {key: ({"KE:1": {"A"}}, "csv")}, {})
+
+        _, _, resolution = app.load_cached_reference_sets(["WikiPathways"])
+
+        assert resolution[0]["cached_at"] is None
+        assert app.describe_resource_resolution(resolution) == (
+            "WikiPathways (bundled reference files, cached)"
+        )
+
+    def test_gmt_resources_report_their_own_age(self, monkeypatch):
+        """GO BP and Reactome are cached separately, so each dates separately."""
+        import datetime as dt
+
+        filled = dt.datetime(2026, 7, 20, 6, 0, tzinfo=dt.timezone.utc)
+        key = app._confidence_cache_key(app._GMT_RESOURCE_CACHE_KEYS["GO_BP"], "all")
+        self._cache_with_expiry(
+            monkeypatch,
+            {key: ({"KE:1097": {"TP53"}}, "api")},
+            {key: filled.timestamp() + app.Config.CACHE_TTL},
+        )
+
+        _, _, resolution = app.load_cached_reference_sets(["GO_BP"])
+
+        assert resolution[0]["cached_at"] == "2026-07-20 06:00 UTC"
+
+    def test_a_skipped_resource_carries_the_key_but_no_age(self):
+        """Every entry has the field, so consumers need no special-casing."""
+        with patch.object(app, "_load_gmt_resource_reference_sets",
+                          side_effect=RuntimeError("HTTP 502")):
+            _, _, resolution = app.load_cached_reference_sets(["Reactome"])
+
+        assert resolution[0]["status"] == "skipped"
+        assert resolution[0]["cached_at"] is None


### PR DESCRIPTION
Closes #106.

Based on #109 (the test-suite fix) — merge that first; this diff is one commit.

The provenance line reported `WikiPathways — Builder API, cached (90 KEs)`. Marking the cache hop was right (#68), but "cached" carries no age: two runs minutes apart can be served gene sets of different vintages with nothing in either output telling them apart, and a run reproduced weeks later can differ for reasons invisible in every artefact it produces. This is the line a methods section quotes to say which gene sets produced a result, so it needs to say more than "from the Builder at some point".

## What changed

Each resolution entry now carries `cached_at`, and the line reads `WikiPathways (Builder API, cached 2026-07-22 09:14 UTC)` wherever it appears — results page, batch summary, and both report formats, all of which render from `describe_resource_resolution` or the same resolution entries.

The timestamp is recorded by the loader at the moment it reads the entry, so the age reported always belongs to the gene sets actually loaded. It is derived from the entry's expiry less `Config.CACHE_TTL`, which leaves the cached payloads untouched — their shapes already carry compatibility history from #79 and #81. The one assumption is documented in the code: change the TTL while an entry is warm and that entry's age is off by the difference until it expires.

A live load, an entry stored without an expiry, and a run recorded before the field existed all report no age and keep the previous wording. **An unknown vintage is stated as unknown, never guessed.**

## Verification

Two analyses against the dev server with the cache cleared in between:

- first run: `WikiPathways — Builder API, live`
- second run: `WikiPathways — Builder API, cached 2026-07-22 13:00 UTC`

The same string appears in the generated batch PDF. Full suite green (552 passed), with new tests for the derived fill time, the live case, the unknown-age case, per-resource GMT ages, and the skipped-resource entry.