### PR TITLE
Colour the NES matrix only where the direction is supported (#107)

### DIFF
--- a/app.py
+++ b/app.py
@@ -2814,6 +2814,10 @@ def batch_compare(batch_uuid_str):
             batch_method=batch_method,
             comparison_data_json=comparison_data_json,
             network_json=json.dumps(first_network) if first_network else 'null',
+            # Issue #107: the page masks the NES heatmap at the significance
+            # cutoff, which must be the one cutoff the rest of the app uses
+            # (#63) rather than a literal repeated through the script.
+            fdr_cutoff=Config.SIGNIFICANCE_FDR_CUTOFF,
         )
     finally:
         session_db.close()

--- a/services/batch_report_service.py
+++ b/services/batch_report_service.py
@@ -29,6 +29,7 @@ from services.comparison_service import comparison_matrix_to_dataframe
 from services.image_render import render_figure_png
 from services.enrichment_service import format_ke_summary
 from services.network_service import ke_accounting_from_network
+from config import Config
 from helpers import MIN_CONFIDENCE_LABELS
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,41 @@ def batch_method(batch) -> str:
         except Exception:  # pragma: no cover — provenance must never break a report
             pass
     return (getattr(batch, 'method', None) or 'ora')
+
+
+def _mask_nes_by_significance(nes_matrix, fdr_matrix):
+    """Blank NES cells that are not significant at the active cutoff (#107).
+
+    On a diverging scale colour encodes direction, and for a cell nowhere near
+    significance the sign of NES is not a stable quantity: the same conditions
+    scored against a harmonised batch background and against their own
+    per-file backgrounds returned opposite-signed NES for four of six KEs in
+    the weakest condition, every one with FDR >= 0.48. Colouring those cells
+    invites the reader to interpret a direction the data does not support, so
+    they are left blank; the values remain in the matrix table and the exports.
+
+    Args:
+        nes_matrix: 2-D list of NES floats (rows=KEs, cols=conditions).
+        fdr_matrix: the aligned FDR matrix. When absent, nothing can be
+            assessed and the NES matrix is returned unchanged.
+
+    Returns:
+        list: a new matrix with non-significant cells set to None.
+    """
+    if not fdr_matrix:
+        return nes_matrix
+    cutoff = Config.SIGNIFICANCE_FDR_CUTOFF
+    masked = []
+    for row_idx, row in enumerate(nes_matrix):
+        fdr_row = fdr_matrix[row_idx] if row_idx < len(fdr_matrix) else []
+        masked.append([
+            value if (col_idx < len(fdr_row)
+                      and fdr_row[col_idx] is not None
+                      and fdr_row[col_idx] < cutoff)
+            else None
+            for col_idx, value in enumerate(row)
+        ])
+    return masked
 
 
 def _dropped_rows_note(cond) -> str:
@@ -115,6 +151,11 @@ def render_heatmap_png(comparison_data: dict) -> Optional[bytes]:
 
         if is_gsea:
             z = comparison_data.get('nes_matrix') or comparison_data['neg_log10_matrix']
+            # Issue #107: colour direction only where direction is supported.
+            # Applied here as well as on the compare page so the printed
+            # heatmap and the screen cannot make different claims.
+            if comparison_data.get('nes_matrix'):
+                z = _mask_nes_by_significance(z, comparison_data.get('fdr_matrix'))
             heatmap_kwargs = dict(
                 colorscale='RdBu',
                 reversescale=True,  # red = positive NES (coordinated up-shift)
@@ -131,11 +172,19 @@ def render_heatmap_png(comparison_data: dict) -> Optional[bytes]:
                 colorbar=dict(title='-log10(FDR)'),
             )
 
