### PR TITLE
Apply the mapping-confidence threshold to GO BP and Reactome (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,48 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 - Design-token layer in `static/css/main.css` mirroring the Builder's `:root` block —
   VHP4Safety palette, spacing, radius, shadow and z-index scales as CSS custom properties.
 
+### Added
+
+- **The mapping-confidence threshold now applies to GO BP and Reactome, not just
+  WikiPathways** (#71). The threshold has been offered on both forms since #60, but it only
+  ever filtered the Builder's curated WikiPathways mappings — a "High only" run over all
+  three resources filtered one component and used the other two whole. #67 made the Analyser
+  *disclose* that rather than fix it, because the fix was not available: the Builder's GMT
+  `?min_confidence=` selected a **single tier**, so forwarding the user's choice would have
+  dropped every high-confidence mapping when they asked for "Medium and High" — worse than
+  not filtering at all.
+
+  molAOP-builder#206 shipped on 2026-07-22 and the parameter now means *at-or-above*, with
+  unrecorded confidences always included, so `services/api_service.fetch_gmt_reference_sets()`
+  forwards it. Verified against the live Builder: `GO_BP` goes 12 KEs / 4,334 genes at `all`
+  to 6 KEs / 1,791 at `high`, `Reactome` 8 / 755 to 4 / 144, and each level's Key Events are a
+  subset of the one below — the nesting that distinguishes a threshold from the old tier
+  selector.
+
+  Two traps handled explicitly. Our vocabulary is `("all", "medium", "high")` and the
+  Builder's whitelist is `{high, medium, low}`: `all` is **not** in it and returns HTTP 400,
+  which would drop the resource for the whole run, so `gmt_min_confidence_param()` translates
+  it to an omitted parameter and degrades anything unrecognised the same way. And the
+  reference-set cache key already carried the threshold, which now matters materially rather
+  than defensively — the three levels fetch genuinely different gene sets, so a shared key
+  would serve a `high` run the sets cached for `all`.
+
+  A run that falls back to the reference files bundled in the image is still unfiltered —
+  those carry no confidence column — and both forms now say the threshold applies to all
+  three resources with that one exception, instead of naming WikiPathways alone.
+
 ### Fixed
+
+- **An unfiltered resource is no longer blamed on the bundled reference files** (#71). The
+  disclosure added with #67 split its explanation on whether a resource appeared in the
+  filterable list, which was the same thing as "has a bundled CSV fallback" only for as long
+  as WikiPathways was the sole filterable resource. Once GO BP and Reactome became filterable,
+  a run recorded before #71 — whose stored resolution marks them unfiltered — would have
+  rendered *"served from the bundled reference files"* for resources that **have no bundled
+  fallback and never did**. The reason is now attributed from the resource's own fallback path
+  (`CSV_FALLBACK_RESOURCES`), so the bundled-files explanation is only ever given where it is
+  true, and everything else says plainly that the threshold was not applied. This is the same
+  class of defect as #108: a disclaimer that reads as diligence while stating something false.
 
 - **The unresolved-pathway warning describes the AOP being analysed** (#108). The warning
   added with #79/#81 — *"N mapped pathway(s) could not be resolved to genes … their coverage

--- a/app.py
+++ b/app.py
@@ -1458,27 +1458,43 @@ RESOURCE_SOURCE_LABELS = {
     'gmt': 'Builder GMT export',
 }
 
-# Issue #67 — the minimum-confidence threshold can only be applied where the
-# mappings carry a confidence field. That is the Builder's mapping API, which
-# serves WikiPathways; the GMT exports behind GO_BP/Reactome have no such
-# field, and neither does the bundled KE-WP.csv fallback. So applicability is a
-# function of BOTH the resource and where its gene sets came from.
-CONFIDENCE_FILTERABLE_RESOURCES = ('WikiPathways',)
+# Issue #67/#71 — the minimum-confidence threshold can only be applied where the
+# mappings carry a confidence field AND the path that served them honours it.
+#
+# All three resources now qualify. WikiPathways is filtered here, from the
+# Builder's mapping API. GO_BP and Reactome are filtered Builder-side: their GMT
+# exports gained real threshold semantics in molAOP-builder#206 (2026-07-22) and
+# the Analyser forwards `?min_confidence=` since #71. Before that the parameter
+# selected a single tier, so forwarding it would have dropped the
+# best-evidenced mappings — which is why this tuple held WikiPathways alone.
+#
+# The bundled KE-WP.csv fallback still carries no confidence column, so
+# applicability remains a function of BOTH the resource and where its gene sets
+# came from: a WikiPathways run served from the CSVs is still unfiltered.
+CONFIDENCE_FILTERABLE_RESOURCES = ('WikiPathways', 'GO_BP', 'Reactome')
 CONFIDENCE_FILTERABLE_SOURCES = ('api', 'cache(api)')
+
+# Resources that can fall back to reference files bundled in the image. Only
+# WikiPathways has one (data/KE-WP.csv + edges_wpid_to_gene.csv); a GMT resource
+# with no Builder is simply skipped. Kept separate from the filterable list so a
+# warning can attribute an unfiltered resource to the *right* cause.
+CSV_FALLBACK_RESOURCES = ('WikiPathways',)
 
 
 def _confidence_was_applicable(resource, source):
-    """Could the minimum-confidence threshold act on this resource? (#67)
+    """Could the minimum-confidence threshold act on this resource? (#67, #71)
 
     Args:
         resource: resource key from VALID_RESOURCES.
         source: where its gene sets came from ('api', 'cache(csv)', ...).
 
     Returns:
-        bool: True only when the mappings carry a confidence field — the
-        Builder mapping API's WikiPathways mappings. Everything else is a
-        documented no-op that the UI and reports must disclose rather than
-        imply a filter that never ran.
+        bool: True when the run's gene sets for this resource were actually
+        filtered — every resource served live (or from a cache of a live
+        response), since #71 made the GMT resources filterable too. False for
+        the bundled-CSV path, which carries no confidence column and is a
+        documented no-op the UI and reports must disclose rather than imply a
+        filter that never ran.
     """
     return (
         resource in CONFIDENCE_FILTERABLE_RESOURCES
@@ -1661,10 +1677,11 @@ def _load_gmt_resource_reference_sets(resource, min_confidence=DEFAULT_MIN_CONFI
 
     Args:
         resource: 'GO_BP' or 'Reactome'.
-        min_confidence: issue #60 threshold. The GMT exports carry no confidence
-            field, so filtering is a no-op for these resources — but the cache
-            key is still scoped by the threshold so entries can never leak
-            across levels.
+        min_confidence: issue #60 threshold, forwarded to the Builder's GMT
+            export as ``?min_confidence=`` since issue #71. The cache key is
+            scoped by the threshold, which now matters materially rather than
+            defensively: the three thresholds fetch three different gene sets,
+            so a shared key would serve a 'high' run the sets cached for 'all'.
 
     Returns:
         tuple: (reference_sets dict, source string) where source is 'api' or
@@ -1682,7 +1699,9 @@ def _load_gmt_resource_reference_sets(resource, min_confidence=DEFAULT_MIN_CONFI
         )
         return reference_sets, f"cache({original_source})"
 
-    reference_sets = fetch_gmt_reference_sets(Config, resource)
+    reference_sets = fetch_gmt_reference_sets(
+        Config, resource, min_confidence=min_confidence
+    )
     _reference_cache.set(
         cache_key,
         (reference_sets, "api"),
@@ -2019,24 +2038,30 @@ def resource_resolution_warnings(resolution, min_confidence=DEFAULT_MIN_CONFIDEN
         )
 
     if min_confidence != DEFAULT_MIN_CONFIDENCE:
-        # Two different reasons the threshold did nothing, worth telling apart:
-        # the resource has no confidence field at all, or it does but this run
-        # took a path that does not carry it (the bundled CSVs).
-        no_field = [
+        # Two different reasons the threshold did nothing, worth telling apart —
+        # and the reason must be attributed from the resource's own fallback
+        # path, not inferred from the filterable list. Since #71 every resource
+        # is filterable on its live path, so an unfiltered entry means either a
+        # bundled-CSV fallback (WikiPathways only) or a run recorded before #71.
+        # Blaming the bundled files for a GMT resource would be a false
+        # statement of the same kind #108 was about: GO_BP and Reactome have no
+        # bundled fallback, so they can never have been served from one.
+        unfiltered = [
             e['resource'] for e in resolution
             if e.get('status') == 'loaded' and not e.get('confidence_applied')
-            and e['resource'] not in CONFIDENCE_FILTERABLE_RESOURCES
         ]
         no_field_this_run = [
-            e['resource'] for e in resolution
-            if e.get('status') == 'loaded' and not e.get('confidence_applied')
-            and e['resource'] in CONFIDENCE_FILTERABLE_RESOURCES
+            r for r in unfiltered if r in CSV_FALLBACK_RESOURCES
         ]
-        if no_field:
+        unfiltered_unattributed = [
+            r for r in unfiltered if r not in CSV_FALLBACK_RESOURCES
+        ]
+        if unfiltered_unattributed:
             warnings.append(
-                f"The minimum mapping confidence filtered the Builder's curated "
-                f"mappings only. {', '.join(no_field)} carries no confidence field, "
-                f"so its gene sets are unfiltered."
+                f"The minimum mapping confidence was not applied to "
+                f"{', '.join(unfiltered_unattributed)}; those gene sets are "
+                f"unfiltered. Runs recorded before this became possible report "
+                f"it this way."
             )
         if no_field_this_run:
             warnings.append(

--- a/services/api_service.py
+++ b/services/api_service.py
@@ -410,7 +410,36 @@ def parse_gmt_reference_sets(gmt_text):
     return reference_sets
 
 
-def fetch_gmt_reference_sets(config, resource):
+def gmt_min_confidence_param(min_confidence):
+    """Translate our confidence vocabulary into the Builder's query param (#71).
+
+    The two vocabularies do not match. Ours is
+    :data:`helpers.VALID_MIN_CONFIDENCE` — ``("all", "medium", "high")``, where
+    ``all`` is a sentinel meaning "do not filter". The Builder's whitelist is
+    ``{high, medium, low}``, and ``all`` is **not in it**: forwarding it
+    verbatim returns HTTP 400 and loses the resource for the whole run. So
+    ``all`` becomes an omitted parameter, which under the post-builder#206
+    semantics is exactly equivalent (``low`` is also equivalent, but omitting
+    says what we mean).
+
+    Args:
+        min_confidence: a value from ``VALID_MIN_CONFIDENCE``. Anything
+            unrecognised is treated as ``all`` — an unfiltered gene set is the
+            safe failure here, since the alternative is a 400 that skips the
+            resource entirely.
+
+    Returns:
+        dict: query params for ``requests``; empty when no filtering applies.
+        The Builder matches case-insensitively (verified live 2026-07-22
+        against `High`/`high`/`HIGH`), so our lowercase values go through
+        unchanged.
+    """
+    if min_confidence in ("medium", "high"):
+        return {"min_confidence": min_confidence}
+    return {}
+
+
+def fetch_gmt_reference_sets(config, resource, min_confidence=DEFAULT_MIN_CONFIDENCE):
     """Fetch KE-to-gene reference sets for a resource from the Builder GMT export.
 
     Used for resources whose genes are resolved Builder-side and exposed via the
@@ -425,6 +454,19 @@ def fetch_gmt_reference_sets(config, resource):
     resource : str
         Resource key, one of :data:`GMT_RESOURCE_PATHS` (``"GO_BP"`` or
         ``"Reactome"``).
+    min_confidence : str
+        Issue #71 threshold, from :data:`helpers.VALID_MIN_CONFIDENCE`.
+        Forwarded to the Builder as ``?min_confidence=`` via
+        :func:`gmt_min_confidence_param`.
+
+        This became possible only with **molAOP-builder#206** (2026-07-22).
+        Before that the parameter selected a *single tier*, so passing
+        ``medium`` returned medium-confidence mappings and dropped every
+        high-confidence one — the opposite of what the name promises, and the
+        reason the Analyser disclosed the limitation instead of forwarding the
+        threshold. It now means at-or-above, and mappings with no recorded
+        confidence are always included, so a threshold can never silently
+        empty an export.
 
     Returns
     -------
@@ -445,15 +487,18 @@ def fetch_gmt_reference_sets(config, resource):
         raise ValueError(f"Unknown GMT resource: {resource!r}")
 
     url = f"{config.BUILDER_API_URL.rstrip('/')}/{GMT_RESOURCE_PATHS[resource]}"
+    params = gmt_min_confidence_param(min_confidence)
     session = _make_api_session()
-    response = session.get(url, timeout=config.BUILDER_API_TIMEOUT)
+    response = session.get(url, params=params, timeout=config.BUILDER_API_TIMEOUT)
     response.raise_for_status()
 
     reference_sets = parse_gmt_reference_sets(response.text)
     logger.info(
-        "Loaded %d KE gene sets for resource %s from GMT export %s",
+        "Loaded %d KE gene sets for resource %s from GMT export %s (min_confidence=%s%s)",
         len(reference_sets),
         resource,
         url,
+        min_confidence,
+        "" if params else ", sent unfiltered",
     )
     return reference_sets

--- a/templates/_batch_analysis.html
+++ b/templates/_batch_analysis.html
@@ -261,12 +261,16 @@
             mappings are all below the threshold is not tested. Mappings without a recorded
             confidence are always kept. Applied equally to all conditions.
         </p>
-        {# Issue #67: the threshold only bites where the mappings carry a
-           confidence, i.e. the WikiPathways mappings from the Builder API. #}
+        {# Issue #67/#71: the threshold bites on all three resources now —
+           WikiPathways filtered here, GO BP and Reactome forwarded to the
+           Builder's GMT exports. The bundled CSV fallback has no confidence
+           column, so a run served from it is still unfiltered. #}
         <p style="font-size: 14px; color: #555; margin-bottom: 12px;">
-            <strong>Applies to WikiPathways mappings only.</strong> The Gene Ontology and
-            Reactome gene sets are served as GMT exports that carry no confidence field,
-            so they are used in full whatever you choose here.
+            <strong>Applies to all three resources.</strong> WikiPathways mappings are
+            filtered here; the Gene Ontology and Reactome gene sets are filtered by the
+            Builder when they are fetched. A resource served from the reference files
+            bundled with this image is used in full — the batch records which resources
+            the threshold was actually applied to.
         </p>
         <div style="margin-bottom: 24px;">
             <select id="batch-min-confidence" style="padding: 8px; font-size: 14px; max-width: 320px;">

--- a/templates/_single_analysis.html
+++ b/templates/_single_analysis.html
@@ -474,14 +474,17 @@
                 a KE whose mappings are all below the threshold is not tested. Mappings
                 without a recorded confidence are always kept.
             </p>
-            {# Issue #67: say where the filter actually bites. The GO BP and
-               Reactome gene sets come from GMT exports with no confidence
-               field, so raising the threshold leaves them untouched. #}
+            {# Issue #67/#71: say where the filter actually bites. Since #71 the
+               GO BP and Reactome thresholds are forwarded to the Builder's GMT
+               exports, so all three resources are filtered — but only on the
+               live path; the bundled CSV fallback has no confidence column. #}
             <p class="settings-subgroup__hint" style="margin: 0 0 8px;">
-                <strong>Applies to WikiPathways mappings only.</strong> The Gene Ontology and
-                Reactome gene sets are served as GMT exports that carry no confidence field,
-                so they are used in full whatever you choose here. The results page records
-                which resources the threshold was actually applied to.
+                <strong>Applies to all three resources.</strong> WikiPathways mappings are
+                filtered here; the Gene Ontology and Reactome gene sets are filtered by the
+                Builder when they are fetched. If a resource falls back to the reference files
+                bundled with this image, those carry no confidence column and are used in
+                full — the results page records which resources the threshold was actually
+                applied to.
             </p>
             {% set sel_min_conf = min_confidence or 'all' %}
             <select name="min_confidence" id="min_confidence"

--- a/tests/test_api_service.py
+++ b/tests/test_api_service.py
@@ -88,6 +88,67 @@ class TestFetchGmtReferenceSets:
         with pytest.raises(ValueError):
             fetch_gmt_reference_sets(self._config(url=""), "Reactome")
 
+    def _captured_params(self, min_confidence):
+        """Run a fetch and return the query params actually sent."""
+        mock_resp = MagicMock()
+        mock_resp.text = SAMPLE_GMT
+        mock_resp.raise_for_status = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+
+        import services.api_service as api_svc
+        with patch.object(api_svc, "_make_api_session", return_value=mock_session):
+            fetch_gmt_reference_sets(
+                self._config(), "GO_BP", min_confidence=min_confidence
+            )
+        return mock_session.get.call_args.kwargs.get("params")
+
+    def test_threshold_is_forwarded_to_the_builder(self):
+        """Issue #71: the whole point — the GMT export does the filtering."""
+        assert self._captured_params("high") == {"min_confidence": "high"}
+        assert self._captured_params("medium") == {"min_confidence": "medium"}
+
+    def test_all_is_sent_as_an_omitted_parameter_not_forwarded(self):
+        """`all` is our sentinel and is NOT in the Builder's whitelist.
+
+        Forwarding it verbatim returns HTTP 400, which would skip the resource
+        for the whole run — a silently narrower analysis, not a visible error.
+        """
+        assert self._captured_params("all") == {}
+
+    def test_unrecognised_threshold_degrades_to_unfiltered(self):
+        """An unfiltered gene set beats a 400 that drops the resource."""
+        assert self._captured_params("bogus") == {}
+        assert self._captured_params(None) == {}
+
+
+class TestGmtMinConfidenceParam:
+    """Issue #71: the vocabulary mismatch that makes this translation necessary.
+
+    Ours is ("all", "medium", "high"); the Builder's whitelist is
+    {high, medium, low}. The overlap is partial in both directions, so the
+    mapping is stated explicitly rather than assumed.
+    """
+
+    def test_our_vocabulary_maps_cleanly(self):
+        from services.api_service import gmt_min_confidence_param
+
+        assert gmt_min_confidence_param("high") == {"min_confidence": "high"}
+        assert gmt_min_confidence_param("medium") == {"min_confidence": "medium"}
+        assert gmt_min_confidence_param("all") == {}
+
+    def test_never_emits_a_value_outside_the_builder_whitelist(self):
+        """Anything we send must be one the Builder accepts, or the run loses
+        the resource. Enumerated rather than spot-checked."""
+        from helpers import VALID_MIN_CONFIDENCE
+        from services.api_service import gmt_min_confidence_param
+
+        builder_whitelist = {"high", "medium", "low"}
+        for value in VALID_MIN_CONFIDENCE:
+            params = gmt_min_confidence_param(value)
+            if params:
+                assert params["min_confidence"] in builder_whitelist
+
 
 class TestFilterRecordsByConfidence:
     """Issue #60: minimum KE-mapping confidence filtering of raw records."""

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -1880,7 +1880,14 @@ class TestResourceProvenanceOnResultsPage:
         assert b'left out of this' in body
 
     def test_confidence_applicability_is_disclosed(self, authenticated_client):
-        """A 'high only' run over GMT resources is not filtered throughout."""
+        """An unfiltered resource is still disclosed — with an honest reason.
+
+        Since #71 a GMT resource is filtered on its live path, so this shape
+        (Reactome loaded but unfiltered) is what a run *recorded before #71*
+        replays as. The page must say the threshold was not applied without
+        blaming the bundled reference files: GO BP and Reactome have no bundled
+        fallback, so that explanation would be false — the #108 failure mode.
+        """
         resolution = [
             {'resource': 'WikiPathways', 'status': 'loaded', 'source': 'api',
              'ke_count': 1, 'confidence_applied': True, 'error': None},
@@ -1889,7 +1896,18 @@ class TestResourceProvenanceOnResultsPage:
         ]
         response = self._analyze(authenticated_client, resolution, min_confidence='high')
         assert response.status_code == 200
-        assert b'carries no confidence field' in response.data
+        assert b'was not applied to Reactome' in response.data
+        assert b'bundled' not in response.data
+
+    def test_csv_fallback_is_still_blamed_on_the_bundled_files(self, authenticated_client):
+        """WikiPathways *does* have a bundled fallback, so name it."""
+        resolution = [
+            {'resource': 'WikiPathways', 'status': 'loaded', 'source': 'cache(csv)',
+             'ke_count': 1, 'confidence_applied': False, 'error': None},
+        ]
+        response = self._analyze(authenticated_client, resolution, min_confidence='high')
+        assert response.status_code == 200
+        assert b'bundled reference files' in response.data
 
     def test_clean_run_shows_provenance_without_a_warning(self, authenticated_client):
         resolution = [

--- a/tests/test_reference_resources.py
+++ b/tests/test_reference_resources.py
@@ -289,13 +289,18 @@ class TestConfidenceScopedCacheKeys:
         fake_cache.set.side_effect = lambda key, value, expire=None: store.__setitem__(key, value)
         monkeypatch.setattr(app, "_reference_cache", fake_cache)
 
-        # GMT exports carry no confidence field, so the sets are identical --
-        # but they must still be stored under distinct, threshold-scoped keys.
+        # Since #71 the threshold is forwarded to the Builder, so the three
+        # levels genuinely fetch different gene sets -- the threshold-scoped
+        # cache key stops a 'high' run being served the sets cached for 'all'.
         with patch.object(app, "fetch_gmt_reference_sets", return_value={"KE:1115": {"SOD1"}}) as fetch:
             app._load_gmt_resource_reference_sets("GO_BP", "all")
             app._load_gmt_resource_reference_sets("GO_BP", "high")
         assert fetch.call_count == 2
         assert len(store) == 2
+        # The threshold reaches the fetch, not just the cache key.
+        assert [c.kwargs.get("min_confidence") for c in fetch.call_args_list] == [
+            "all", "high"
+        ]
 
 
 class TestCachePreservesOriginalSource:
@@ -402,9 +407,16 @@ class TestResourceResolutionRecording:
 
 
 class TestConfidenceApplicabilityIsRecorded:
-    """Issue #67: the threshold only bites where mappings carry a confidence."""
+    """Issue #67/#71: the threshold only bites where it was actually applied."""
 
-    def test_gmt_resources_are_marked_unfiltered(self):
+    def test_gmt_resources_are_filtered_since_71(self):
+        """Was the inverse assertion until 2026-07-22.
+
+        Until molAOP-builder#206 the GMT `?min_confidence=` selected a single
+        tier, so forwarding the threshold would have dropped the *best*-evidenced
+        mappings; the Analyser disclosed the limitation instead. #206 made it a
+        real minimum and #71 forwards it, so all three resources now filter.
+        """
         wp = {"KE:1": {"A"}}
         go = {"KE:1": {"B"}}
         with patch.object(app, "_load_wikipathways_reference_sets", return_value=(wp, "api", [], {})), \
@@ -414,10 +426,20 @@ class TestConfidenceApplicabilityIsRecorded:
             )
         by_resource = {e["resource"]: e for e in resolution}
         assert by_resource["WikiPathways"]["confidence_applied"] is True
-        assert by_resource["GO_BP"]["confidence_applied"] is False
+        assert by_resource["GO_BP"]["confidence_applied"] is True
 
+        # And the run must stop disclosing a limitation it no longer has.
         warnings = app.resource_resolution_warnings(resolution, "high")
-        assert any("GO_BP" in w and "confidence field" in w for w in warnings)
+        assert not any("confidence field" in w for w in warnings), warnings
+
+    def test_a_gmt_resource_served_from_cache_of_a_live_fetch_still_counts(self):
+        """The filtering happened Builder-side before the response was cached."""
+        go = {"KE:1": {"B"}}
+        with patch.object(app, "_load_gmt_resource_reference_sets", return_value=(go, "cache(api)")):
+            _, _, resolution = app.load_cached_reference_sets(
+                ["GO_BP"], min_confidence="high"
+            )
+        assert resolution[0]["confidence_applied"] is True
 
     def test_csv_fallback_cannot_apply_the_threshold_either(self):
         """KE-WP.csv has no confidence column, so 'high' is a no-op there too."""


### PR DESCRIPTION
Closes #71.

## Why this was blocked, and why it isn't now

The minimum-confidence control has been on both forms since #60, but it only ever filtered the Builder's curated **WikiPathways** mappings. A "High only" run over all three resources filtered one component and used the other two whole. #67 made the Analyser *disclose* that rather than fix it — the fix genuinely wasn't available, because the Builder's GMT `?min_confidence=` selected a **single tier**. Forwarding "Medium and High" would have returned medium-confidence mappings and dropped every high-confidence one: worse than not filtering.

[molAOP-builder#206](https://github.com/marvinm2/molAOP-builder/issues/206) shipped 2026-07-22 and the parameter now means *at-or-above*, with unrecorded confidences always included.

## Verified against the live Builder

Not just mocked — the semantics are the whole premise:

| Resource | `all` | `medium` | `high` | nested? |
|---|---|---|---|---|
| `GO_BP` | 12 KEs / 4,334 genes | 12 / 4,334 | 6 / 1,791 | ✅ |
| `Reactome` | 8 / 755 | 8 / 755 | 4 / 144 | ✅ |

Each level's Key Events are a subset of the one below — the nesting that distinguishes a real threshold from the old tier selector. (`medium` ≡ `all` because nothing in the current data is low-confidence.) The Builder also matches case-insensitively, so our lowercase vocabulary goes through unchanged.

## Two traps, handled explicitly

- **`all` is not in the Builder's whitelist** (`{high, medium, low}`) and returns **HTTP 400** — which would skip the resource for the entire run, i.e. a silently narrower analysis rather than a visible error. `gmt_min_confidence_param()` translates it to an omitted parameter, and degrades anything unrecognised the same way.
- **The cache key already carried the threshold**, which now matters materially rather than defensively: the three levels fetch genuinely different gene sets, so a shared key would serve a `high` run the sets cached for `all`.

## A defect this change created, fixed in the same PR

The #67 disclosure split its explanation on whether a resource was in the filterable list — which was the same thing as "has a bundled CSV fallback" only while WikiPathways was the sole filterable resource. Once GO BP and Reactome became filterable, a run **recorded before this change** (whose stored resolution marks them unfiltered) would have rendered *"served from the bundled reference files"* for resources that have no bundled fallback and never did.

That is the same class of defect as #108: a disclaimer that reads as diligence while stating something false. The reason is now attributed from the resource's own fallback path (`CSV_FALLBACK_RESOURCES`), so the bundled-files explanation is only given where it's true.

## Scope note

A resource served from the bundled files is still unfiltered — those carry no confidence column. Both forms now say the threshold applies to all three resources with that one exception, instead of naming WikiPathways alone.

Full suite: **593 passed**, coverage 81.7%.