### PR TITLE
docs: min_confidence on the Builder's GMT routes is now a threshold

### DIFF
--- a/docs/KE-MAPPING-API-REFERENCE.md
+++ b/docs/KE-MAPPING-API-REFERENCE.md
@@ -254,7 +254,26 @@ Download KE-WP mappings as a GMT (Gene Matrix Transposed) file. The Builder
 resolves each mapped pathway/term to its **member genes**, so the GMT contains
 gene symbols (not pathway IDs) — ready for `fgsea` / `clusterProfiler`.
 
-**Query params:** `?min_confidence=High|Medium|Low` (optional filter)
+**Query params:** `?min_confidence=High|Medium|Low` (optional **threshold**)
+
+`min_confidence` is a minimum, not a tier selector: `Medium` returns medium- and
+high-confidence mappings, `High` returns high only, and `Low` is equivalent to
+omitting the parameter. Mappings with no recorded confidence are always
+included, so the filter can never silently empty an export.
+
+> **Builder behaviour changed on 2026-07-22 (builder#206).** Before that date the
+> parameter selected a *single* tier, so `min_confidence=Medium` returned medium
+> only and dropped every high-confidence mapping — the opposite of what the name
+> promises. This is why the Analyser's minimum-confidence control could not
+> simply be forwarded to these endpoints (analyser#71): passing it through would
+> have discarded the best-evidenced mappings.
+>
+> Two things to get right when wiring it up:
+> - The Analyser's vocabulary is `("all", "medium", "high")`; the Builder's
+>   whitelist is `{high, medium, low}`. `all` returns **HTTP 400** — translate it
+>   to an omitted parameter rather than forwarding it verbatim.
+> - `min_confidence` must be part of the reference-set cache key, or a run at one
+>   threshold will serve gene sets cached at another.
 
 **Response:** `text/plain` GMT file. One gene set per line, tab-separated:
 ```


### PR DESCRIPTION
Updates the integration contract for marvinm2/molAOP-builder#206, which merged today.

`?min_confidence=` on `/exports/gmt/*` used to select a **single tier** — `Medium` returned medium-confidence mappings only and silently dropped the high-confidence ones. That is why our minimum-confidence control could not simply be forwarded to those endpoints (#67), and why #71 was blocked: passing it through would have discarded the *best*-evidenced mappings.

It is now a genuine threshold, and mappings with no recorded confidence are always included so the filter can never empty an export.

Two things to get right when #71 is actually wired up, both now recorded in the doc:

- Our vocabulary is `("all", "medium", "high")`; the Builder's whitelist is `{high, medium, low}`. **`all` returns HTTP 400** if forwarded verbatim — translate it to an omitted parameter.
- `min_confidence` must become part of the reference-set cache key, or a run at one threshold will serve gene sets cached at another.

Docs only — no code change. #71 stays open.

Heads-up on a separate Builder change landing at the same time: marvinm2/molAOP-builder#208 propagates GO gene annotations over the ontology closure, so GO-backed KE gene sets grow substantially (`GO:0008219` goes 7 → 891 genes). Fisher p-values and BH-FDR will shift for every GO-backed Key Event, and some Key Events will cross `MIN_KE_GENES = 5` for the first time. That is a correction, but it will read as a regression to anyone diffing old and new reports. It takes effect once the Builder's data artifacts are regenerated on the mount.