-        fig = go.Figure(data=go.Heatmap(
-            z=z, x=x, y=y,
-            hoverongaps=False,
-            **heatmap_kwargs,
-        ))
+        # Issue #107: the significance mask can blank every cell, and plotly
+        # infers its axes from the data — an all-null z renders a featureless
+        # box with no tick labels at all. A fully transparent companion trace
+        # over the same categories anchors the axes without drawing anything,
+        # so a blank heatmap still says which KEs and conditions it covers.
+        axis_anchor = go.Heatmap(
+            z=[[0] * len(x) for _ in y], x=x, y=y,
+            opacity=0, showscale=False, hoverinfo='skip',
+        )
+        fig = go.Figure(data=[
+            axis_anchor,
+            go.Heatmap(z=z, x=x, y=y, hoverongaps=False, **heatmap_kwargs),
+        ])
         # Size scales with row/column count, bounded for sane PDFs.
         height = max(300, min(1200, 40 * len(y) + 120))
         width = max(500, min(1400, 120 * len(x) + 260))
@@ -370,8 +419,11 @@ def generate_batch_html(batch, conditions, comparison_data: dict) -> str:
     is_gsea = batch_method(batch) == 'gsea'
     comparison_caption = (
         'Normalised enrichment score (NES, signed) of each Key Event across '
-        'conditions. Red is a coordinated up-shift, blue a down-shift; the table '
-        'below carries the same NES values.'
+        'conditions. Red is a coordinated up-shift, blue a down-shift. The '
+        'heatmap colours only Key Events reaching FDR &lt; '
+        f'{Config.SIGNIFICANCE_FDR_CUTOFF} — above that cutoff the sign of NES '
+        'is not stable, so colouring it would show noise as direction (#107). '
+        'The table below carries every NES value, significant or not.'
         if is_gsea else
         'Significance (-log10 FDR) of each Key Event across conditions.'
     )
