### PR TITLE
Scope the unresolved-pathway warning to the analysed AOP (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,28 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Fixed
 
+- **The unresolved-pathway warning describes the AOP being analysed** (#108). The warning
+  added with #79/#81 — *"N mapped pathway(s) could not be resolved to genes … their coverage
+  is understated here"* — was computed over the whole reference universe rather than the
+  selected AOP, so it fired on every run whether or not that run had lost anything. On
+  AOP:472 it named `WP1234`, `WP3980` and `WP4010`, none of which is mapped to any of its Key
+  Events; every one of its fourteen pathways resolved and no Key Event lost a single gene.
+  This is the inverse of the failure #79 and #81 were about, and worse: rather than hiding a
+  real gap it asserts one that does not exist, on the same page the numbers are read from. An
+  author writing up that result would reasonably add a caveat that their coverage was
+  understated, and the caveat would be false. A warning that fires unconditionally is also
+  one readers learn to ignore — including on the runs where it is true.
+
+  `scope_resolution_to_aop()` now narrows the resolution's `unresolved_pathways` and
+  `unresolved_ke_pathways` to the run's own Key Events, and the block is suppressed entirely
+  when nothing survives. Scoping happens where the run is created — the single-analysis route
+  and `_persist_and_launch_batch()`, both of which already know the AOP — so the stored
+  resolution is correct and the results page, the report, the batch summary, the condition
+  pages and shared links all inherit it without repeating the lookup. An AOP whose topology
+  cannot be loaded leaves the resolution unscoped rather than emptied: an over-broad warning
+  is recoverable, a silently suppressed one is not. Runs stored before this change keep the
+  unscoped accounting they were saved with.
+
 - **Batch condition pages state the gene-set resources the batch actually used** (#74).
   `/batch/<uuid>/condition/<n>` re-renders the results page from stored condition data, but
   never carried the batch's resource selection into that context — and the template

--- a/app.py
+++ b/app.py
@@ -835,6 +835,11 @@ def analyze():
         current_reference_sets, data_source, resource_resolution = load_cached_reference_sets(
             resources, min_confidence=min_confidence
         )
+        # Issue #108: the resolution above covers the whole reference universe.
+        # Narrow its unresolved-pathway accounting to this AOP's Key Events
+        # before it is stored or rendered, or the run reports lost coverage that
+        # belongs to some other AOP.
+        resource_resolution = scope_resolution_to_aop(resource_resolution, ke_list)
 
         # Issue #81: a KE whose only pathway could not be resolved to genes is
         # absent from the reference sets exactly like an uncurated one. This
@@ -1889,6 +1894,58 @@ def load_cached_reference_sets(resources=DEFAULT_RESOURCES,
     )
 
 
+def scope_resolution_to_aop(resolution, ke_ids):
+    """Restrict the unresolved-pathway accounting to one AOP's Key Events (#108).
+
+    ``load_cached_reference_sets()`` resolves the whole reference universe, so
+    its ``unresolved_pathways`` / ``unresolved_ke_pathways`` entries name every
+    mapped pathway no source could resolve — across every AOP, not the one being
+    analysed. Rendered unscoped, the #79/#81 warning fires on every run
+    regardless of whether the selected AOP lost anything, telling an author that
+    their coverage is understated when it is not. That is the inverse of the
+    failure #79/#81 fixed and worse: a warning that fires unconditionally is
+    also one users learn to ignore on the runs where it is true.
+
+    Scoping happens here, where the run is created and its AOP is known, so the
+    stored resolution is already correct and every downstream reader (results
+    page, report, batch summary, condition pages, shared links) inherits it
+    without repeating the AOP lookup.
+
+    Args:
+        resolution: list produced by ``load_cached_reference_sets``.
+        ke_ids: the KE IDs belonging to this run's AOP. Falsy means the AOP's
+            Key Events could not be established, in which case the resolution is
+            returned unchanged — an over-broad warning is a lesser failure than
+            one silently suppressed.
+
+    Returns:
+        list: a new resolution list with copied entries, so a resolution shared
+        with another caller is never narrowed in place.
+    """
+    if not ke_ids:
+        return resolution
+
+    in_scope = {str(ke) for ke in ke_ids}
+    scoped = []
+    for entry in resolution:
+        entry = dict(entry)
+        by_ke = {
+            ke: list(pathways)
+            for ke, pathways in (entry.get('unresolved_ke_pathways') or {}).items()
+            if str(ke) in in_scope
+        }
+        entry['unresolved_ke_pathways'] = by_ke
+        # Derive the flat list from the surviving map rather than filtering it
+        # separately. Both are built from the same KE-pathway mappings, so
+        # deriving one from the other keeps the warning's pathway count and its
+        # Key Event count describing the same set by construction.
+        entry['unresolved_pathways'] = sorted({
+            wp for pathways in by_ke.values() for wp in pathways
+        })
+        scoped.append(entry)
+    return scoped
+
+
 def describe_resource_resolution(resolution):
     """One-line summary of how each requested resource actually resolved (#68).
 
@@ -2290,6 +2347,20 @@ def _persist_and_launch_batch(*, batch_uuid, filenames, condition_labels, doses,
     current_reference_sets, _, resource_resolution = load_cached_reference_sets(
         resources, min_confidence=min_confidence
     )
+    # Issue #108: scope the unresolved-pathway accounting to the batch's AOP
+    # before storing it — every condition page and the batch report read this
+    # one record, so an unscoped copy misreports lost coverage on all of them.
+    # run_batch() loads the same topology moments later; the lookup is cached,
+    # and a failure here only costs the scoping, never the batch.
+    try:
+        batch_ke_list, _edges, _types, _titles = load_aop_data(aop_id)
+    except Exception as exc:
+        logger.warning(
+            'Could not load AOP %s to scope the resource resolution (%s); '
+            'storing it unscoped', aop_id, exc
+        )
+        batch_ke_list = None
+    resource_resolution = scope_resolution_to_aop(resource_resolution, batch_ke_list)
     # Issue #68: record what the batch actually loaded, not what it requested —
     # every condition in the batch shares this resolution.
     _store_batch_resource_resolution(batch_id, resource_resolution)

--- a/tests/test_reference_resources.py
+++ b/tests/test_reference_resources.py
@@ -544,6 +544,75 @@ class TestPathwayResolutionGap:
         }]
         assert app.resource_resolution_warnings(resolution) == []
 
+
+class TestUnresolvedWarningIsScopedToTheAOP:
+    """Issue #108: the warning must describe the AOP being analysed.
+
+    The resolution is built over the whole reference universe, so before this
+    scoping every run claimed its coverage was understated — naming pathways
+    belonging to Key Events in other AOPs entirely. Asserting a gap that does
+    not exist is worse than the silent gap #79/#81 fixed: it travels into the
+    caveats an author writes around the numbers on the same page.
+    """
+
+    def _resolution(self):
+        return [{
+            'resource': 'WikiPathways', 'status': 'loaded', 'source': 'api',
+            'ke_count': 90, 'confidence_applied': True,
+            'unresolved_pathways': ['WP1234', 'WP3980', 'WP4010'],
+            'unresolved_ke_pathways': {
+                'KE:840': ['WP1234'],
+                'KE:344': ['WP3980'],
+                'KE:1115': ['WP4010'],
+            },
+            'error': None,
+        }]
+
+    def test_pathways_from_other_aops_are_dropped(self):
+        scoped = app.scope_resolution_to_aop(self._resolution(), {'KE:1115'})
+
+        assert scoped[0]['unresolved_pathways'] == ['WP4010']
+        assert scoped[0]['unresolved_ke_pathways'] == {'KE:1115': ['WP4010']}
+
+    def test_warning_is_suppressed_when_this_aop_lost_nothing(self):
+        """The AOP:472 case from the report: none of the three is its own."""
+        scoped = app.scope_resolution_to_aop(
+            self._resolution(), {'KE:1', 'KE:2', 'KE:3'}
+        )
+
+        assert scoped[0]['unresolved_pathways'] == []
+        assert app.resource_resolution_warnings(scoped) == []
+
+    def test_surviving_warning_names_only_this_aops_key_events(self):
+        scoped = app.scope_resolution_to_aop(self._resolution(), {'KE:1115'})
+
+        joined = " ".join(app.resource_resolution_warnings(scoped))
+        assert "WP4010" in joined and "KE:1115" in joined
+        for elsewhere in ("WP1234", "WP3980", "KE:840", "KE:344"):
+            assert elsewhere not in joined
+
+    def test_unknown_key_events_leave_the_resolution_alone(self):
+        """Scoping we cannot perform must not silently empty the accounting.
+
+        An over-broad warning is recoverable; one suppressed because the AOP
+        topology failed to load hides a real gap with no trace.
+        """
+        original = self._resolution()
+
+        assert app.scope_resolution_to_aop(original, None) == original
+        assert app.scope_resolution_to_aop(original, set()) == original
+
+    def test_the_source_resolution_is_not_mutated(self):
+        """The resolution can come from a cache shared with the next caller."""
+        original = self._resolution()
+
+        app.scope_resolution_to_aop(original, {'KE:1115'})
+
+        assert original[0]['unresolved_pathways'] == ['WP1234', 'WP3980', 'WP4010']
+        assert set(original[0]['unresolved_ke_pathways']) == {
+            'KE:840', 'KE:344', 'KE:1115'
+        }
+
 class TestCacheFormatUpgrade:
     """The #79 cache entry gained a third element; warm caches must survive.
 


### PR DESCRIPTION
Closes #108.

## The problem

The warning added with #79/#81 —

> N mapped pathway(s) could not be resolved to genes (…) and contributed nothing to this analysis. The affected Key Events are curated — their coverage is understated here.

— was computed over the **whole reference universe** rather than the selected AOP, so it fired on every run whether or not that run lost anything.

Reproduced against the live reference cache: the unscoped accounting names `WP1234, WP3980, WP4010` across `KE:123, KE:244, KE:344, KE:345, KE:459, KE:840` — exactly the pathways and Key Events reported on AOP:472, none of which belongs to it.

This is the inverse of the failure #79 and #81 were about, and worse: rather than hiding a real gap it asserts one that does not exist, on the same page the numbers are read from. An author writing up that result would reasonably add a caveat that their coverage is understated, and the caveat would be false. It is also self-undermining — a warning that fires unconditionally is one readers learn to ignore, including on the runs where it is true.

## The fix

`scope_resolution_to_aop()` narrows each resolution entry's `unresolved_ke_pathways` to the run's own Key Events and derives `unresolved_pathways` from what survives; the existing empty check then suppresses the block. Deriving one from the other keeps the sentence's pathway count and Key Event count describing the same set by construction.

Scoping happens **where the run is created** — the single-analysis route (`ke_list` is already loaded two lines earlier) and `_persist_and_launch_batch()` — so the stored resolution is correct and the results page, report, batch summary, condition pages and shared links all inherit it without repeating the AOP lookup.

Two deliberate choices:

- An AOP whose topology cannot be loaded leaves the resolution **unscoped rather than emptied**. An over-broad warning is recoverable; one suppressed because a SPARQL lookup failed hides a real gap with no trace.
- Entries are copied, not mutated — the resolution can come from a cache shared with the next caller.

Runs stored before this change keep the unscoped accounting they were saved with.

## Verification

Against the live cache, before and after:

| AOP | affected KEs | warning |
|---|---|---|
| unscoped | 6 | names WP1234, WP3980, WP4010 |
| AOP:2 | 0 | silent |
| AOP:DEMO | 1 | names WP4010 only |

Five new tests in `tests/test_reference_resources.py` cover the drop, the suppression, the surviving-warning contents, the unknown-KE fallback and non-mutation. Full suite: 586 passed, coverage 81.7%.