@@ -575,7 +627,11 @@ def generate_batch_pdf(batch, conditions, comparison_data: dict) -> bytes:
     is_gsea = batch_method(batch) == 'gsea'
     story.append(Paragraph('Cross-Condition Comparison', heading_style))
     story.append(Paragraph(
-        'Normalised enrichment score (NES, signed) per Key Event across conditions.'
+        'Normalised enrichment score (NES, signed) per Key Event across '
+        'conditions. The heatmap colours only Key Events reaching FDR &lt; '
+        f'{Config.SIGNIFICANCE_FDR_CUTOFF}; above that cutoff the sign of NES is '
+        'not stable, so colouring it would show noise as direction (#107). The '
+        'table below carries every NES value, significant or not.'
         if is_gsea else
         'Significance (-log10 FDR) per Key Event across conditions.',
         normal_style,

--- a/services/comparison_service.py
+++ b/services/comparison_service.py
@@ -42,7 +42,16 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
     upward shift in one condition and a downward shift in another are
     distinguishable, which a p-value-derived matrix cannot show. Unlike
     ``neg_log10_matrix`` it is *not* blanked at the significance cutoff: a
-    consistent sub-threshold NES across a dose series is itself the signal.
+    consistent sub-threshold NES across a dose series is itself the signal, and
+    this matrix is the record the table and the exports read.
+
+    Issue #107 qualifies that for *colour* specifically. The sign of a
+    sub-threshold NES is not a stable quantity — the same conditions run
+    against a harmonised and a per-file background returned opposite signs for
+    four of six KEs in the weakest condition, all with FDR >= 0.48 — so both
+    heatmap renderers mask this matrix at the cutoff before colouring it. The
+    masking lives with the rendering, not here: what is unsuitable for a
+    diverging colour scale is still a legitimate number to read and to export.
 
     Args:
         conditions: List of ConditionRecord ORM objects ordered by position.
@@ -252,6 +261,12 @@ def comparison_matrix_to_dataframe(
                        matching the heatmap's null semantics)
       - ``'nes'``      normalised enrichment score (#76; blank throughout for
                        an ORA batch, which produces no NES)
+
+    The NES export is deliberately **not** masked at the significance cutoff the
+    way the heatmap is (#107). A download is the raw record — the FDR matrix is
+    downloadable alongside it, so a reader can apply any cutoff they like —
+    whereas the heatmap has to choose a colour per cell and must not encode a
+    direction the data cannot support.
 
     Key Event titles are passed through :func:`csv_guard` so a title beginning
     with a formula character cannot be interpreted as a formula on open.

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -109,6 +109,16 @@
     <!-- Heatmap panel (default visible) -->
     <div id="tab-heatmap" class="compare-tab-panel compare-tab-panel--active">
       <div id="heatmap-div" style="width:100%;min-height:400px;"></div>
+      {# Issue #107: the NES heatmap colours only significant cells, so say so —
+         a blank cell means "direction not supported here", not "no result". #}
+      {% if batch_method == 'gsea' %}
+      <p class="compare-genes-note">
+        Colour shows the normalised enrichment score (NES) for Key Events reaching
+        FDR &lt; {{ fdr_cutoff }}. Cells above that cutoff are left blank: their NES sign is
+        not stable, so colouring them would show noise as direction. Every value,
+        significant or not, is in the Table tab and in the exports.
+      </p>
+      {% endif %}
     </div>
 
     <!-- Table panel -->
@@ -117,8 +127,9 @@
       <p class="compare-genes-note">
         {% if batch_method == 'gsea' %}
           Cells show the normalised enrichment score (NES, signed) with the permutation
-          FDR beneath it. Shading marks FDR &lt; 0.05; an unshaded but consistently
-          signed NES across conditions is still a coordinated shift.
+          FDR beneath it. Shading marks FDR &lt; {{ fdr_cutoff }}; an unshaded but consistently
+          signed NES across conditions is still a coordinated shift, which is why the
+          value is greyed rather than hidden (#107).
         {% else %}
           Cells show the Benjamini&ndash;Hochberg FDR from Fisher's exact test.
           Shading marks FDR &lt; 0.05.
@@ -217,6 +228,47 @@
   // ORA FDR columns. Matrices produced before #76 carry no 'method' key, which
   // reads as ORA — the behaviour those batches were rendered with.
   const isGsea = comparisonData && comparisonData.method === 'gsea';
+
+  // Issue #63's single notion of significance, supplied by the route (#107).
+  const FDR_CUTOFF = {{ fdr_cutoff | default(0.05) | tojson }};
+
+  /**
+   * Is this cell significant at the active cutoff? (#107)
+   *
+   * @param {number|null|undefined} fdr - FDR for the cell, or null/undefined
+   *   when the KE was not tested in that condition.
+   * @returns {boolean} false for an untested cell — absent is not significant.
+   */
+  function isSignificantFdr(fdr) {
+    return fdr !== null && fdr !== undefined && fdr < FDR_CUTOFF;
+  }
+
+  /**
+   * NES matrix with non-significant cells blanked (#107).
+   *
+   * On the diverging NES scale, colour encodes direction. For a cell nowhere
+   * near significance the sign of NES is not a stable quantity: comparing a
+   * harmonised batch run against the same conditions run singly, four of six
+   * KEs for cisplatin 72h flipped sign (KE 1392 +1.16 vs -0.75, KE 149 +0.66
+   * vs -0.61, KE 1825 +1.09 vs -0.81, KE 177 +1.06 vs -0.61), every one with
+   * FDR >= 0.48. That is ordinary background sensitivity, not
+   * non-determinism — but on the heatmap those cells swung from saturated blue
+   * to saturated red between two legitimate ways of running the same
+   * comparison. Blanking them means colour shows direction only where
+   * direction is supported; the numbers stay in the table and in the exports.
+   *
+   * @returns {Array<Array<number|null>>}
+   */
+  function maskedNesMatrix() {
+    const nes = comparisonData.nes_matrix || [];
+    const fdr = comparisonData.fdr_matrix || [];
+    return nes.map(function (row, ke) {
+      return row.map(function (value, col) {
+        const cellFdr = fdr[ke] ? fdr[ke][col] : null;
+        return isSignificantFdr(cellFdr) ? value : null;
+      });
+    });
+  }
 
   /**
    * The matrix the heatmap, delta mode and the trend arrows are driven from.
@@ -542,7 +594,9 @@
       // GSEA (#76): colour on the signed NES with a diverging scale centred at
       // zero, so a coordinated upward shift and a downward one are not both
       // rendered as "significant". Server clamps NES to +/-3; match that here.
-      zData   = comparisonData.nes_matrix;
+      // #107: only cells at or below the FDR cutoff are coloured — see
+      // maskedNesMatrix() for why an unstable sign must not read as direction.
+      zData   = maskedNesMatrix();
       xLabels = comparisonData.condition_labels;
       colorscale = 'RdBu';
       reversescale = true; // red = positive NES (coordinated up-regulation)
@@ -638,7 +692,25 @@
       modeBarButtonsToRemove: ['lasso2d', 'select2d']
     };
 
-    return { trace: trace, layout: layout, config: config };
+    // #107: the significance mask can blank every cell, and a batch where
+    // nothing reaches the cutoff is an ordinary result, not an error. Plotly
+    // infers its axes from the data it is given, so an all-null z produces a
+    // figure with no tick labels at all — a featureless grey box that says
+    // nothing about which Key Events and conditions it covers. A fully
+    // transparent companion trace over the same categories anchors the axes
+    // without drawing anything, so a blank heatmap reads as "nothing
+    // significant here" while every axis behaviour above stays untouched.
+    var axisAnchor = {
+      type: 'heatmap',
+      z: zData.map(function (row) { return row.map(function () { return 0; }); }),
+      x: xLabels,
+      y: comparisonData.ke_titles,
+      opacity: 0,
+      showscale: false,
+      hoverinfo: 'skip'
+    };
+
+    return { trace: trace, axisAnchor: axisAnchor, layout: layout, config: config };
   }
 
   /**
@@ -652,11 +724,11 @@
     var hd = buildHeatmapData(mode, refIndex);
     if (!heatmapInitialised) {
       // Initial render — create the Plotly figure from scratch.
-      Plotly.newPlot('heatmap-div', [hd.trace], hd.layout, hd.config);
+      Plotly.newPlot('heatmap-div', [hd.axisAnchor, hd.trace], hd.layout, hd.config);
       heatmapInitialised = true;
     } else {
       // Subsequent updates — efficiently patch the existing figure without full re-create.
-      Plotly.react('heatmap-div', [hd.trace], hd.layout);
+      Plotly.react('heatmap-div', [hd.axisAnchor, hd.trace], hd.layout);
     }
   }
 
@@ -745,12 +817,19 @@
           } else {
             var fdrText = (fdrVal === null || fdrVal === undefined)
               ? 'n/a' : fdrVal.toExponential(2);
-            displayVal = (nesVal >= 0 ? '+' : '') + nesVal.toFixed(2)
+            isSig = isSignificantFdr(fdrVal);
+            // #107: grey the NES where the heatmap blanks it, so the table and
+            // the heatmap make the same claim about which signs are supported.
+            // The value itself stays readable — de-emphasised, not hidden.
+            var nesText = (nesVal >= 0 ? '+' : '') + nesVal.toFixed(2);
+            displayVal = (isSig ? nesText
+                          : '<span style="color:#999;" title="FDR &ge; '
+                            + FDR_CUTOFF + ' — the sign of NES is not supported here">'
+                            + nesText + '</span>')
               + '<span style="color:#777;font-size:11px;"> q=' + fdrText + '</span>';
             // Sort on NES descending-friendly magnitude; keep raw NES so the
             // column sorts by direction as displayed.
             sortVal = String(nesVal);
-            isSig = (fdrVal !== null && fdrVal !== undefined && fdrVal < 0.05);
           }
         } else if (mode === 'absolute') {
           if (fdrVal === null || fdrVal === undefined) {

--- a/tests/test_batch_gsea.py
+++ b/tests/test_batch_gsea.py
@@ -712,3 +712,123 @@ class TestBatchFormThresholdsUnderGsea:
         # while the run kept using it for the significant-gene counts.
         assert "thresholds.style.display = isGsea ? 'none' : ''" not in body
         assert 'batch-threshold-gsea-note' in body
+
+
+class TestNesHeatmapMasking:
+    """Issue #107: colour must encode direction only where direction is supported."""
+
+    def _matrix(self):
+        """A GSEA matrix mixing significant and far-from-significant cells.
+
+        The non-significant values are the ones from the issue: cisplatin 72h
+        KEs whose NES flipped sign between two legitimate ways of running the
+        same comparison, all at FDR >= 0.48.
+        """
+        return {
+            'method': 'gsea',
+            'ke_labels': ['KE:1392', 'KE:115'],
+            'ke_titles': ['Unstable', 'Real'],
+            'condition_labels': ['C1', 'C2'],
+            'fdr_matrix': [[0.48, 0.62], [0.001, None]],
+            'neg_log10_matrix': [[None, None], [3.0, None]],
+            'nes_matrix': [[1.16, -0.75], [2.4, 1.9]],
+        }
+
+    def test_non_significant_cells_are_blanked(self):
+        from services.batch_report_service import _mask_nes_by_significance
+
+        m = self._matrix()
+        masked = _mask_nes_by_significance(m['nes_matrix'], m['fdr_matrix'])
+
+        assert masked[0] == [None, None], 'FDR >= 0.48 must not be coloured'
+
+    def test_significant_cells_keep_their_signed_nes(self):
+        from services.batch_report_service import _mask_nes_by_significance
+
+        m = self._matrix()
+        masked = _mask_nes_by_significance(m['nes_matrix'], m['fdr_matrix'])
+
+        assert masked[1][0] == 2.4
+
+    def test_untested_cell_is_blank_not_coloured(self):
+        """A KE absent from a condition has no FDR — absent is not significant."""
+        from services.batch_report_service import _mask_nes_by_significance
+
+        m = self._matrix()
+        masked = _mask_nes_by_significance(m['nes_matrix'], m['fdr_matrix'])
+
+        assert masked[1][1] is None
+
+    def test_input_matrix_is_not_mutated(self):
+        """The unmasked NES is the record the table and exports read."""
+        from services.batch_report_service import _mask_nes_by_significance
+
+        m = self._matrix()
+        _mask_nes_by_significance(m['nes_matrix'], m['fdr_matrix'])
+
+        assert m['nes_matrix'] == [[1.16, -0.75], [2.4, 1.9]]
+
+    def test_missing_fdr_matrix_leaves_nes_untouched(self):
+        """Nothing can be assessed without FDR — do not blank the whole figure."""
+        from services.batch_report_service import _mask_nes_by_significance
+
+        assert _mask_nes_by_significance([[1.0]], None) == [[1.0]]
+
+    def test_report_heatmap_uses_the_masked_matrix(self):
+        """The PDF and the screen must not disagree about which signs count."""
+        from unittest.mock import patch
+
+        from services import batch_report_service as brs
+
+        with patch.object(brs, 'render_figure_png', return_value=b'PNG'), \
+             patch('plotly.graph_objects.Heatmap') as heatmap:
+            brs.render_heatmap_png(self._matrix())
+
+        z = heatmap.call_args.kwargs['z']
+        assert z[0] == [None, None]
+        assert z[1][0] == 2.4
+
+    def test_export_keeps_every_nes(self):
+        """The download is the raw record — masking belongs to the rendering."""
+        df = comparison_matrix_to_dataframe(self._matrix(), which='nes')
+
+        assert list(df['C1']) == [1.16, 2.4]
+        assert list(df['C2'])[0] == -0.75
+
+
+class TestBlankHeatmapStaysLegible:
+    """Issue #107: a heatmap with nothing significant must still say what it covers."""
+
+    def test_axis_anchor_trace_accompanies_the_heatmap(self):
+        """Plotly infers its axes from the data; an all-null z draws no labels.
+
+        The transparent companion trace carries the same categories so the
+        figure keeps its Key Event and condition labels when every cell is
+        masked — which is the common case for a batch where nothing reaches
+        the cutoff, and an ordinary result rather than an error.
+        """
+        from unittest.mock import patch
+
+        from services import batch_report_service as brs
+
+        matrix = {
+            'method': 'gsea',
+            'ke_labels': ['KE:1'],
+            'ke_titles': ['Alpha'],
+            'condition_labels': ['C1', 'C2'],
+            'fdr_matrix': [[0.9, 0.8]],
+            'neg_log10_matrix': [[None, None]],
+            'nes_matrix': [[1.1, -0.9]],
+        }
+
+        with patch.object(brs, 'render_figure_png', return_value=b'PNG'), \
+             patch('plotly.graph_objects.Heatmap') as heatmap:
+            brs.render_heatmap_png(matrix)
+
+        assert heatmap.call_count == 2, 'expected an axis anchor plus the data trace'
+        anchor = heatmap.call_args_list[0].kwargs
+        assert anchor['opacity'] == 0
+        assert anchor['showscale'] is False
+        assert anchor['x'] == ['C1', 'C2']
+        assert anchor['y'] == ['Alpha']
+        assert anchor['z'] == [[0, 0]], 'anchor must be drawable, not null'


### PR DESCRIPTION
Closes #107. Follow-up to #76.

Based on #111 (which is based on #109) — both touch `batch_report_service`, so merge order is #109 → #111 → this. The diff here is one commit.

The batch GSEA comparison matrix coloured every cell on a diverging NES scale regardless of significance. For a cell nowhere near significant the sign of NES is not a stable quantity, so the colour was showing noise as direction.

Comparing a batch run (harmonised background, 12545 genes) against the same conditions run singly (per-file background, ~12960), four of six KEs for cisplatin 72h carried opposite-signed NES — KE 1392 +1.16 vs −0.75, KE 149 +0.66 vs −0.61, KE 1825 +1.09 vs −0.81, KE 177 +1.06 vs −0.61 — every one at FDR ≥ 0.48. Re-running a single GSEA twice returns identical NES and FDR to four decimals, so this is not non-determinism but ordinary background sensitivity in the weakest condition. On the heatmap those cells nonetheless swung from saturated blue to saturated red between two legitimate ways of running the same comparison.

## What changed

Cells above the FDR cutoff are left uncoloured, in the browser and in the server-rendered report heatmap alike, so the two cannot make different claims. The table greys the same values rather than hiding them — a consistently signed sub-threshold NES across a dose series is still worth reading — and **the exports are untouched**: a download is the raw record, and the FDR matrix is downloadable beside it. That divergence is deliberate and now stated in the docstrings.

Two supporting changes:

- The cutoff reaches the compare page from `Config.SIGNIFICANCE_FDR_CUTOFF` instead of a literal repeated through the script, keeping #63's single notion of significance.
- Because plotly infers its axes from the data it is given, a fully masked matrix rendered as a **featureless grey box with no tick labels at all**. A batch where nothing reaches the cutoff is an ordinary result, not an error, so a transparent companion trace anchors the categories and the blank heatmap still names its Key Events and conditions.

## Verification

Ran a real two-condition GSEA batch on AOP:472 through the dev server. Every cell landed at FDR ≥ 0.097, including two sign flips between conditions (Oxidative Stress +1.43 vs −1.10, Mitochondrial dysfunction −1.13 vs +1.28). Confirmed in the browser and in the generated PDF:

- heatmap: all cells blank, all six Key Events and both conditions still labelled, caption explains why
- table: every NES present but greyed, with its q-value
- forcing one cell significant restores its colour and the colourbar, with the rest still blank
- CSV/Excel export still carries every signed NES

Full suite green (569 passed), with new tests for the mask, the untested-cell case, non-mutation of the source matrix, the report heatmap using the masked matrix, the unmasked export, and the axis anchor.