### PR TITLE
Detect the degenerate GSEA null instead of reporting it as no enrichment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,21 +147,69 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
   The condition is now read off the null distribution rather than off the reported values: the
   size of the same-signed tail, not `NES == 1.0`. That matters because the failure is
-  continuous. A tail of one or two permutations still yields a plausible-looking NES and a
-  sound p-value, but the magnitude is a ratio against a sample of two and cannot be ranked or
-  thresholded on — and no check on the output values can find it. Results now carry a
-  `nes_status` of `ok`, `unstable_normalisation` or `beyond_permutation_resolution`, the
-  same-signed count that produced the call, and the raw `ES` so direction survives even where
+  continuous. A tail of one or two permutations still yields a plausible-looking NES, but the
+  magnitude is a ratio against a sample of two — and no check on the output values can find
+  it. Results now carry a `nes_status` of `ok`, `unstable_normalisation`,
+  `beyond_permutation_resolution` or `undiagnosed`, the same-signed count that produced the
+  call, the achievable `p_value_resolution`, and the raw `ES` so direction survives even where
   the NES does not.
+
+  **The p-value goes with the magnitude.** An earlier draft of this change said the nominal
+  p-value survived a short same-signed tail and only the NES did not; that claim is retracted.
+  gseapy divides the exceedance count by the *same-signed* tail, not by the permutation count,
+  so a term with a tail of five can only report p in steps of 0.2 and a term with a tail of one
+  only 0 or 1. Measured on gseapy 1.1.4, a term with a tail of 56 and one exceedance returns
+  1/56, not 1/100 — and the AOP 472 grid contains a p of 0.600 that is three out of five and a
+  p of 0.000 that is zero out of one. Under `unstable_normalisation` neither number may be
+  ranked or thresholded on, the step size is reported per row as `p_value_resolution`, and the
+  reports print the p-value with that qualifier attached.
 
   Where the tail is empty the NES is reported as undefined rather than as a number — it is
   genuinely not normalisable — while the p-value becomes the resolution bound `1/permutations`
   and the FDR its limit of zero, because no permutation was as extreme as the observation.
   The cell reads as maximally significant, which is what it is, instead of as null.
 
+  **The distinction now reaches every view, not only the single-analysis table.** The batch
+  comparison path — the cross-condition grid, its exports and both batch reports — received a
+  recovered Key Event as a bare `NES = None` and rendered it as an em-dash: unshaded, sorted
+  last, dropped from the heatmap and stripped even of the FDR every other cell carries, i.e.
+  indistinguishable from a Key Event that was never tested and the exact inverse of the
+  result. `nes_status` and `ES` now travel through `build_comparison_matrix` into the table,
+  the heatmap (those cells are ringed rather than coloured — there is no magnitude to put on a
+  diverging scale, only a direction) and both report tables. On the network the same cell
+  reached `nesColor(null)`, whose `parseFloat(nes) || 0` folded it onto `#FFFFFF`, the colour
+  reserved for a NES of exactly zero: a maximally enriched Key Event drawn white with a
+  significance border, inherited by the `.cyjs` export and the network PNG in both reports. The
+  node now carries `nes_status` and `es`, and the state has its own off-gradient treatment and
+  legend entry. Two report captions that promised "every NES value, significant or not" were
+  false for exactly these cells and have been corrected.
+
+  **The diagnostics no longer fabricate statistics under concurrency.** The capture rebinds a
+  process-global (`gseapy.gsea.prerank_rs`), and this app is threaded: Flask runs with
+  `threaded=True` and every batch condition is dispatched on its own thread, so two overlapping
+  runs are routine. Unserialised, the patches nested, both sinks received both runs' summaries,
+  and — since the per-term counts are keyed by KE ID, which is identical across conditions —
+  one condition's tail count landed on another condition's row, where the repair then rewrote
+  that row's NES, p and FDR on the strength of it. The same nesting left the global permanently
+  bound to a dead wrapper whenever the inner block outlived the outer one, which is the normal
+  case. The patch and the `gp.prerank` call it exists for now run under one module-level lock,
+  taken before the global is read, and the restore is identity-checked.
+
+  **A failure to capture is no longer reported as a clean result.** If gseapy renames the entry
+  point, or `method='multilevel'` routes through `fgsea_rs` instead, no null can be inspected.
+  Those rows were labelled `ok` — so a future gseapy bump would have quietly reintroduced the
+  original misreporting under a clean bill of health. They are now labelled `undiagnosed`,
+  logged at error level naming the symbol, and counted into the run's own Key Event accounting
+  sentence, which says in as many words that their NES and p-value are unchecked.
+
   Incidence rises with gene-set size, since a larger set tightens the null: this gets *more*
   likely as Key Event curation improves. Across the AOP 472 grid (5 gene-set pools × 9
   conditions, 315 cells) the six affected cells all carry 379–817 measured genes.
+
+  Known residual, not addressed here: gseapy computes the FDR for the *unaffected* terms from
+  a pooled null that still contains the degenerate terms' substituted `NES = 1.0`. Correcting
+  that means recomputing the FDR outside gseapy, which is a larger change than this one and is
+  tracked separately.
 
 - **A Key Event above the GSEA size ceiling is no longer reported as under-measured** (#120).
   `gseapy.prerank` discards a gene set larger than `max_size` before computing anything, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,7 +209,7 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   Known residual, not addressed here: gseapy computes the FDR for the *unaffected* terms from
   a pooled null that still contains the degenerate terms' substituted `NES = 1.0`. Correcting
   that means recomputing the FDR outside gseapy, which is a larger change than this one and is
-  tracked separately.
+  tracked as #122.
 
 - **A Key Event above the GSEA size ceiling is no longer reported as under-measured** (#120).
   `gseapy.prerank` discards a gene set larger than `max_size` before computing anything, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,45 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Fixed
 
+- **A maximally enriched Key Event is no longer reported as not enriched** (#117). GSEA
+  normalises an observed enrichment score by the mean of the *same-signed* tail of that gene
+  set's permutation null. When the null falls entirely on the other side of zero that tail is
+  empty, the normalisation is undefined, and gseapy substitutes `NES = 1.0` with `p = 1.0` —
+  the values a thoroughly unenriched gene set produces. The one case where every permutation
+  failed to reach the observed score was therefore printed as the null result, and nothing in
+  the table gave the reader a way to tell. On AOP 472 it hid "Increase, DNA damage" in
+  carboplatin at 48 h, which an independent implementation puts among the strongest calls in
+  the grid.
+
+  The condition is now read off the null distribution rather than off the reported values: the
+  size of the same-signed tail, not `NES == 1.0`. That matters because the failure is
+  continuous. A tail of one or two permutations still yields a plausible-looking NES and a
+  sound p-value, but the magnitude is a ratio against a sample of two and cannot be ranked or
+  thresholded on — and no check on the output values can find it. Results now carry a
+  `nes_status` of `ok`, `unstable_normalisation` or `beyond_permutation_resolution`, the
+  same-signed count that produced the call, and the raw `ES` so direction survives even where
+  the NES does not.
+
+  Where the tail is empty the NES is reported as undefined rather than as a number — it is
+  genuinely not normalisable — while the p-value becomes the resolution bound `1/permutations`
+  and the FDR its limit of zero, because no permutation was as extreme as the observation.
+  The cell reads as maximally significant, which is what it is, instead of as null.
+
+  Incidence rises with gene-set size, since a larger set tightens the null: this gets *more*
+  likely as Key Event curation improves. Across the AOP 472 grid (5 gene-set pools × 9
+  conditions, 315 cells) the six affected cells all carry 379–817 measured genes.
+
+- **A Key Event above the GSEA size ceiling is no longer reported as under-measured** (#120).
+  `gseapy.prerank` discards a gene set larger than `max_size` before computing anything, and
+  the exclusion accounting attributed every size-based drop to `min_size`. A Key Event with
+  1200 measured genes was reported — on the results page, on the network and in both reports —
+  as "excluded (fewer than 5 measured genes)", which points the reader at the opposite repair
+  from the one needed. Over-ceiling drops now have their own exclusion reason and accounting
+  clause, the log line names the real bound and the real gene count, and the ceiling itself is
+  a named constant (`Config.GSEA_MAX_KE_GENES`) rather than a literal, so a run can report
+  what it could not test. The value stays at 1000 rather than the Broad convention of 500:
+  three of the seven testable AOP 472 Key Events already exceed 500 measured genes.
+
 - **An unfiltered resource is no longer blamed on the bundled reference files** (#71). The
   disclosure added with #67 split its explanation on whether a resource appeared in the
   filterable list, which was the same thing as "has a bundled CSV fallback" only for as long

--- a/config.py
+++ b/config.py
@@ -94,6 +94,17 @@ class Config:
     # of genes has too little power for the result to be interpretable.
     MIN_KE_GENES = 5
 
+    # GSEA_MAX_KE_GENES is the *upper* bound, and applies to the GSEA path
+    # only — Fisher's exact test has no equivalent. gseapy discards a gene set
+    # larger than this before computing anything, so a Key Event above the
+    # ceiling produces no row at all (issue #120). The Broad/gseapy convention
+    # is 500; 1000 is used here because AOP 472 already has Key Events carrying
+    # 743 and 817 measured genes after curation, and losing them would cost
+    # more than the loss of resolution a broad set costs. It is a named
+    # constant rather than a literal because it has to be reportable: a run has
+    # to be able to say which Key Events it could not test and why.
+    GSEA_MAX_KE_GENES = 1000
+
 
     # Required data files
     REQUIRED_DATA_FILES = [

--- a/services/batch_report_service.py
+++ b/services/batch_report_service.py
@@ -25,9 +25,13 @@ from services.report_service import (
     get_software_versions,
     REPORTLAB_AVAILABLE,
 )
-from services.comparison_service import comparison_matrix_to_dataframe
+from services.comparison_service import (
+    comparison_matrix_to_dataframe,
+    comparison_nes_display_dataframe,
+)
 from services.image_render import render_figure_png
 from services.enrichment_service import format_ke_summary
+from services.gsea_service import NES_BEYOND_RESOLUTION
 from services.network_service import ke_accounting_from_network
 from config import Config
 from helpers import MIN_CONFIDENCE_LABELS
@@ -101,6 +105,33 @@ def _mask_nes_by_significance(nes_matrix, fdr_matrix):
             for col_idx, value in enumerate(row)
         ])
     return masked
+
+
+def _beyond_resolution_cells(comparison_data: dict):
+    """Locate the cells whose NES could not be normalised (#117).
+
+    Args:
+        comparison_data: Dict from ``build_comparison_matrix``. Matrices stored
+            before #117 carry no ``nes_status_matrix``, which yields no cells —
+            those runs did not know, and marking nothing is the honest result.
+
+    Returns:
+        tuple: aligned ``(condition labels, KE titles)`` lists, one entry per
+        beyond-resolution cell, ready for a Plotly scatter overlay.
+    """
+    status = (comparison_data or {}).get('nes_status_matrix') or []
+    x_labels = (comparison_data or {}).get('condition_labels') or []
+    y_labels = (comparison_data or {}).get('ke_titles') or []
+    xs, ys = [], []
+    for row_idx, row in enumerate(status):
+        if row_idx >= len(y_labels) or not row:
+            continue
+        for col_idx, value in enumerate(row):
+            if value != NES_BEYOND_RESOLUTION or col_idx >= len(x_labels):
+                continue
+            xs.append(x_labels[col_idx])
+            ys.append(y_labels[row_idx])
+    return xs, ys
 
 
 def _dropped_rows_note(cond) -> str:
@@ -181,10 +212,27 @@ def render_heatmap_png(comparison_data: dict) -> Optional[bytes]:
             z=[[0] * len(x) for _ in y], x=x, y=y,
             opacity=0, showscale=False, hoverinfo='skip',
         )
-        fig = go.Figure(data=[
+        traces = [
             axis_anchor,
             go.Heatmap(z=z, x=x, y=y, hoverongaps=False, **heatmap_kwargs),
-        ])
+        ]
+        # Issue #117: a Key Event that beat every permutation carries no NES, so
+        # the mask above cannot colour it and it would print as a blank cell —
+        # visually identical to a Key Event that was never tested, which is the
+        # inverse of the result. Ring it instead of colouring it: there is no
+        # magnitude to put on the scale, only a direction, and that is in the
+        # legend entry rather than in a colour that would imply one.
+        beyond_x, beyond_y = _beyond_resolution_cells(comparison_data)
+        if is_gsea and beyond_x:
+            traces.append(go.Scatter(
+                x=beyond_x, y=beyond_y, mode='markers',
+                marker=dict(symbol='circle-open', size=12,
+                            line=dict(width=3, color='#111111'),
+                            color='#111111'),
+                name='beyond permutation resolution',
+                showlegend=True, hoverinfo='skip',
+            ))
+        fig = go.Figure(data=traces)
         # Size scales with row/column count, bounded for sane PDFs.
         height = max(300, min(1200, 40 * len(y) + 120))
         width = max(500, min(1400, 120 * len(x) + 260))
@@ -423,11 +471,25 @@ def generate_batch_html(batch, conditions, comparison_data: dict) -> str:
         'heatmap colours only Key Events reaching FDR &lt; '
         f'{Config.SIGNIFICANCE_FDR_CUTOFF} — above that cutoff the sign of NES '
         'is not stable, so colouring it would show noise as direction (#107). '
-        'The table below carries every NES value, significant or not.'
+        # Issue #117 — the previous wording ("every NES value, significant or
+        # not") was false: a Key Event that beat every permutation has no NES to
+        # carry, and those are the strongest cells in the grid, not the weakest.
+        'Not every cell has a NES: where no permutation reached the observed '
+        'enrichment score there is nothing to normalise against, and the table '
+        'marks those cells &#9650;/&#9660; beyond res. with the direction of '
+        'the raw enrichment score (their FDR is its limit of zero). A trailing '
+        '! marks a cell normalised against fewer than ten same-signed '
+        'permutations — gseapy computes the nominal p-value on that same short '
+        'tail, so neither its magnitude nor its p-value is fine-grained enough '
+        'to rank on. A trailing ? marks a cell whose permutation null could not '
+        'be inspected at all (#117).'
         if is_gsea else
         'Significance (-log10 FDR) of each Key Event across conditions.'
     )
-    df = comparison_matrix_to_dataframe(comparison_data, which='nes' if is_gsea else 'fdr')
+    df = (
+        comparison_nes_display_dataframe(comparison_data) if is_gsea
+        else comparison_matrix_to_dataframe(comparison_data, which='fdr')
+    )
     if not df.empty:
         comp_table_html = df.head(30).to_html(index=False, na_rep='', border=0,
                                               classes='enrichment-table')
@@ -630,8 +692,15 @@ def generate_batch_pdf(batch, conditions, comparison_data: dict) -> bytes:
         'Normalised enrichment score (NES, signed) per Key Event across '
         'conditions. The heatmap colours only Key Events reaching FDR &lt; '
         f'{Config.SIGNIFICANCE_FDR_CUTOFF}; above that cutoff the sign of NES is '
-        'not stable, so colouring it would show noise as direction (#107). The '
-        'table below carries every NES value, significant or not.'
+        'not stable, so colouring it would show noise as direction (#107). '
+        # Issue #117 — see the HTML caption; the same false claim stood here.
+        'Not every cell has a NES: where no permutation reached the observed '
+        'enrichment score there is nothing to normalise against, and the table '
+        'marks those cells "beyond res." with the direction of the raw '
+        'enrichment score. A trailing ! marks a cell normalised against fewer '
+        'than ten same-signed permutations, whose magnitude and nominal '
+        'p-value are both computed on that short tail; a trailing ? marks a '
+        'cell whose permutation null could not be inspected (#117).'
         if is_gsea else
         'Significance (-log10 FDR) per Key Event across conditions.',
         normal_style,
@@ -654,7 +723,13 @@ def generate_batch_pdf(batch, conditions, comparison_data: dict) -> bytes:
     story.append(Spacer(1, 16))
 
     # Comparison matrix table — NES for a GSEA batch, FDR otherwise (#76).
-    df = comparison_matrix_to_dataframe(comparison_data, which='nes' if is_gsea else 'fdr')
+    # Under GSEA the cells are pre-rendered text so a Key Event with no NES is
+    # marked rather than blank (#117); _fmt below passes strings through.
+    df = (
+        comparison_nes_display_dataframe(comparison_data, ascii_only=True)
+        if is_gsea
+        else comparison_matrix_to_dataframe(comparison_data, which='fdr')
+    )
     if not df.empty:
         df = df.head(25)
         # Format floats compactly; blank for NaN. NES is a small signed number,

--- a/services/comparison_service.py
+++ b/services/comparison_service.py
@@ -73,6 +73,13 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
                                (non-significant)
             nes_matrix       — 2-D list of NES floats (GSEA batches only; all
                                None for ORA batches, which carry no NES)
+            nes_status_matrix— 2-D list of ``nes_status`` strings (#117), None
+                               where the condition carries no status. A None
+                               NES with status
+                               ``beyond_permutation_resolution`` is a Key Event
+                               that beat every permutation, not an untested one
+            es_matrix        — 2-D list of raw enrichment scores, the only
+                               surviving direction for those cells
             condition_colors — list of hex colour strings from CONDITION_PALETTE
 
         Returns an empty dict ``{}`` if no enrichment rows are found.
@@ -100,12 +107,21 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
             if ke is None or fdr is None:
                 continue
             nes = entry.get('NES')
+            es = entry.get('ES')
             rows.append({
                 'condition': cond.condition_label,
                 'KE': ke,
                 'Title': title,
                 'FDR': float(fdr),
                 'NES': float(nes) if nes is not None else None,
+                # Issue #117 — a missing NES is not one thing. It is absent on
+                # an untested Key Event and it is absent on a Key Event that
+                # beat every permutation, and those are opposite results. The
+                # status says which; the ES is the only surviving statement of
+                # direction in the second case, and the cross-condition view is
+                # the one place a reader looks for direction.
+                'nes_status': entry.get('nes_status'),
+                'ES': float(es) if es is not None else None,
             })
             # Keep first-seen title per KE
             if ke not in ke_title_map:
@@ -115,7 +131,10 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
         logger.info('build_comparison_matrix: no enrichment rows found — returning empty dict')
         return {}
 
-    df = pd.DataFrame(rows, columns=['condition', 'KE', 'Title', 'FDR', 'NES'])
+    df = pd.DataFrame(
+        rows,
+        columns=['condition', 'KE', 'Title', 'FDR', 'NES', 'nes_status', 'ES'],
+    )
 
     # H-1: a well-formed enrichment table has unique KEs per condition. If a
     # condition's blob contains duplicate (condition, KE) pairs, pivot_table's
@@ -155,8 +174,23 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
         # Reindex rows too: a KE whose NES was NaN in every condition is dropped
         # by pivot_table, and the matrix must stay aligned with `pivot`.
         nes_pivot = nes_pivot.reindex(index=pivot.index)
+        # Issue #117 — carried alongside, not folded in. A NES of None on a
+        # beyond-resolution cell used to reach compare.html as an em-dash with
+        # isSig false, i.e. the same rendering as a Key Event that was never
+        # tested, which is the inverse of what happened. pivot_table drops
+        # non-numeric columns, so the status goes through pivot() on the
+        # de-duplicated frame instead.
+        status_source = df.drop_duplicates(['condition', 'KE'])
+        nes_status_pivot = status_source.pivot(
+            index='KE', columns='condition', values='nes_status'
+        ).reindex(columns=condition_labels).reindex(index=pivot.index)
+        es_pivot = df.pivot_table(
+            index='KE', columns='condition', values='ES', aggfunc='first'
+        ).reindex(columns=condition_labels).reindex(index=pivot.index)
     else:
         nes_pivot = None
+        nes_status_pivot = None
+        es_pivot = None
 
     # Sort KE rows by mean -log10(FDR) significance descending (most significant first).
     # Fill NaN with 0 for sorting purposes only.
@@ -166,6 +200,8 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
     neg_log10_pivot = neg_log10_pivot.loc[sort_order]
     if nes_pivot is not None:
         nes_pivot = nes_pivot.loc[sort_order]
+        nes_status_pivot = nes_status_pivot.loc[sort_order]
+        es_pivot = es_pivot.loc[sort_order]
 
     ke_labels = list(pivot.index)
     ke_titles = [ke_title_map.get(ke, ke) for ke in ke_labels]
@@ -184,6 +220,14 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
     neg_log10_matrix = _to_list(neg_log10_pivot)
     nes_matrix = (
         _to_list(nes_pivot) if nes_pivot is not None
+        else [[None] * len(condition_labels) for _ in ke_labels]
+    )
+    nes_status_matrix = (
+        _to_list(nes_status_pivot) if nes_status_pivot is not None
+        else [[None] * len(condition_labels) for _ in ke_labels]
+    )
+    es_matrix = (
+        _to_list(es_pivot) if es_pivot is not None
         else [[None] * len(condition_labels) for _ in ke_labels]
     )
 
@@ -211,6 +255,10 @@ def build_comparison_matrix(conditions: list, method: str = 'ora') -> dict[str, 
         'fdr_matrix': fdr_matrix,
         'neg_log10_matrix': neg_log10_matrix,
         'nes_matrix': nes_matrix,  # #76 — all None for ORA batches
+        # #117 — all None for ORA batches and for GSEA batches stored before the
+        # diagnostics existed, which the frontend reads as "no claim made".
+        'nes_status_matrix': nes_status_matrix,
+        'es_matrix': es_matrix,
         'condition_colors': condition_colors,
         'condition_gene_counts': condition_gene_counts,
         'condition_sig_gene_counts': condition_sig_gene_counts,
@@ -261,6 +309,10 @@ def comparison_matrix_to_dataframe(
                        matching the heatmap's null semantics)
       - ``'nes'``      normalised enrichment score (#76; blank throughout for
                        an ORA batch, which produces no NES)
+      - ``'nes_status'`` the per-cell NES regime (#117), so a blank in the NES
+                       export can be told apart from an untested Key Event
+      - ``'es'``       raw enrichment score, which carries direction even where
+                       the NES could not be normalised (#117)
 
     The NES export is deliberately **not** masked at the significance cutoff the
     way the heatmap is (#107). A download is the raw record — the FDR matrix is
@@ -286,10 +338,13 @@ def comparison_matrix_to_dataframe(
         'fdr': 'fdr_matrix',
         'neglog10': 'neg_log10_matrix',
         'nes': 'nes_matrix',
+        'nes_status': 'nes_status_matrix',
+        'es': 'es_matrix',
     }
     if which not in matrix_keys:
         raise ValueError(
-            f"Unknown matrix selector: {which!r} (expected 'fdr', 'neglog10' or 'nes')"
+            f"Unknown matrix selector: {which!r} (expected one of "
+            f"{', '.join(sorted(matrix_keys))})"
         )
 
     # nes_matrix is absent from matrices built before #76; treat it as all-blank.
@@ -309,6 +364,87 @@ def comparison_matrix_to_dataframe(
         # None cells become NaN -> render as empty string in CSV / empty in Excel.
         data[cond_label] = [row[col_idx] for row in matrix]
 
+    return pd.DataFrame(data)
+
+
+#: Issue #117 — how a beyond-resolution cell reads in a report table. It has no
+#: NES, so the cell carries the direction from the ES and says why there is no
+#: number. Blank would be indistinguishable from an untested Key Event, which is
+#: the opposite result.
+BEYOND_RESOLUTION_UP = '▲ beyond res.'
+BEYOND_RESOLUTION_DOWN = '▼ beyond res.'
+BEYOND_RESOLUTION_UNKNOWN = '? beyond res.'
+#: ASCII forms for ReportLab, whose Helvetica has no arrow glyphs and would
+#: print a black box where the direction should be.
+BEYOND_RESOLUTION_UP_ASCII = '+ beyond res.'
+BEYOND_RESOLUTION_DOWN_ASCII = '- beyond res.'
+
+
+def comparison_nes_display_dataframe(
+    matrix_dict: dict, ascii_only: bool = False
+) -> pd.DataFrame:
+    """Shape the NES comparison matrix into report-ready **text** (#117).
+
+    The numeric NES export (``which='nes'``) is the machine-readable record and
+    stays numeric, so a beyond-resolution cell is blank in it — indistinguishable
+    from a Key Event that was never tested. A report is read by a person, and
+    both batch reports used to caption that table "every NES value, significant
+    or not", which was false in exactly the direction that hides the strongest
+    calls in the grid.
+
+    This renders the same matrix as strings: a formatted NES where one exists, a
+    direction-carrying marker where it does not, and a trailing marker on cells
+    whose same-signed permutation tail was too short for either the magnitude or
+    the nominal p-value to be fine-grained.
+
+    Args:
+        matrix_dict: The dict returned by :func:`build_comparison_matrix`.
+        ascii_only: Use ``+``/``-`` instead of ``▲``/``▼`` for the direction
+            marker. ReportLab's default Helvetica has no arrow glyphs and
+            renders them as black boxes, so the PDF report passes True.
+
+    Returns:
+        A DataFrame with ``Key Event ID``, ``Key Event Title`` and one text
+        column per condition. Empty if ``matrix_dict`` is empty.
+    """
+    if not matrix_dict or not matrix_dict.get('ke_labels'):
+        return pd.DataFrame()
+
+    ke_labels = matrix_dict['ke_labels']
+    ke_titles = matrix_dict['ke_titles']
+    condition_labels = matrix_dict['condition_labels']
+    blank = [[None] * len(condition_labels) for _ in ke_labels]
+    nes = matrix_dict.get('nes_matrix') or blank
+    status = matrix_dict.get('nes_status_matrix') or blank
+    es = matrix_dict.get('es_matrix') or blank
+
+    def _cell(row: int, col: int) -> str:
+        cell_status = status[row][col] if status[row] else None
+        if cell_status == 'beyond_permutation_resolution':
+            es_val = es[row][col] if es[row] else None
+            if es_val is None:
+                return BEYOND_RESOLUTION_UNKNOWN
+            if es_val >= 0:
+                return (BEYOND_RESOLUTION_UP_ASCII if ascii_only
+                        else BEYOND_RESOLUTION_UP)
+            return (BEYOND_RESOLUTION_DOWN_ASCII if ascii_only
+                    else BEYOND_RESOLUTION_DOWN)
+        value = nes[row][col] if nes[row] else None
+        if value is None or (isinstance(value, float) and value != value):
+            return ''
+        text = f'{float(value):+.2f}'
+        if cell_status == 'unstable_normalisation':
+            return f'{text} !'
+        if cell_status == 'undiagnosed':
+            return f'{text} ?'
+        return text
+
+    data = {
+        'Key Event ID': [csv_guard(k) for k in ke_labels],
+        'Key Event Title': [csv_guard(t) for t in ke_titles],
+    }
+    for col_idx, cond_label in enumerate(condition_labels):
+        data[cond_label] = [_cell(row, col_idx) for row in range(len(ke_labels))]
     return pd.DataFrame(data)
 
 

--- a/services/enrichment_service.py
+++ b/services/enrichment_service.py
@@ -34,6 +34,13 @@ KE_SUMMARY_ATTR = 'ke_summary'
 EXCLUDED_NO_MAPPING = 'no_mapping'
 EXCLUDED_UNRESOLVED_MAPPING = 'unresolved_mapping'
 EXCLUDED_TOO_FEW_GENES = 'too_few_genes'
+# Issue #120 — GSEA only. gseapy drops a gene set larger than ``max_size``
+# before computing anything, and the drop is invisible in its output. Folding
+# it into ``too_few_genes`` told the reader the best-covered Key Event in the
+# analysis was under-measured, and pointed the repair (curate more genes onto
+# it) in exactly the wrong direction. The Fisher path has no upper bound and
+# never sets this.
+EXCLUDED_TOO_MANY_GENES = 'too_many_genes'
 EXCLUDED_ERROR = 'error'
 
 
@@ -121,6 +128,14 @@ def format_ke_summary(summary: Optional[Dict[str, Any]]) -> str:
         clauses.append(
             f"{too_few} excluded (fewer than "
             f"{summary.get('min_ke_genes', Config.MIN_KE_GENES)} measured genes)"
+        )
+    too_many = summary.get('excluded_too_many_genes', 0)
+    if too_many:
+        ceiling = summary.get('max_ke_genes')
+        clauses.append(
+            f"{too_many} excluded (more than {ceiling} measured genes, above "
+            "the GSEA gene-set ceiling)" if ceiling
+            else f"{too_many} excluded (above the GSEA gene-set ceiling)"
         )
     no_mapping = summary.get('excluded_no_mapping', 0)
     if no_mapping:
@@ -542,6 +557,7 @@ def _build_ke_summary(
     excluded_reasons: Dict[str, str],
     min_ke_genes: int,
     unresolved_pathways_by_ke: Optional[Dict[str, List[str]]] = None,
+    max_ke_genes: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Assemble the tested/excluded KE accounting dict (issue #65).
 
@@ -572,8 +588,15 @@ def _build_ke_summary(
             1 for r in reasons if r == EXCLUDED_UNRESOLVED_MAPPING
         ),
         'excluded_too_few_genes': sum(1 for r in reasons if r == EXCLUDED_TOO_FEW_GENES),
+        # Issue #120 — GSEA's upper size bound. Absent (0) on every ORA run and
+        # on runs stored before the distinction existed, which keeps the clause
+        # out of the sentence rather than asserting a zero.
+        'excluded_too_many_genes': sum(
+            1 for r in reasons if r == EXCLUDED_TOO_MANY_GENES
+        ),
         'excluded_error': sum(1 for r in reasons if r == EXCLUDED_ERROR),
         'min_ke_genes': min_ke_genes,
+        'max_ke_genes': max_ke_genes,
         # Issue #81 — named so the reader can check them against the Builder
         # rather than being told, wrongly, that the Key Event is uncurated.
         'unresolved_pathways': unresolved_pathways,

--- a/services/enrichment_service.py
+++ b/services/enrichment_service.py
@@ -151,6 +151,18 @@ def format_ke_summary(summary: Optional[Dict[str, Any]]) -> str:
         clauses.append(f"{errored} excluded (statistics could not be computed)")
     if clauses:
         parts.append('; ' + ', '.join(clauses))
+    # Issue #117 — GSEA only, and only when it happened. A run whose permutation
+    # null could not be inspected cannot rule out the degenerate one-signed case
+    # that reports a maximally enriched Key Event as null, and the reader has to
+    # be told that in the same sentence that tells them what was tested. Absent
+    # (0) on every ORA run and on results stored before the check existed, which
+    # keeps the clause out rather than asserting a zero.
+    undiagnosed = summary.get('nes_undiagnosed_kes', 0)
+    if undiagnosed:
+        parts.append(
+            f". The permutation null could not be inspected for {undiagnosed} "
+            "tested Key Event(s), so their NES and p-value are unchecked"
+        )
     return ''.join(parts)
 
 
@@ -558,6 +570,7 @@ def _build_ke_summary(
     min_ke_genes: int,
     unresolved_pathways_by_ke: Optional[Dict[str, List[str]]] = None,
     max_ke_genes: Optional[int] = None,
+    nes_undiagnosed_kes: int = 0,
 ) -> Dict[str, Any]:
     """Assemble the tested/excluded KE accounting dict (issue #65).
 
@@ -597,6 +610,10 @@ def _build_ke_summary(
         'excluded_error': sum(1 for r in reasons if r == EXCLUDED_ERROR),
         'min_ke_genes': min_ke_genes,
         'max_ke_genes': max_ke_genes,
+        # Issue #117 — tested Key Events whose permutation null could not be
+        # read, so the degenerate one-signed case could not be ruled out for
+        # them. GSEA only; always 0 under Fisher, which has no permutation null.
+        'nes_undiagnosed_kes': nes_undiagnosed_kes,
         # Issue #81 — named so the reader can check them against the Builder
         # rather than being told, wrongly, that the Key Event is uncurated.
         'unresolved_pathways': unresolved_pathways,

--- a/services/gsea_service.py
+++ b/services/gsea_service.py
@@ -9,6 +9,7 @@ user's method selection.
 import importlib
 import math
 import logging
+import threading
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Optional, Set
 
@@ -41,10 +42,19 @@ logger = logging.getLogger(__name__)
 #
 # The failure is continuous, not binary. A tail of one or two permutations
 # still yields a finite NES, but its magnitude is a ratio against a sample of
-# one or two and carries no information, even though the nominal p-value is
-# sound. Testing NES == 1.0 catches only the first regime; the size of the
-# same-signed tail catches both, and it is available from the null distribution
-# gseapy already computes.
+# one or two and carries no information. Testing NES == 1.0 catches only the
+# first regime; the size of the same-signed tail catches both, and it is
+# available from the null distribution gseapy already computes.
+#
+# The *nominal p-value goes with it*. An earlier version of this module said
+# the p-value survived a short tail. It does not: gseapy divides by the same
+# same-signed tail it normalises against, so the p is quantised to multiples of
+# 1/tail. Measured directly against gseapy 1.1.4 on a ranking of 200 genes, a
+# term with a same-signed tail of 56 and one exceedance returned exactly
+# 1/56 = 0.017857…, not 1/100 = 0.01, which is the pooled figure. A tail of two
+# therefore admits only p ∈ {0, 0.5, 1}; a tail of one only p ∈ {0, 1}. Under
+# NES_UNSTABLE both the magnitude and the p-value are coarse, and the coarseness
+# is reported as ``p_value_resolution`` beside them.
 #
 # Incidence rises with gene-set size: a larger set tightens the permutation
 # null, and a tight null sitting off zero in a skewed ranking is exactly the
@@ -54,7 +64,8 @@ logger = logging.getLogger(__name__)
 #: NES reported as a number only when at least this many permutations fell on
 #: the same side of zero as the observed ES. Below 10 the mean being divided by
 #: has a relative standard error above ~30%, so the magnitude is not a quantity
-#: to rank or threshold on.
+#: to rank or threshold on — and the nominal p-value, computed on that same
+#: tail, is quantised to steps of 1/10 or coarser.
 MIN_SAME_SIGNED_NULL = 10
 
 #: Both tails healthy — NES is an estimate and may be read as one.
@@ -63,9 +74,35 @@ NES_OK = 'ok'
 #: single permutation, so the empirical p is below 1/permutation_num; the NES
 #: itself is not normalisable and is reported as NaN rather than as a number.
 NES_BEYOND_RESOLUTION = 'beyond_permutation_resolution'
-#: Fewer than MIN_SAME_SIGNED_NULL same-signed permutations. The p-value stands;
-#: the NES magnitude is normalised against a handful of values and does not.
+#: Fewer than MIN_SAME_SIGNED_NULL same-signed permutations. Neither the NES
+#: magnitude nor the nominal p-value is usable: both are computed against that
+#: handful of values, so the p can only take the values k/tail. The achievable
+#: resolution travels with the row in ``p_value_resolution``.
 NES_UNSTABLE = 'unstable_normalisation'
+#: The permutation null could not be read at all — the gseapy entry point this
+#: module wraps was not called (renamed upstream, or the ``multilevel`` method
+#: routed through ``fgsea_rs``). Distinct from NES_OK on purpose: "we looked and
+#: the tails were healthy" and "we could not look" are different claims, and
+#: collapsing the second into the first would let a gseapy upgrade reintroduce
+#: the whole of #117 under a clean bill of health.
+NES_UNDIAGNOSED = 'undiagnosed'
+
+#: Serialises the process-global patch in :func:`_capture_prerank_summaries`.
+#:
+#: The capture rebinds ``gseapy.gsea.prerank_rs``, which is process-global, and
+#: this application is concurrent: Flask runs threaded and every batch condition
+#: is dispatched on its own ``threading.Thread``, so two ``run_gsea_analysis``
+#: calls overlapping is routine rather than exotic. Without this lock the two
+#: patches nest, every sink receives both runs' summaries, and the per-term
+#: counts — keyed by KE ID, which is identical across conditions — are
+#: last-write-wins. That does not merely lose the diagnostics: it writes one
+#: condition's tail count onto another condition's row, and the repair in
+#: :func:`apply_null_diagnostics` then rewrites that row's NES, p and FDR on the
+#: strength of it. The lock covers the patch *and* the ``gp.prerank`` call it
+#: exists for, so GSEA runs serialise against each other. gseapy is already
+#: pinned to ``threads=1`` for determinism, so this costs wall-clock on
+#: concurrent batches and nothing else.
+_PRERANK_PATCH_LOCK = threading.Lock()
 
 
 def _build_ranking(df: pd.DataFrame) -> pd.Series:
@@ -103,7 +140,7 @@ def _build_ranking(df: pd.DataFrame) -> pd.Series:
 
 
 @contextmanager
-def _capture_prerank_summaries(sink: List[Any]) -> Iterator[None]:
+def _capture_prerank_summaries(sink: List[Any]) -> Iterator[Dict[str, bool]]:
     """Collect the per-term GSEA summaries ``gseapy.prerank`` throws away.
 
     The permutation null distribution is the only place the empty-tail
@@ -113,43 +150,72 @@ def _capture_prerank_summaries(sink: List[Any]) -> Iterator[None]:
     back: ``res2d`` carries ES/NES/p/FDR but not ``esnull``.
 
     Rather than reimplement prerank, this wraps the extension entry point
-    ``gseapy.gsea.prerank_rs`` for the duration of one call and keeps the
-    summaries. Verified against gseapy 1.1.4 and 1.3.0, which both resolve that
-    name as a module global at call time. If a future release renames it, or
-    the caller selects the ``multilevel`` method (which routes through
-    ``fgsea_rs`` instead), the sink stays empty and the analysis proceeds
-    without the diagnostics rather than failing — the numbers are still
-    gseapy's own.
+    ``gseapy.gsea.prerank_rs`` and keeps the summaries. Verified against gseapy
+    1.1.4 and 1.3.0, which both resolve that name as a module global at call
+    time. If a future release renames it, or the caller selects the
+    ``multilevel`` method (which routes through ``fgsea_rs`` instead), the sink
+    stays empty, ``captured`` stays False and every row is labelled
+    :data:`NES_UNDIAGNOSED` — the analysis proceeds on gseapy's own numbers, but
+    it does not claim to have checked them.
+
+    The rebind is process-global, so the whole block runs under
+    :data:`_PRERANK_PATCH_LOCK`; see that constant for what overlapping runs did
+    without it. The restore is also identity-checked, because an unlocked nested
+    patch used to leave the global bound to a dead wrapper appending to an
+    abandoned list for the life of the process.
 
     Args:
         sink: List the captured ``GSEASummary`` objects are appended to.
 
     Yields:
-        None. The patch is reverted on exit, including on exception.
+        dict: ``{'captured': bool}`` — flipped to True once the wrapper has
+        actually run, i.e. once the diagnostics are known to be available for
+        this call. Read it after the block, not inside it. The patch is reverted
+        on exit, including on exception.
     """
+    state: Dict[str, bool] = {'captured': False}
     try:
         gsea_module = importlib.import_module('gseapy.gsea')
     except ImportError:  # pragma: no cover — gseapy is a hard dependency
         gsea_module = None
-    original = getattr(gsea_module, 'prerank_rs', None)
-    if original is None:
-        logger.warning(
-            "gseapy.gsea.prerank_rs not found — GSEA null diagnostics "
-            "(issue #117) are unavailable for this run"
-        )
-        yield
-        return
 
-    def _wrapped(*args, **kwargs):
-        result = original(*args, **kwargs)
-        sink.extend(list(getattr(result, 'summaries', None) or []))
-        return result
+    # The lock is taken *before* the global is read. Reading it first and
+    # locking afterwards is the same defect in slower motion: a run that arrives
+    # while another holds the patch would capture the other run's wrapper as its
+    # "original" and restore that on exit, leaving the global permanently bound
+    # to a dead wrapper appending to an abandoned list.
+    with _PRERANK_PATCH_LOCK:
+        original = getattr(gsea_module, 'prerank_rs', None)
+        if original is None:
+            logger.error(
+                "gseapy.gsea.prerank_rs not found — the GSEA permutation null "
+                "cannot be inspected, so the degenerate one-signed null of "
+                "issue #117 cannot be detected in this run. Every Key Event "
+                "will be reported with nes_status='%s'. This usually means "
+                "gseapy renamed the entry point; the wrapper needs updating.",
+                NES_UNDIAGNOSED,
+            )
+            yield state
+            return
 
-    setattr(gsea_module, 'prerank_rs', _wrapped)
-    try:
-        yield
-    finally:
-        setattr(gsea_module, 'prerank_rs', original)
+        def _wrapped(*args, **kwargs):
+            result = original(*args, **kwargs)
+            sink.extend(list(getattr(result, 'summaries', None) or []))
+            state['captured'] = True
+            return result
+
+        setattr(gsea_module, 'prerank_rs', _wrapped)
+        try:
+            yield state
+        finally:
+            if getattr(gsea_module, 'prerank_rs', None) is not _wrapped:
+                logger.error(
+                    "gseapy.gsea.prerank_rs was rebound by something other "
+                    "than this capture while it was patched — restoring the "
+                    "real function anyway. GSEA null diagnostics for this run "
+                    "may be unreliable."
+                )
+            setattr(gsea_module, 'prerank_rs', original)
 
 
 def _null_tail_sizes(summaries: List[Any]) -> Dict[str, int]:
@@ -186,13 +252,15 @@ def apply_null_diagnostics(
     res: pd.DataFrame,
     same_signed_sizes: Dict[str, int],
     permutation_num: int,
+    diagnostics_captured: bool = True,
 ) -> pd.DataFrame:
     """Classify each result row by its same-signed null tail and repair it (#117).
 
-    Adds ``null_same_signed_n`` and ``nes_status``, and for the degenerate
-    regime replaces the values gseapy invents. It is a separate function
-    because the two regimes it distinguishes are the whole content of #117 and
-    they must be testable without paying for a thousand permutations.
+    Adds ``null_same_signed_n``, ``nes_status`` and ``p_value_resolution``, and
+    for the degenerate regime replaces the values gseapy invents. It is a
+    separate function because the regimes it distinguishes are the whole content
+    of #117 and they must be testable without paying for a thousand
+    permutations.
 
     An empty same-signed tail is not a missing result: the observed ES beat
     every permutation, so the empirical p is bounded above by
@@ -202,25 +270,45 @@ def apply_null_diagnostics(
     the status column carries the reason. NaN is the one thing that cannot be
     read as a weak result; the direction survives in the ES column beside it.
 
-    A KE missing from ``same_signed_sizes`` keeps ``NaN`` there and status
-    ``ok``: the diagnostics were not available, which is a different statement
-    from a tail of zero, and it must not silently rewrite gseapy's numbers.
+    ``p_value_resolution`` is the finest p-value the row could have produced.
+    gseapy divides the exceedance count by the *same-signed* tail, not by
+    ``permutation_num``, so a row with a tail of two can only report
+    p ∈ {0, 0.5, 1} — a p of 0.000 there means "zero of two", and a p of 0.600
+    on a tail of five means "three of five". Reporting the step size beside the
+    p-value is the only way a reader can tell those from a p estimated on a
+    thousand permutations. Under :data:`NES_BEYOND_RESOLUTION` the column
+    carries ``1/permutation_num``, the bound the substituted p-value is.
+
+    A KE missing from ``same_signed_sizes`` is labelled
+    :data:`NES_UNDIAGNOSED`, never ``ok``: the diagnostics were not available,
+    which is a different statement from a healthy tail, and gseapy's numbers are
+    left exactly as they came.
 
     Args:
         res: Result frame with at least 'KE', 'NES', 'p_value', 'FDR'.
         same_signed_sizes: KE → same-signed permutation count.
-        permutation_num: Permutations run, i.e. the resolution of the p-value.
+        permutation_num: Permutations run, i.e. the coarsest bound on the
+            p-value when the same-signed tail is empty.
+        diagnostics_captured: Whether the null-capture wrapper actually ran.
+            False means the wrapper never fired — the failure is in this
+            module's grip on gseapy, not in the data — and is logged as an
+            error rather than a warning.
 
     Returns:
         pd.DataFrame: ``res``, mutated in place and returned for chaining.
     """
     res['null_same_signed_n'] = res['KE'].map(same_signed_sizes)
     tail = res['null_same_signed_n']
+    undiagnosed = tail.isna()
     beyond = tail == 0
     unstable = (tail > 0) & (tail < MIN_SAME_SIGNED_NULL)
     res['nes_status'] = NES_OK
     res.loc[unstable, 'nes_status'] = NES_UNSTABLE
     res.loc[beyond, 'nes_status'] = NES_BEYOND_RESOLUTION
+    res.loc[undiagnosed, 'nes_status'] = NES_UNDIAGNOSED
+    # The step size the nominal p-value was quantised to (see docstring).
+    res['p_value_resolution'] = 1.0 / tail.where(tail > 0)
+    res.loc[beyond, 'p_value_resolution'] = 1.0 / permutation_num
     if beyond.any():
         res.loc[beyond, 'NES'] = np.nan
         res.loc[beyond, 'p_value'] = 1.0 / permutation_num
@@ -237,15 +325,32 @@ def apply_null_diagnostics(
     if unstable.any():
         logger.warning(
             "GSEA: %d Key Event(s) normalised against fewer than %d same-signed "
-            "permutations — the p-value stands but the NES magnitude is not "
-            "usable (issue #117): %s",
+            "permutations (issue #117): %s. Neither the NES magnitude nor the "
+            "nominal p-value is usable there — gseapy computes the p on that "
+            "same short tail, so it is quantised to steps of 1/tail (reported "
+            "per row as p_value_resolution).",
             int(unstable.sum()), MIN_SAME_SIGNED_NULL,
-            sorted(res.loc[unstable, 'KE'].tolist()),
+            sorted(
+                f"{ke} (tail {int(n)}, p in steps of {1.0 / int(n):.3g})"
+                for ke, n in zip(
+                    res.loc[unstable, 'KE'], res.loc[unstable, 'null_same_signed_n']
+                )
+            ),
         )
-    if not same_signed_sizes:
-        logger.warning(
-            "GSEA: permutation null diagnostics unavailable — degenerate "
-            "one-signed nulls (issue #117) cannot be detected in this run"
+    if undiagnosed.any():
+        logger.error(
+            "GSEA: the permutation null could not be read for %d of %d Key "
+            "Event(s)%s, so the degenerate one-signed null of issue #117 could "
+            "not be ruled out for them. They are reported with "
+            "nes_status='%s' — that is not a clean bill of health, and their "
+            "NES and p-value are gseapy's unchecked output: %s",
+            int(undiagnosed.sum()), len(res),
+            "" if diagnostics_captured
+            else " (the capture wrapper never ran — gseapy has probably "
+                 "renamed its entry point, or method='multilevel' routed "
+                 "around it)",
+            NES_UNDIAGNOSED,
+            sorted(res.loc[undiagnosed, 'KE'].tolist()),
         )
     return res
 
@@ -296,18 +401,22 @@ def run_gsea_analysis(
 
     Returns:
         pd.DataFrame sorted by FDR ascending with columns:
-        ['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value', 'FDR',
-         'null_same_signed_n', 'lead_genes', 'total_KE_genes_in_dataset']
+        ['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value',
+         'p_value_resolution', 'FDR', 'null_same_signed_n', 'lead_genes',
+         'total_KE_genes_in_dataset']
 
-        ``nes_status`` is one of ``NES_OK``, ``NES_UNSTABLE`` or
-        ``NES_BEYOND_RESOLUTION`` (issue #117). Under
+        ``nes_status`` is one of ``NES_OK``, ``NES_UNSTABLE``,
+        ``NES_BEYOND_RESOLUTION`` or ``NES_UNDIAGNOSED`` (issue #117). Under
         ``NES_BEYOND_RESOLUTION`` the NES is NaN — the quantity does not
         exist — while ``p_value`` carries the bound ``1/permutation_num``,
         ``FDR`` is 0.0 and ``ES`` still carries the direction. Under
-        ``NES_UNSTABLE`` every number is gseapy's own; only the NES *magnitude*
-        should not be ranked or thresholded on. ``null_same_signed_n`` is the
-        evidence for the call and is NaN when the diagnostics could not be
-        read.
+        ``NES_UNSTABLE`` every number is gseapy's own, but neither the NES
+        magnitude nor the p-value may be ranked or thresholded on: gseapy
+        computes both against the same short same-signed tail, so the p-value
+        is quantised to the step size in ``p_value_resolution``. Under
+        ``NES_UNDIAGNOSED`` the null could not be read at all and nothing about
+        the row has been checked. ``null_same_signed_n`` is the evidence for
+        the call and is NaN when the diagnostics could not be read.
 
     Raises:
         ValueError: When no reference gene sets are found for the selected AOP,
@@ -339,7 +448,7 @@ def run_gsea_analysis(
     # Run gseapy.prerank
     # threads=1 is the determinism guard per RESEARCH §Pitfall #2 — load-bearing for D-15.1
     summaries: List[Any] = []
-    with _capture_prerank_summaries(summaries):
+    with _capture_prerank_summaries(summaries) as capture_state:
         pre_res = gp.prerank(
             rnk=ranking,
             gene_sets=gene_sets,
@@ -352,6 +461,7 @@ def run_gsea_analysis(
             no_plot=True,
             verbose=False,
         )
+    diagnostics_captured = bool(capture_state.get('captured'))
     same_signed_sizes = _null_tail_sizes(summaries)
 
     res = pre_res.res2d.copy()
@@ -387,7 +497,11 @@ def run_gsea_analysis(
 
     # Issue #117 — classify each cell by the size of its same-signed
     # permutation tail and repair the two regimes gseapy misreports.
-    res = apply_null_diagnostics(res, same_signed_sizes, permutation_num)
+    res = apply_null_diagnostics(
+        res, same_signed_sizes, permutation_num,
+        diagnostics_captured=diagnostics_captured,
+    )
+    undiagnosed_kes = int((res['nes_status'] == NES_UNDIAGNOSED).sum())
 
     # Populate total_KE_genes_in_dataset from pre-computed overlap counts
     res['total_KE_genes_in_dataset'] = (
@@ -456,14 +570,17 @@ def run_gsea_analysis(
         ke_list, len(res), excluded_reasons, min_size,
         unresolved_pathways_by_ke=unresolved_named,
         max_ke_genes=max_size,
+        # Issue #117 / R5: a run that could not inspect its own permutation null
+        # has to say so where the reader is, not only in the server log.
+        nes_undiagnosed_kes=undiagnosed_kes,
     )
 
     # Sort by FDR ascending; use KE ID as tie-breaker so row order is fully
     # deterministic regardless of the internal ordering gseapy returns.
     res = res.sort_values(['FDR', 'KE'], ascending=[True, True], kind='mergesort')
 
-    out = res[['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value', 'FDR',
-               'null_same_signed_n', 'lead_genes',
+    out = res[['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value',
+               'p_value_resolution', 'FDR', 'null_same_signed_n', 'lead_genes',
                'total_KE_genes_in_dataset']]
     # Attach on the returned object: pandas only propagates .attrs through
     # operations that call __finalize__, so set it last.

--- a/services/gsea_service.py
+++ b/services/gsea_service.py
@@ -6,17 +6,21 @@ Fisher's exact test path in enrichment_service.py. The dispatcher
 (enrichment_service.run_enrichment) routes to this module based on the
 user's method selection.
 """
+import importlib
 import math
 import logging
-from typing import Any, Dict, Optional, Set
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional, Set
 
 import numpy as np
 import pandas as pd
 import gseapy as gp
 
+from config import Config
 from services.enrichment_service import (
     EXCLUDED_NO_MAPPING,
     EXCLUDED_TOO_FEW_GENES,
+    EXCLUDED_TOO_MANY_GENES,
     EXCLUDED_UNRESOLVED_MAPPING,
     KE_SUMMARY_ATTR,
     _build_ke_summary,
@@ -24,6 +28,44 @@ from services.enrichment_service import (
 )
 
 logger = logging.getLogger(__name__)
+
+# --- NES normalisation regimes (issue #117) --------------------------------
+#
+# GSEA normalises an observed enrichment score by the mean of the *same-signed*
+# tail of that gene set's permutation null. When the null lands entirely on the
+# other side of zero that tail is empty, the normalisation is 0/0, and gseapy
+# falls back to NES = 1.0 with p = 1.0 rather than declaring the cell
+# undefined. Those are the values a thoroughly unenriched gene set produces, so
+# a maximally enriched Key Event is reported as null — the one direction of
+# error that cannot be caught by reading the table.
+#
+# The failure is continuous, not binary. A tail of one or two permutations
+# still yields a finite NES, but its magnitude is a ratio against a sample of
+# one or two and carries no information, even though the nominal p-value is
+# sound. Testing NES == 1.0 catches only the first regime; the size of the
+# same-signed tail catches both, and it is available from the null distribution
+# gseapy already computes.
+#
+# Incidence rises with gene-set size: a larger set tightens the permutation
+# null, and a tight null sitting off zero in a skewed ranking is exactly the
+# one-signed case. So this gets *more* likely as KE curation improves, which is
+# the opposite of what anyone would expect a curation improvement to do.
+
+#: NES reported as a number only when at least this many permutations fell on
+#: the same side of zero as the observed ES. Below 10 the mean being divided by
+#: has a relative standard error above ~30%, so the magnitude is not a quantity
+#: to rank or threshold on.
+MIN_SAME_SIGNED_NULL = 10
+
+#: Both tails healthy — NES is an estimate and may be read as one.
+NES_OK = 'ok'
+#: No permutation fell on the observed side of zero. The observed ES beat every
+#: single permutation, so the empirical p is below 1/permutation_num; the NES
+#: itself is not normalisable and is reported as NaN rather than as a number.
+NES_BEYOND_RESOLUTION = 'beyond_permutation_resolution'
+#: Fewer than MIN_SAME_SIGNED_NULL same-signed permutations. The p-value stands;
+#: the NES magnitude is normalised against a handful of values and does not.
+NES_UNSTABLE = 'unstable_normalisation'
 
 
 def _build_ranking(df: pd.DataFrame) -> pd.Series:
@@ -60,6 +102,154 @@ def _build_ranking(df: pd.DataFrame) -> pd.Series:
     return s
 
 
+@contextmanager
+def _capture_prerank_summaries(sink: List[Any]) -> Iterator[None]:
+    """Collect the per-term GSEA summaries ``gseapy.prerank`` throws away.
+
+    The permutation null distribution is the only place the empty-tail
+    condition of #117 is visible, and it is computed inside the Rust extension.
+    ``Prerank.run()`` binds its result to a local, hands the summaries to
+    ``to_df`` and returns None, so nothing survives on the object gseapy hands
+    back: ``res2d`` carries ES/NES/p/FDR but not ``esnull``.
+
+    Rather than reimplement prerank, this wraps the extension entry point
+    ``gseapy.gsea.prerank_rs`` for the duration of one call and keeps the
+    summaries. Verified against gseapy 1.1.4 and 1.3.0, which both resolve that
+    name as a module global at call time. If a future release renames it, or
+    the caller selects the ``multilevel`` method (which routes through
+    ``fgsea_rs`` instead), the sink stays empty and the analysis proceeds
+    without the diagnostics rather than failing — the numbers are still
+    gseapy's own.
+
+    Args:
+        sink: List the captured ``GSEASummary`` objects are appended to.
+
+    Yields:
+        None. The patch is reverted on exit, including on exception.
+    """
+    try:
+        gsea_module = importlib.import_module('gseapy.gsea')
+    except ImportError:  # pragma: no cover — gseapy is a hard dependency
+        gsea_module = None
+    original = getattr(gsea_module, 'prerank_rs', None)
+    if original is None:
+        logger.warning(
+            "gseapy.gsea.prerank_rs not found — GSEA null diagnostics "
+            "(issue #117) are unavailable for this run"
+        )
+        yield
+        return
+
+    def _wrapped(*args, **kwargs):
+        result = original(*args, **kwargs)
+        sink.extend(list(getattr(result, 'summaries', None) or []))
+        return result
+
+    setattr(gsea_module, 'prerank_rs', _wrapped)
+    try:
+        yield
+    finally:
+        setattr(gsea_module, 'prerank_rs', original)
+
+
+def _null_tail_sizes(summaries: List[Any]) -> Dict[str, int]:
+    """Count each term's same-signed permutation tail (issue #117).
+
+    "Same-signed" is the side of zero the *observed* ES fell on, which is the
+    side GSEA normalises against and the side the nominal p-value counts on.
+    A count of zero means no permutation reached the observed side at all.
+
+    Args:
+        summaries: ``GSEASummary`` objects captured from ``prerank_rs``.
+
+    Returns:
+        Term → number of same-signed permutations. Terms whose summary cannot
+        be read are omitted, which downstream reads as "not assessed" rather
+        than as a count of zero.
+    """
+    sizes: Dict[str, int] = {}
+    for summary in summaries:
+        try:
+            observed = float(summary.es)
+            null = np.asarray(summary.esnull, dtype=float)
+        except (AttributeError, TypeError, ValueError):
+            continue
+        null = null[np.isfinite(null)]
+        if null.size == 0:
+            continue
+        same_signed = (null >= 0) if observed >= 0 else (null < 0)
+        sizes[str(summary.term)] = int(same_signed.sum())
+    return sizes
+
+
+def apply_null_diagnostics(
+    res: pd.DataFrame,
+    same_signed_sizes: Dict[str, int],
+    permutation_num: int,
+) -> pd.DataFrame:
+    """Classify each result row by its same-signed null tail and repair it (#117).
+
+    Adds ``null_same_signed_n`` and ``nes_status``, and for the degenerate
+    regime replaces the values gseapy invents. It is a separate function
+    because the two regimes it distinguishes are the whole content of #117 and
+    they must be testable without paying for a thousand permutations.
+
+    An empty same-signed tail is not a missing result: the observed ES beat
+    every permutation, so the empirical p is bounded above by
+    ``1/permutation_num`` and the FDR limit is 0 — nothing in the pooled null
+    is more extreme than a score no permutation reached. The NES genuinely has
+    no value, being a ratio against an empty sample, so it is set to NaN and
+    the status column carries the reason. NaN is the one thing that cannot be
+    read as a weak result; the direction survives in the ES column beside it.
+
+    A KE missing from ``same_signed_sizes`` keeps ``NaN`` there and status
+    ``ok``: the diagnostics were not available, which is a different statement
+    from a tail of zero, and it must not silently rewrite gseapy's numbers.
+
+    Args:
+        res: Result frame with at least 'KE', 'NES', 'p_value', 'FDR'.
+        same_signed_sizes: KE → same-signed permutation count.
+        permutation_num: Permutations run, i.e. the resolution of the p-value.
+
+    Returns:
+        pd.DataFrame: ``res``, mutated in place and returned for chaining.
+    """
+    res['null_same_signed_n'] = res['KE'].map(same_signed_sizes)
+    tail = res['null_same_signed_n']
+    beyond = tail == 0
+    unstable = (tail > 0) & (tail < MIN_SAME_SIGNED_NULL)
+    res['nes_status'] = NES_OK
+    res.loc[unstable, 'nes_status'] = NES_UNSTABLE
+    res.loc[beyond, 'nes_status'] = NES_BEYOND_RESOLUTION
+    if beyond.any():
+        res.loc[beyond, 'NES'] = np.nan
+        res.loc[beyond, 'p_value'] = 1.0 / permutation_num
+        res.loc[beyond, 'FDR'] = 0.0
+        logger.warning(
+            "GSEA: %d Key Event(s) had no same-signed permutation and were "
+            "reported by gseapy as NES=1.0, p=1.0 — corrected to "
+            "p < 1/%d with NES undefined (issue #117): %s. Incidence of this "
+            "rises with gene-set size, so expect more of it as curation grows "
+            "the Key Event gene sets.",
+            int(beyond.sum()), permutation_num,
+            sorted(res.loc[beyond, 'KE'].tolist()),
+        )
+    if unstable.any():
+        logger.warning(
+            "GSEA: %d Key Event(s) normalised against fewer than %d same-signed "
+            "permutations — the p-value stands but the NES magnitude is not "
+            "usable (issue #117): %s",
+            int(unstable.sum()), MIN_SAME_SIGNED_NULL,
+            sorted(res.loc[unstable, 'KE'].tolist()),
+        )
+    if not same_signed_sizes:
+        logger.warning(
+            "GSEA: permutation null diagnostics unavailable — degenerate "
+            "one-signed nulls (issue #117) cannot be detected in this run"
+        )
+    return res
+
+
 def run_gsea_analysis(
     df: pd.DataFrame,
     reference_sets: Dict[str, Set[str]],
@@ -67,7 +257,7 @@ def run_gsea_analysis(
     ke_title_map: Dict[str, str],
     *,
     min_size: int = 5,
-    max_size: int = 1000,
+    max_size: int = Config.GSEA_MAX_KE_GENES,
     permutation_num: int = 1000,
     seed: int = 42,
     unresolved_ke_pathways: Optional[Dict[str, Any]] = None,
@@ -88,7 +278,14 @@ def run_gsea_analysis(
         ke_title_map: Mapping of KE IDs to human-readable titles.
         min_size: Minimum number of overlapping genes for a KE to be included
             (keyword-only so locked constants cannot be overridden positionally).
-        max_size: Maximum gene-set size passed to gseapy (keyword-only).
+        max_size: Maximum number of measured genes a KE may carry and still be
+            tested (keyword-only). gseapy drops anything larger before it
+            computes a statistic. The Broad convention is 500; 1000 is used
+            here because three of the seven testable AOP 472 Key Events already
+            exceed 500 measured genes, and dropping them would cost more than
+            the dilution costs. A drop on this bound is accounted separately
+            from a ``min_size`` drop (issue #120) — the two say opposite things
+            about the Key Event.
         permutation_num: Number of permutations for the null distribution
             (keyword-only).
         seed: Random seed for reproducibility (keyword-only).
@@ -99,8 +296,18 @@ def run_gsea_analysis(
 
     Returns:
         pd.DataFrame sorted by FDR ascending with columns:
-        ['KE', 'Title', 'NES', 'p_value', 'FDR', 'lead_genes',
-         'total_KE_genes_in_dataset']
+        ['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value', 'FDR',
+         'null_same_signed_n', 'lead_genes', 'total_KE_genes_in_dataset']
+
+        ``nes_status`` is one of ``NES_OK``, ``NES_UNSTABLE`` or
+        ``NES_BEYOND_RESOLUTION`` (issue #117). Under
+        ``NES_BEYOND_RESOLUTION`` the NES is NaN — the quantity does not
+        exist — while ``p_value`` carries the bound ``1/permutation_num``,
+        ``FDR`` is 0.0 and ``ES`` still carries the direction. Under
+        ``NES_UNSTABLE`` every number is gseapy's own; only the NES *magnitude*
+        should not be ranked or thresholded on. ``null_same_signed_n`` is the
+        evidence for the call and is NaN when the diagnostics could not be
+        read.
 
     Raises:
         ValueError: When no reference gene sets are found for the selected AOP,
@@ -131,18 +338,21 @@ def run_gsea_analysis(
 
     # Run gseapy.prerank
     # threads=1 is the determinism guard per RESEARCH §Pitfall #2 — load-bearing for D-15.1
-    pre_res = gp.prerank(
-        rnk=ranking,
-        gene_sets=gene_sets,
-        outdir=None,
-        min_size=min_size,
-        max_size=max_size,
-        permutation_num=permutation_num,
-        seed=seed,
-        threads=1,
-        no_plot=True,
-        verbose=False,
-    )
+    summaries: List[Any] = []
+    with _capture_prerank_summaries(summaries):
+        pre_res = gp.prerank(
+            rnk=ranking,
+            gene_sets=gene_sets,
+            outdir=None,
+            min_size=min_size,
+            max_size=max_size,
+            permutation_num=permutation_num,
+            seed=seed,
+            threads=1,
+            no_plot=True,
+            verbose=False,
+        )
+    same_signed_sizes = _null_tail_sizes(summaries)
 
     res = pre_res.res2d.copy()
 
@@ -171,20 +381,47 @@ def run_gsea_analysis(
 
     # Server-side NES clamp to ±3 per D-12 (frontend gradient also clamps
     # as a second layer so the wire payload stays interpretable)
+    for col in ('ES', 'NES', 'p_value', 'FDR'):
+        res[col] = pd.to_numeric(res[col], errors='coerce')
     res['NES'] = res['NES'].clip(lower=-3, upper=3)
+
+    # Issue #117 — classify each cell by the size of its same-signed
+    # permutation tail and repair the two regimes gseapy misreports.
+    res = apply_null_diagnostics(res, same_signed_sizes, permutation_num)
 
     # Populate total_KE_genes_in_dataset from pre-computed overlap counts
     res['total_KE_genes_in_dataset'] = (
         res['KE'].map(kes_to_overlap_count).fillna(0).astype(int)
     )
 
-    # Log KEs dropped by min_size filter for parity with Fisher per-KE skip log
-    # (RESEARCH Open Question #2) — diff the input ke_list against res['KE']
+    # Log KEs dropped by the size filters for parity with the Fisher per-KE
+    # skip log (RESEARCH Open Question #2) — diff the input ke_list against
+    # res['KE']. Issue #120: gseapy drops on *both* bounds and says which is
+    # not recoverable from its output, so the two are separated here using the
+    # overlap counts computed above. Reporting an over-large Key Event as
+    # "fewer than min_size measured genes" is not a cosmetic slip: it sends the
+    # reader to curate more genes onto the very set that is already too big.
     dropped = (set(ke_list) & set(reference_sets.keys())) - set(res['KE'])
-    if dropped:
+    dropped_too_many = {
+        ke for ke in dropped
+        if gene_sets.get(ke) and kes_to_overlap_count.get(ke, 0) > max_size
+    }
+    dropped_too_few = dropped - dropped_too_many
+    if dropped_too_few:
         logger.info(
-            f"GSEA dropped {len(dropped)} KEs due to min_size={min_size} filter: "
-            f"{sorted(dropped)}"
+            f"GSEA dropped {len(dropped_too_few)} KEs due to min_size={min_size} "
+            f"filter: {sorted(dropped_too_few)}"
+        )
+    if dropped_too_many:
+        logger.warning(
+            "GSEA dropped %d KEs due to max_size=%d filter: %s. These are the "
+            "best-covered Key Events in the analysis, not under-measured ones "
+            "(issue #120)",
+            len(dropped_too_many), max_size,
+            sorted(
+                f"{ke} ({kes_to_overlap_count.get(ke, 0)} measured genes)"
+                for ke in dropped_too_many
+            ),
         )
 
     # Issue #65 — same tested/excluded accounting the Fisher backend produces,
@@ -203,23 +440,30 @@ def run_gsea_analysis(
             unresolved_named[ke] = unresolved_map[ke]
         else:
             excluded_reasons[ke] = EXCLUDED_NO_MAPPING
+    # Issue #120 — a fourth exclusion: a KE whose measured gene set exceeds the
+    # GSEA size ceiling. It is dropped before any statistic is computed, and it
+    # is the opposite fact about the KE from the min_size case.
     for ke in dropped:
         if not gene_sets.get(ke):
             excluded_reasons[ke] = EXCLUDED_UNRESOLVED_MAPPING
             if unresolved_map.get(ke):
                 unresolved_named[ke] = unresolved_map[ke]
+        elif ke in dropped_too_many:
+            excluded_reasons[ke] = EXCLUDED_TOO_MANY_GENES
         else:
             excluded_reasons[ke] = EXCLUDED_TOO_FEW_GENES
     ke_summary = _build_ke_summary(
         ke_list, len(res), excluded_reasons, min_size,
         unresolved_pathways_by_ke=unresolved_named,
+        max_ke_genes=max_size,
     )
 
     # Sort by FDR ascending; use KE ID as tie-breaker so row order is fully
     # deterministic regardless of the internal ordering gseapy returns.
     res = res.sort_values(['FDR', 'KE'], ascending=[True, True], kind='mergesort')
 
-    out = res[['KE', 'Title', 'NES', 'p_value', 'FDR', 'lead_genes',
+    out = res[['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value', 'FDR',
+               'null_same_signed_n', 'lead_genes',
                'total_KE_genes_in_dataset']]
     # Attach on the returned object: pandas only propagates .attrs through
     # operations that call __finalize__, so set it last.

--- a/services/network_service.py
+++ b/services/network_service.py
@@ -12,6 +12,7 @@ from services.enrichment_service import (
     EXCLUDED_ERROR,
     EXCLUDED_NO_MAPPING,
     EXCLUDED_TOO_FEW_GENES,
+    EXCLUDED_TOO_MANY_GENES,
     EXCLUDED_UNRESOLVED_MAPPING,
 )
 
@@ -163,9 +164,12 @@ def build_cytoscape_network(
             # Issue #70 — significantly under-represented. A distinct class, not
             # the significance border, so the reader can tell which way it went.
             classes.append("depleted")
-        if excluded_reason == EXCLUDED_TOO_FEW_GENES:
-            # Assessed-impossible, not assessed-and-null: fewer than the
-            # minimum number of the KE's genes were measured (issue #65).
+        if excluded_reason in (EXCLUDED_TOO_FEW_GENES, EXCLUDED_TOO_MANY_GENES):
+            # Assessed-impossible, not assessed-and-null: the KE's measured
+            # gene count fell outside the testable range — below the minimum
+            # (issue #65) or, under GSEA, above gseapy's ceiling (issue #120).
+            # One class, because the styling says "no statistic was computed";
+            # the accounting sentence says which bound it was.
             classes.append("too-few-genes")
         if excluded_reason == EXCLUDED_UNRESOLVED_MAPPING:
             # Issue #81 — the KE *is* mapped; the mapping resolved to no genes.
@@ -297,8 +301,14 @@ def ke_accounting_from_network(network_json: Any) -> Optional[Dict[str, Any]]:
                 1 for r in reasons if r == EXCLUDED_UNRESOLVED_MAPPING
             ),
             'excluded_too_few_genes': sum(1 for r in reasons if r == EXCLUDED_TOO_FEW_GENES),
+            # Issue #120 — GSEA's upper bound. Zero for every ORA run and for
+            # networks stored before the reason existed.
+            'excluded_too_many_genes': sum(
+                1 for r in reasons if r == EXCLUDED_TOO_MANY_GENES
+            ),
             'excluded_error': sum(1 for r in reasons if r == EXCLUDED_ERROR),
             'min_ke_genes': Config.MIN_KE_GENES,
+            'max_ke_genes': Config.GSEA_MAX_KE_GENES,
             # Issue #81 — the pathway IDs behind those exclusions, recovered
             # from the nodes that carry them. Empty for networks stored before
             # they were written, which reads as "not known" rather than wrong.

--- a/services/network_service.py
+++ b/services/network_service.py
@@ -15,6 +15,7 @@ from services.enrichment_service import (
     EXCLUDED_TOO_MANY_GENES,
     EXCLUDED_UNRESOLVED_MAPPING,
 )
+from services.gsea_service import NES_UNDIAGNOSED
 
 logger = logging.getLogger(__name__)
 
@@ -140,6 +141,20 @@ def build_cytoscape_network(
             nes = _to_native(enrichment_row.get('NES')) if method == 'gsea' else None
             if nes is not None:
                 nes = max(-3.0, min(3.0, float(nes)))
+            # Issue #117 — the NES alone cannot say why it is missing. Under
+            # NES_BEYOND_RESOLUTION it is None because the quantity does not
+            # exist, on a Key Event that beat every permutation; without the
+            # status beside it the frontend's `parseFloat(nes) || 0` turns that
+            # into 0, which is the colour reserved for *no* enrichment. The raw
+            # ES rides along because it is the only surviving statement of
+            # direction for exactly those nodes, and both travel into the .cyjs
+            # export and the network PNG.
+            if method == 'gsea':
+                nes_status = _to_native(enrichment_row.get('nes_status'))
+                es = _to_native(enrichment_row.get('ES'))
+            else:
+                nes_status = None
+                es = None
         else:
             odds_ratio = 0
             is_significant = False
@@ -148,6 +163,8 @@ def build_cytoscape_network(
             fdr = None
             fdr_depleted = None
             nes = None
+            nes_status = None
+            es = None
 
         # Get KE metadata
         label = ke_title_map.get(ke, ke)
@@ -221,6 +238,10 @@ def build_cytoscape_network(
             node_payload["unresolved_pathways"] = sorted(node_unresolved)
         if method == 'gsea':
             node_payload["nes"] = nes
+            # Issue #117 — see above. None on results produced before the
+            # diagnostics existed, which the frontend reads as "no claim".
+            node_payload["nes_status"] = nes_status
+            node_payload["es"] = es
             node_payload["logfc"] = 0  # neutral surrogate per D-10 back-compat
         else:
             node_payload["logfc"] = odds_ratio  # ORA: odds ratio as color surrogate
@@ -317,6 +338,14 @@ def ke_accounting_from_network(network_json: Any) -> Optional[Dict[str, Any]]:
                 for d in ke_nodes
                 for wp in (d.get('unresolved_pathways') or [])
             }),
+            # Issue #117 — tested Key Events whose permutation null could not be
+            # read. Recovered from the node payload so a shared link and the
+            # batch report make the same admission the live results page does.
+            # Zero for ORA and for networks stored before nes_status existed.
+            'nes_undiagnosed_kes': sum(
+                1 for d in ke_nodes
+                if d.get('nes_status') == NES_UNDIAGNOSED
+            ),
         }
     except (json.JSONDecodeError, TypeError, AttributeError) as exc:
         logger.warning(f"ke_accounting_from_network failed: {exc}")

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -20,7 +20,11 @@ from dataclasses import dataclass
 from io import BytesIO
 import pandas as pd
 
-from services.gsea_service import NES_BEYOND_RESOLUTION, NES_UNSTABLE
+from services.gsea_service import (
+    NES_BEYOND_RESOLUTION,
+    NES_UNDIAGNOSED,
+    NES_UNSTABLE,
+)
 
 try:
     import plotly.graph_objects as go
@@ -93,7 +97,56 @@ def format_nes(nes: Any, status: Optional[str] = None) -> str:
     if status == NES_BEYOND_RESOLUTION:
         return f"{text} (beyond permutation resolution, p < 1/permutations)"
     if status == NES_UNSTABLE:
-        return f"{text} (magnitude unstable)"
+        return f"{text} (unstable)"
+    if status == NES_UNDIAGNOSED:
+        return f"{text} (null not inspected)"
+    return text
+
+
+def format_pvalue(
+    pvalue: Any,
+    status: Optional[str] = None,
+    resolution: Optional[float] = None,
+) -> str:
+    """Render a nominal GSEA p-value, saying when it is coarser than it looks.
+
+    Issue #117, corrected. An earlier revision of this module asserted that the
+    nominal p-value survived a short same-signed permutation tail and only the
+    NES magnitude did not. That is wrong: gseapy divides the exceedance count by
+    the *same-signed* tail, not by the permutation count, so a term with a tail
+    of five can only report p in steps of 0.2 and a term with a tail of one only
+    0 or 1. Measured on gseapy 1.1.4, a term with a tail of 56 and a single
+    exceedance returned 1/56, not 1/100. Printing ``0.0000`` for "zero out of
+    two" beside ``0.0000`` for "zero out of a thousand" invites exactly the
+    thresholding the qualifier exists to prevent.
+
+    A report is the artefact that leaves the tool, so the qualifier travels with
+    the number rather than living in a separate status column.
+
+    Args:
+        pvalue: The nominal p-value.
+        status: The row's ``nes_status``, when the result carries one. Results
+            stored before #117 do not, and render as they always did.
+        resolution: The row's ``p_value_resolution`` — the step size the
+            p-value was quantised to.
+
+    Returns:
+        str: the formatted cell text.
+    """
+    if pvalue is None or (isinstance(pvalue, float) and math.isnan(pvalue)):
+        text = 'n/a'
+    elif isinstance(pvalue, (int, float)):
+        text = f"{pvalue:.2e}" if pvalue < 0.001 else f"{pvalue:.4f}"
+    else:
+        text = str(pvalue)
+    if status == NES_BEYOND_RESOLUTION:
+        return f"< {text} (bound; no permutation reached the observed score)"
+    if status == NES_UNSTABLE:
+        if isinstance(resolution, (int, float)) and not math.isnan(resolution):
+            return f"{text} (resolution {resolution:.3g}; do not threshold)"
+        return f"{text} (coarse; do not threshold)"
+    if status == NES_UNDIAGNOSED:
+        return f"{text} (null not inspected)"
     return text
 
 
@@ -527,6 +580,12 @@ class ReportGenerator:
 
             if is_gsea:
                 nes_str = format_nes(result.get('NES'), result.get('nes_status'))
+                # Issue #117: the p-value is qualified the same way the NES is,
+                # because it is computed on the same short tail.
+                gsea_pval_str = format_pvalue(
+                    result.get('p_value'), result.get('nes_status'),
+                    result.get('p_value_resolution'),
+                )
                 lead = result.get('lead_genes', '')
                 # Export carries the FULL untruncated gene list.
                 lead_str = ', '.join(lead) if isinstance(lead, (list, tuple)) else (lead or '')
@@ -535,7 +594,7 @@ class ReportGenerator:
                 <td>{ke_id}</td>
                 <td>{title}</td>
                 <td>{nes_str}</td>
-                <td>{pval_str}</td>
+                <td>{gsea_pval_str}</td>
                 <td>{adj_pval_str}</td>
                 <td>{ke_size}</td>
                 <td>{lead_str}</td>
@@ -1000,10 +1059,15 @@ class ReportGenerator:
 
             if is_gsea:
                 nes_str = format_nes(result.get('NES'), result.get('nes_status'))
+                # Issue #117 — see the HTML table: same tail, same qualifier.
+                gsea_pval_str = format_pvalue(
+                    result.get('p_value'), result.get('nes_status'),
+                    result.get('p_value_resolution'),
+                )
                 lead = result.get('lead_genes', '')
                 lead_str = ', '.join(lead) if isinstance(lead, (list, tuple)) else (lead or '')
                 table_data.append([
-                    result.get('KE', 'N/A'), title, nes_str, pval_str, fdr_str,
+                    result.get('KE', 'N/A'), title, nes_str, gsea_pval_str, fdr_str,
                     str(result.get('total_KE_genes_in_dataset', 0)), lead_str,
                 ])
             else:

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass
 from io import BytesIO
 import pandas as pd
 
+from services.gsea_service import NES_BEYOND_RESOLUTION, NES_UNSTABLE
+
 try:
     import plotly.graph_objects as go
     import plotly.io as pio
@@ -63,6 +65,37 @@ from helpers import MIN_CONFIDENCE_LABELS  # Issue #60: confidence threshold lab
 from services.enrichment_service import REPRESENTATION_LABELS  # Issue #70
 
 logger = logging.getLogger(__name__)
+
+
+def format_nes(nes: Any, status: Optional[str] = None) -> str:
+    """Render a NES for a report table, saying so when it is not a number.
+
+    Issue #117: under ``NES_BEYOND_RESOLUTION`` the NES does not exist — the
+    observed score beat every permutation, so there is no same-signed tail to
+    divide by — and the cell must not read as a blank or as ``None``. The
+    qualifier travels with the value because the reports are the artefact that
+    leaves the tool: a reader with only the PDF has no status column to consult.
+
+    Args:
+        nes: The NES value, or None/NaN when it could not be normalised.
+        status: The row's ``nes_status``, when the result carries one. Results
+            stored before #117 do not, and render as they always did.
+
+    Returns:
+        str: the formatted cell text.
+    """
+    if nes is None or (isinstance(nes, float) and math.isnan(nes)):
+        text = 'n/a'
+    elif isinstance(nes, (int, float)):
+        text = f"{nes:.2f}"
+    else:
+        text = str(nes)
+    if status == NES_BEYOND_RESOLUTION:
+        return f"{text} (beyond permutation resolution, p < 1/permutations)"
+    if status == NES_UNSTABLE:
+        return f"{text} (magnitude unstable)"
+    return text
+
 
 @dataclass
 class ReportData:
@@ -493,8 +526,7 @@ class ReportGenerator:
             row_class = 'significant' if adj_pval < Config.SIGNIFICANCE_FDR_CUTOFF else ''
 
             if is_gsea:
-                nes = result.get('NES', 0)
-                nes_str = f"{nes:.2f}" if isinstance(nes, (int, float)) else str(nes)
+                nes_str = format_nes(result.get('NES'), result.get('nes_status'))
                 lead = result.get('lead_genes', '')
                 # Export carries the FULL untruncated gene list.
                 lead_str = ', '.join(lead) if isinstance(lead, (list, tuple)) else (lead or '')
@@ -967,8 +999,7 @@ class ReportGenerator:
                 title = title[:37] + "..."
 
             if is_gsea:
-                nes = result.get('NES', 0)
-                nes_str = f"{nes:.2f}" if isinstance(nes, (int, float)) else str(nes)
+                nes_str = format_nes(result.get('NES'), result.get('nes_status'))
                 lead = result.get('lead_genes', '')
                 lead_str = ', '.join(lead) if isinstance(lead, (list, tuple)) else (lead or '')
                 table_data.append([

--- a/static/css/pages/compare.css
+++ b/static/css/pages/compare.css
@@ -81,6 +81,35 @@
 .genes-table th:first-child, .genes-table td:first-child { text-align: left; white-space: nowrap; }
 .genes-table tr:nth-child(even) { background-color: #f9f9f9; }
 
+/* Issue #117 — a cell whose NES could not be normalised because the Key Event
+   beat every permutation. It must not look like the em-dash of an untested
+   cell, and it must not look like an ordinary NES either, because there is no
+   magnitude behind it. Boxed and monospaced: a label, not a number. */
+.compare-cell--beyond {
+  display: inline-block;
+  font-family: var(--font-mono, ui-monospace, "SFMono-Regular", Menlo, monospace);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 1px 5px;
+  border: 1px dashed #111;
+  border-radius: 3px;
+  background: repeating-linear-gradient(
+    45deg, #f2f2f2, #f2f2f2 4px, #e2e2e2 4px, #e2e2e2 8px
+  );
+  color: #111;
+  cursor: help;
+}
+
+/* Issue #117 — a cell whose numbers are coarse (short same-signed tail) or
+   unchecked (null not readable). A marker, not a restyle: the value is still
+   gseapy's own and still readable. */
+.compare-cell--flag {
+  margin-left: 3px;
+  font-size: 11px;
+  color: #b25a00;
+  cursor: help;
+}
+
 /* Table trend column (Feature D) */
 .compare-table__trend { font-size: 15px; }
 

--- a/templates/compare.html
+++ b/templates/compare.html
@@ -110,13 +110,20 @@
     <div id="tab-heatmap" class="compare-tab-panel compare-tab-panel--active">
       <div id="heatmap-div" style="width:100%;min-height:400px;"></div>
       {# Issue #107: the NES heatmap colours only significant cells, so say so —
-         a blank cell means "direction not supported here", not "no result". #}
+         a blank cell means "direction not supported here", not "no result".
+         Issue #117: and correct the claim that used to follow it. Not every
+         cell has a NES value: where the Key Event beat every permutation the
+         quantity does not exist, so that cell is marked rather than coloured
+         and the exports carry its ES and status instead of a number. #}
       {% if batch_method == 'gsea' %}
       <p class="compare-genes-note">
         Colour shows the normalised enrichment score (NES) for Key Events reaching
         FDR &lt; {{ fdr_cutoff }}. Cells above that cutoff are left blank: their NES sign is
-        not stable, so colouring them would show noise as direction. Every value,
-        significant or not, is in the Table tab and in the exports.
+        not stable, so colouring them would show noise as direction. Cells ringed in
+        black have no NES at all &mdash; no permutation reached the observed enrichment
+        score, so there is nothing to normalise against; hover for the enrichment score
+        that carries their direction. Every NES that exists, significant or not, is in
+        the Table tab and in the exports, alongside the status of the cells that have none.
       </p>
       {% endif %}
     </div>
@@ -129,7 +136,13 @@
           Cells show the normalised enrichment score (NES, signed) with the permutation
           FDR beneath it. Shading marks FDR &lt; {{ fdr_cutoff }}; an unshaded but consistently
           signed NES across conditions is still a coordinated shift, which is why the
-          value is greyed rather than hidden (#107).
+          value is greyed rather than hidden (#107). A boxed
+          <span class="compare-cell--beyond">&#9650;&nbsp;beyond res.</span> cell has no
+          NES: no permutation reached its enrichment score, so the arrow gives the
+          direction and the FDR is its limit of zero. A &#9888; marks a cell normalised
+          against fewer than ten same-signed permutations &mdash; gseapy computes the
+          nominal p-value on that same short tail, so neither the magnitude nor the
+          p-value there is fine-grained enough to rank on (#117).
         {% else %}
           Cells show the Benjamini&ndash;Hochberg FDR from Fisher's exact test.
           Shading marks FDR &lt; 0.05.
@@ -268,6 +281,59 @@
         return isSignificantFdr(cellFdr) ? value : null;
       });
     });
+  }
+
+  /** Issue #117 — the cell beat every permutation; its NES is not normalisable. */
+  const NES_BEYOND_RESOLUTION = 'beyond_permutation_resolution';
+  /** Issue #117 — the permutation null could not be inspected for this cell. */
+  const NES_UNDIAGNOSED = 'undiagnosed';
+
+  /**
+   * The nes_status of one cell, or null when the batch carries none (#117).
+   *
+   * @param {number} ke  - Row index.
+   * @param {number} col - Column index.
+   * @returns {string|null}
+   */
+  function nesStatusAt(ke, col) {
+    const m = comparisonData.nes_status_matrix;
+    if (!Array.isArray(m) || !m[ke]) return null;
+    const v = m[ke][col];
+    return v === undefined ? null : v;
+  }
+
+  /**
+   * The raw enrichment score of one cell, or null (#117).
+   *
+   * Beyond permutation resolution the ES is the only surviving statement of
+   * direction, so the comparison view reads direction from here rather than
+   * from the NES, which does not exist for those cells.
+   *
+   * @param {number} ke  - Row index.
+   * @param {number} col - Column index.
+   * @returns {number|null}
+   */
+  function esAt(ke, col) {
+    const m = comparisonData.es_matrix;
+    if (!Array.isArray(m) || !m[ke]) return null;
+    const v = m[ke][col];
+    return (v === undefined || v === null) ? null : v;
+  }
+
+  /**
+   * Is this cell a Key Event that beat every permutation? (#117)
+   *
+   * The whole point of the distinction: such a cell has NES null and FDR 0, and
+   * before #117 was propagated here it rendered exactly like a Key Event that
+   * was never tested — an em-dash, unshaded, sorted last, blank on the heatmap.
+   * That is the inverse of the result.
+   *
+   * @param {number} ke  - Row index.
+   * @param {number} col - Column index.
+   * @returns {boolean}
+   */
+  function isBeyondResolution(ke, col) {
+    return nesStatusAt(ke, col) === NES_BEYOND_RESOLUTION;
   }
 
   /**
@@ -710,7 +776,67 @@
       hoverinfo: 'skip'
     };
 
-    return { trace: trace, axisAnchor: axisAnchor, layout: layout, config: config };
+    // #117: cells whose NES could not be normalised carry no z value, so the
+    // diverging scale has nothing to colour them with and maskedNesMatrix()
+    // blanks them like any missing cell. They are the opposite of missing — the
+    // observed score beat every permutation — so they get their own mark rather
+    // than a colour: a ring at the cell, annotated with the ES direction. A
+    // colour would have to claim a magnitude the run cannot supply.
+    var beyondMarks = beyondResolutionMarks(mode, xLabels);
+
+    return {
+      trace: trace, axisAnchor: axisAnchor, beyondMarks: beyondMarks,
+      layout: layout, config: config
+    };
+  }
+
+  /**
+   * Scatter overlay marking the beyond-permutation-resolution cells (#117).
+   *
+   * Only meaningful in absolute GSEA mode: in delta mode the quantity plotted
+   * is a difference of NES values, and a cell with no NES has no difference
+   * either, so it stays out rather than being marked on a scale it is not on.
+   *
+   * @param {string} mode     - 'absolute' or 'delta'.
+   * @param {Array<string>} xLabels - The condition labels actually plotted.
+   * @returns {Object} A Plotly scatter trace (empty when there is nothing to mark).
+   */
+  function beyondResolutionMarks(mode, xLabels) {
+    var xs = [], ys = [], texts = [];
+    if (isGsea && mode === 'absolute') {
+      for (var ke = 0; ke < comparisonData.ke_labels.length; ke++) {
+        for (var col = 0; col < comparisonData.condition_labels.length; col++) {
+          if (!isBeyondResolution(ke, col)) continue;
+          var label = comparisonData.condition_labels[col];
+          if (xLabels.indexOf(label) === -1) continue;
+          var es = esAt(ke, col);
+          var dir = (es === null) ? 'direction unknown'
+            : (es >= 0 ? 'enriched at the top of the ranking'
+                       : 'enriched at the bottom of the ranking');
+          xs.push(label);
+          ys.push(comparisonData.ke_titles[ke]);
+          texts.push('Beyond permutation resolution: no permutation reached the '
+            + 'observed score, so the NES cannot be normalised. ES '
+            + (es === null ? 'n/a' : es.toFixed(3)) + ' — ' + dir + '.');
+        }
+      }
+    }
+    return {
+      type: 'scatter',
+      mode: 'markers',
+      x: xs,
+      y: ys,
+      marker: {
+        symbol: 'circle-open',
+        size: 14,
+        line: { width: 3, color: '#111111' },
+        color: '#111111'
+      },
+      name: 'beyond permutation resolution',
+      showlegend: xs.length > 0,
+      hovertemplate: '<b>%{y}</b><br>%{x}<br>%{text}<extra></extra>',
+      text: texts
+    };
   }
 
   /**
@@ -722,13 +848,14 @@
    */
   function updateHeatmap(mode, refIndex) {
     var hd = buildHeatmapData(mode, refIndex);
+    var traces = [hd.axisAnchor, hd.trace, hd.beyondMarks];
     if (!heatmapInitialised) {
       // Initial render — create the Plotly figure from scratch.
-      Plotly.newPlot('heatmap-div', [hd.axisAnchor, hd.trace], hd.layout, hd.config);
+      Plotly.newPlot('heatmap-div', traces, hd.layout, hd.config);
       heatmapInitialised = true;
     } else {
       // Subsequent updates — efficiently patch the existing figure without full re-create.
-      Plotly.react('heatmap-div', [hd.axisAnchor, hd.trace], hd.layout);
+      Plotly.react('heatmap-div', traces, hd.layout);
     }
   }
 
@@ -810,7 +937,31 @@
         if (mode === 'absolute' && isGsea) {
           // GSEA (#76): NES carries the direction and magnitude, FDR the
           // confidence — showing only one of them loses half the result.
-          if (nesVal === null || nesVal === undefined) {
+          if (isBeyondResolution(ke, col)) {
+            // #117: NES null because the Key Event beat every permutation, not
+            // because it was never tested. Rendering it as an em-dash lost the
+            // strongest cells in the grid and dropped the FDR that every other
+            // cell carries. Direction comes from the ES, which is the only
+            // place it survives; magnitude is deliberately not claimed.
+            var esVal = esAt(ke, col);
+            var arrow = (esVal === null) ? '?' : (esVal >= 0 ? '▲' : '▼');
+            var esText = (esVal === null) ? 'n/a'
+              : ((esVal >= 0 ? '+' : '') + esVal.toFixed(3));
+            var brFdrText = (fdrVal === null || fdrVal === undefined)
+              ? 'n/a' : fdrVal.toExponential(2);
+            isSig = isSignificantFdr(fdrVal);
+            displayVal =
+              '<span class="compare-cell--beyond" title="Beyond permutation '
+              + 'resolution: no permutation reached the observed enrichment '
+              + 'score, so the NES has no value to report. ES ' + esText
+              + ' carries the direction; the p-value is bounded by '
+              + '1/permutations.">' + arrow + '&nbsp;beyond res.</span>'
+              + '<span style="color:#777;font-size:11px;"> q=' + brFdrText + '</span>';
+            // Sort to the extreme of its own direction: the cell is the most
+            // enriched the run can distinguish, so sorting it last (which
+            // 'Infinity' did) put the strongest results at the bottom.
+            sortVal = String((esVal !== null && esVal < 0) ? -1e9 : 1e9);
+          } else if (nesVal === null || nesVal === undefined) {
             displayVal = '&mdash;';
             sortVal = 'Infinity';
             isSig = false;
@@ -827,6 +978,22 @@
                             + FDR_CUTOFF + ' — the sign of NES is not supported here">'
                             + nesText + '</span>')
               + '<span style="color:#777;font-size:11px;"> q=' + fdrText + '</span>';
+            // #117: a short same-signed tail makes both numbers coarse —
+            // gseapy computes the nominal p on the very tail it normalises
+            // against — and a cell that could not be diagnosed makes no claim
+            // either way. Both get a mark rather than being read as ordinary.
+            var cellStatus = nesStatusAt(ke, col);
+            if (cellStatus === 'unstable_normalisation') {
+              displayVal += '<span class="compare-cell--flag" title="Fewer than '
+                + '10 permutations fell on the observed side of zero. Both the '
+                + 'NES magnitude and the nominal p-value are computed against '
+                + 'that handful of values, so neither should be ranked or '
+                + 'thresholded on.">&#9888;</span>';
+            } else if (cellStatus === NES_UNDIAGNOSED) {
+              displayVal += '<span class="compare-cell--flag" title="The '
+                + 'permutation null could not be inspected for this cell, so '
+                + 'these numbers are unchecked.">?</span>';
+            }
             // Sort on NES descending-friendly magnitude; keep raw NES so the
             // column sorts by direction as displayed.
             sortVal = String(nesVal);

--- a/templates/results.html
+++ b/templates/results.html
@@ -250,6 +250,7 @@
                             'NES': 'NES',
                             'ES': 'ES',
                             'nes_status': 'NES status',
+                            'p_value_resolution': 'P-value resolution',
                             'null_same_signed_n': 'Same-signed permutations',
                             'lead_genes': 'Lead Edge Genes'
                         } %}
@@ -258,13 +259,22 @@
                            of the three regimes each row is in. #}
                         {% set nes_status_labels = {
                             'ok': 'normalised',
-                            'unstable_normalisation': 'unstable magnitude',
-                            'beyond_permutation_resolution': 'beyond permutation resolution'
+                            'unstable_normalisation': 'coarse — NES and p',
+                            'beyond_permutation_resolution': 'beyond permutation resolution',
+                            'undiagnosed': 'not diagnosed'
                         } %}
+                        {# Issue #117: an earlier version of these tooltips told the reader
+                           that an unstable normalisation left the nominal p-value intact.
+                           It does not. gseapy divides the exceedance count by the same
+                           same-signed tail it normalises against, so a tail of five admits
+                           only p in {0, 0.2, 0.4, 0.6, 0.8, 1} and a tail of one only
+                           {0, 1}. That claim is retracted here and the achievable
+                           resolution is reported per row instead. #}
                         {% set nes_status_titles = {
-                            'ok': 'The permutation null had permutations on both sides of zero; the NES is an estimate.',
-                            'unstable_normalisation': 'Fewer than 10 permutations fell on the same side of zero as the observed score. The p-value stands; the NES magnitude is normalised against too few values to rank or threshold on.',
-                            'beyond_permutation_resolution': 'No permutation reached the observed side of zero, so the observed score beat every one of them. The NES cannot be normalised and is left blank; the p-value is an upper bound (1/permutations) and the ES column carries the direction.'
+                            'ok': 'At least 10 permutations fell on the same side of zero as the observed score; the NES is an estimate and the nominal p-value is resolved to at worst 1 in 10.',
+                            'unstable_normalisation': 'Fewer than 10 permutations fell on the same side of zero as the observed score. Both the NES magnitude and the nominal p-value are computed against that handful of values — gseapy divides by the same-signed tail, not by the permutation count — so the p-value is quantised to the step size in the resolution column. Neither number should be ranked or thresholded on.',
+                            'beyond_permutation_resolution': 'No permutation reached the observed side of zero, so the observed score beat every one of them. The NES cannot be normalised and is left blank; the p-value is an upper bound (1/permutations) and the ES column carries the direction.',
+                            'undiagnosed': 'The permutation null could not be read for this Key Event, so nothing here has been checked: the degenerate one-signed case that reports a maximally enriched Key Event as null cannot be ruled out. This is not the same as a clean result.'
                         } %}
                         {% for col in table[0].keys() %}
                         <th>{{ column_names.get(col, col) }}</th>
@@ -287,10 +297,18 @@
                         {% elif col == 'NES' %}
                             {# Issue #117: a blank NES means "not normalisable", which the
                                nes_status column names. It is never a weak result. #}
-                            <td>{{ "%.2f"|format(val) if val is not none else '—' }}</td>                        {% elif col == 'nes_status' %}
+                            <td>{{ "%.2f"|format(val) if val is not none else '—' }}</td>
+                        {% elif col == 'nes_status' %}
                             <td title="{{ nes_status_titles.get(val, '') }}">{{ nes_status_labels.get(val, val) }}</td>
                         {% elif col == 'ES' %}
                             <td>{{ "%.3f"|format(val) if val is not none else '—' }}</td>
+                        {% elif col == 'p_value_resolution' %}
+                            {# Issue #117: the finest p-value this row could have produced.
+                               gseapy computes the nominal p on the same-signed tail, so a
+                               p of 0.000 against a resolution of 0.5 means "zero out of
+                               two" — the same printed number as a p estimated on a
+                               thousand permutations, and not the same claim. #}
+                            <td title="The step size the nominal p-value was quantised to: 1 divided by the number of same-signed permutations. A p-value finer than this was not achievable for this Key Event.">{{ "%.3g"|format(val) if val is not none else '—' }}</td>
                         {% elif col == 'null_same_signed_n' %}
                             <td>{{ val|int if val is not none else '—' }}</td>
                         {% elif col == 'Representation' %}
@@ -418,6 +436,22 @@
                         <div style="width: 100px; height: 12px; background: linear-gradient(to right, #307BBF, #FFFFFF, #d73027); border: 1px solid #999;"></div>
                         <span style="font-size: 11px; margin-left: 5px;">+3</span>
                         <span style="font-size: 11px; margin-left: 10px; color: #666;">Negative NES &larr; 0 &rarr; Positive NES</span>
+                    </div>
+                    {# Issue #117: white on this scale means NES = 0. A Key Event
+                       whose observed score beat every permutation has no NES at
+                       all, so it is drawn off the scale entirely rather than
+                       being folded onto the zero colour. #}
+                    <div class="network-legend__item" style="margin-top: 6px;">
+                        <div class="network-legend__swatch" style="background: #3A2E4D; border: 3px dashed red;"></div>
+                        <span>NES not normalisable &mdash; no permutation reached this Key
+                              Event's enrichment score, so there is nothing to normalise
+                              against. Off the scale, not at zero; the ES in the results
+                              table carries the direction.</span>
+                    </div>
+                    <div class="network-legend__item">
+                        <div class="network-legend__swatch" style="background: #ffd9b3; border: 3px dotted #b25a00;"></div>
+                        <span>Permutation null not inspected &mdash; this Key Event's NES
+                              and p-value are unchecked.</span>
                     </div>
                 </div>
                 {% else %}
@@ -849,8 +883,20 @@ function defaultLogFCColor(logfc) {
 }
 
 // --- NES gradient for GSEA KE nodes (UI-SPEC §Color, locked stops) ---
+// Issue #117: a null NES is NOT zero. `parseFloat(null) || 0` used to fold the
+// beyond-permutation-resolution case — a Key Event whose observed score beat
+// every permutation, so there is nothing to normalise it against — onto
+// '#FFFFFF', the colour reserved for exactly no enrichment. The node was drawn
+// white with a significance border, saying the opposite of the result, and the
+// .cyjs export and the network PNG in both reports inherited it. A NES that is
+// not a finite number is now given its own colour and never enters the
+// gradient; the node style block below overrides it further for the case where
+// the reason is known.
+const NES_UNDEFINED_COLOR = '#3A2E4D';   // off-gradient: not blue, white or red
 function nesColor(nes) {
-    const v = Math.max(-3, Math.min(3, parseFloat(nes) || 0));
+    const parsed = parseFloat(nes);
+    if (!Number.isFinite(parsed)) return NES_UNDEFINED_COLOR;
+    const v = Math.max(-3, Math.min(3, parsed));
     if (v === 0) return '#FFFFFF';
     const t = (v + 3) / 6;
     const lerp = (a, b, k) => Math.round(a + (b - a) * k);
@@ -1007,6 +1053,36 @@ const cy = cytoscape({
         selector: 'node[method = "gsea"]',
         style: {
             'background-color': ele => nesColor(ele.data('nes'))
+        }
+    },
+    {
+        // Issue #117 — the Key Event beat every permutation, so its NES has no
+        // value at all. This is the strongest result the run can express, and
+        // before this rule it was drawn in the colour reserved for NES = 0.
+        // Solid off-gradient plum with a thick dashed ring: unmistakably not a
+        // point on the blue-white-red scale, and unmistakably not the muted
+        // grey of a Key Event that could not be assessed. Only the border
+        // *style* and width are set, so the red significance border from
+        // node.significant survives and the node still reads as a called
+        // result. The direction lives in `es`, which the tooltip and the .cyjs
+        // export carry.
+        // Ordered after the gradient rule so it wins.
+        selector: 'node[method = "gsea"][nes_status = "beyond_permutation_resolution"]',
+        style: {
+            'background-color': NES_UNDEFINED_COLOR,
+            'border-width': 5,
+            'border-style': 'dashed'
+        }
+    },
+    {
+        // Issue #117 — the permutation null could not be inspected for this
+        // Key Event, so nothing about its NES has been checked. Hatched via a
+        // dotted border rather than recoloured: the value is still gseapy's own.
+        selector: 'node[method = "gsea"][nes_status = "undiagnosed"]',
+        style: {
+            'border-width': 3,
+            'border-color': '#b25a00',
+            'border-style': 'dotted'
         }
     },
     {

--- a/templates/results.html
+++ b/templates/results.html
@@ -1085,6 +1085,27 @@ const cy = cytoscape({
             'border-style': 'dotted'
         }
     },
+    // Issue #117 follow-up — the GSEA gradient selector above matches every
+    // `method = "gsea"` node, including Key Events that were never tested (an
+    // untested node still carries `method = "gsea"` with `nes = null`, and
+    // `nesColor(null)` returns the off-gradient plum reserved for a KE that beat
+    // every permutation). Ordered after the gradient rule, these re-assert the
+    // muted exclusion fills so an uncurated, unresolved or untestable KE is not
+    // painted as the strongest result on the canvas. Scoped to `[method="gsea"]`
+    // so legacy GSEA results (real NES, no status) still colour by gradient, and
+    // so ORA styling is untouched.
+    {
+        selector: 'node.no-genes[method = "gsea"]',
+        style: { 'background-color': '#cccccc' }
+    },
+    {
+        selector: 'node.unresolved-mapping[method = "gsea"]',
+        style: { 'background-color': '#f7e6d5' }
+    },
+    {
+        selector: 'node.too-few-genes[method = "gsea"]',
+        style: { 'background-color': '#e8e8e8' }
+    },
     {
         selector: 'node.gene',
         style: {

--- a/templates/results.html
+++ b/templates/results.html
@@ -248,7 +248,23 @@
                             'p_value_depleted': 'P-value (depletion)',
                             'FDR_depleted': 'FDR (depletion)',
                             'NES': 'NES',
+                            'ES': 'ES',
+                            'nes_status': 'NES status',
+                            'null_same_signed_n': 'Same-signed permutations',
                             'lead_genes': 'Lead Edge Genes'
+                        } %}
+                        {# Issue #117: a NES is only a magnitude when the permutation
+                           null had a usable same-signed tail. These labels say which
+                           of the three regimes each row is in. #}
+                        {% set nes_status_labels = {
+                            'ok': 'normalised',
+                            'unstable_normalisation': 'unstable magnitude',
+                            'beyond_permutation_resolution': 'beyond permutation resolution'
+                        } %}
+                        {% set nes_status_titles = {
+                            'ok': 'The permutation null had permutations on both sides of zero; the NES is an estimate.',
+                            'unstable_normalisation': 'Fewer than 10 permutations fell on the same side of zero as the observed score. The p-value stands; the NES magnitude is normalised against too few values to rank or threshold on.',
+                            'beyond_permutation_resolution': 'No permutation reached the observed side of zero, so the observed score beat every one of them. The NES cannot be normalised and is left blank; the p-value is an upper bound (1/permutations) and the ES column carries the direction.'
                         } %}
                         {% for col in table[0].keys() %}
                         <th>{{ column_names.get(col, col) }}</th>
@@ -269,7 +285,14 @@
                             <td></td>
                             {% endif %}
                         {% elif col == 'NES' %}
-                            <td>{{ "%.2f"|format(val) }}</td>
+                            {# Issue #117: a blank NES means "not normalisable", which the
+                               nes_status column names. It is never a weak result. #}
+                            <td>{{ "%.2f"|format(val) if val is not none else '—' }}</td>                        {% elif col == 'nes_status' %}
+                            <td title="{{ nes_status_titles.get(val, '') }}">{{ nes_status_labels.get(val, val) }}</td>
+                        {% elif col == 'ES' %}
+                            <td>{{ "%.3f"|format(val) if val is not none else '—' }}</td>
+                        {% elif col == 'null_same_signed_n' %}
+                            <td>{{ val|int if val is not none else '—' }}</td>
                         {% elif col == 'Representation' %}
                             {# Issue #70: which tail the Key Event fell on. Kept in
                                step with the FDR selector by applyFdrThreshold(). #}

--- a/templates/shared_results.html
+++ b/templates/shared_results.html
@@ -137,6 +137,7 @@
                             'NES': 'NES',
                             'ES': 'ES',
                             'nes_status': 'NES status',
+                            'p_value_resolution': 'P-value resolution',
                             'null_same_signed_n': 'Same-signed permutations',
                             'lead_genes': 'Lead Edge Genes'
                         } %}
@@ -145,13 +146,22 @@
                            of the three regimes each row is in. #}
                         {% set nes_status_labels = {
                             'ok': 'normalised',
-                            'unstable_normalisation': 'unstable magnitude',
-                            'beyond_permutation_resolution': 'beyond permutation resolution'
+                            'unstable_normalisation': 'coarse — NES and p',
+                            'beyond_permutation_resolution': 'beyond permutation resolution',
+                            'undiagnosed': 'not diagnosed'
                         } %}
+                        {# Issue #117: an earlier version of these tooltips told the reader
+                           that an unstable normalisation left the nominal p-value intact.
+                           It does not. gseapy divides the exceedance count by the same
+                           same-signed tail it normalises against, so a tail of five admits
+                           only p in {0, 0.2, 0.4, 0.6, 0.8, 1} and a tail of one only
+                           {0, 1}. That claim is retracted here and the achievable
+                           resolution is reported per row instead. #}
                         {% set nes_status_titles = {
-                            'ok': 'The permutation null had permutations on both sides of zero; the NES is an estimate.',
-                            'unstable_normalisation': 'Fewer than 10 permutations fell on the same side of zero as the observed score. The p-value stands; the NES magnitude is normalised against too few values to rank or threshold on.',
-                            'beyond_permutation_resolution': 'No permutation reached the observed side of zero, so the observed score beat every one of them. The NES cannot be normalised and is left blank; the p-value is an upper bound (1/permutations) and the ES column carries the direction.'
+                            'ok': 'At least 10 permutations fell on the same side of zero as the observed score; the NES is an estimate and the nominal p-value is resolved to at worst 1 in 10.',
+                            'unstable_normalisation': 'Fewer than 10 permutations fell on the same side of zero as the observed score. Both the NES magnitude and the nominal p-value are computed against that handful of values — gseapy divides by the same-signed tail, not by the permutation count — so the p-value is quantised to the step size in the resolution column. Neither number should be ranked or thresholded on.',
+                            'beyond_permutation_resolution': 'No permutation reached the observed side of zero, so the observed score beat every one of them. The NES cannot be normalised and is left blank; the p-value is an upper bound (1/permutations) and the ES column carries the direction.',
+                            'undiagnosed': 'The permutation null could not be read for this Key Event, so nothing here has been checked: the degenerate one-signed case that reports a maximally enriched Key Event as null cannot be ruled out. This is not the same as a clean result.'
                         } %}
                         {% if table %}
                         {% for col in table[0].keys() %}
@@ -176,10 +186,18 @@
                         {% elif col == 'NES' %}
                             {# Issue #117: a blank NES means "not normalisable", which the
                                nes_status column names. It is never a weak result. #}
-                            <td>{{ "%.2f"|format(val) if val is not none else '—' }}</td>                        {% elif col == 'nes_status' %}
+                            <td>{{ "%.2f"|format(val) if val is not none else '—' }}</td>
+                        {% elif col == 'nes_status' %}
                             <td title="{{ nes_status_titles.get(val, '') }}">{{ nes_status_labels.get(val, val) }}</td>
                         {% elif col == 'ES' %}
                             <td>{{ "%.3f"|format(val) if val is not none else '—' }}</td>
+                        {% elif col == 'p_value_resolution' %}
+                            {# Issue #117: the finest p-value this row could have produced.
+                               gseapy computes the nominal p on the same-signed tail, so a
+                               p of 0.000 against a resolution of 0.5 means "zero out of
+                               two" — the same printed number as a p estimated on a
+                               thousand permutations, and not the same claim. #}
+                            <td title="The step size the nominal p-value was quantised to: 1 divided by the number of same-signed permutations. A p-value finer than this was not achievable for this Key Event.">{{ "%.3g"|format(val) if val is not none else '—' }}</td>
                         {% elif col == 'null_same_signed_n' %}
                             <td>{{ val|int if val is not none else '—' }}</td>
                         {% elif col == 'Representation' %}
@@ -299,6 +317,22 @@
                         <div style="width: 100px; height: 12px; background: linear-gradient(to right, #307BBF, #FFFFFF, #d73027); border: 1px solid #999;"></div>
                         <span style="font-size: 11px; margin-left: 5px;">+3</span>
                         <span style="font-size: 11px; margin-left: 10px; color: #666;">Negative NES &larr; 0 &rarr; Positive NES</span>
+                    </div>
+                    {# Issue #117: white on this scale means NES = 0. A Key Event
+                       whose observed score beat every permutation has no NES at
+                       all, so it is drawn off the scale entirely rather than
+                       being folded onto the zero colour. #}
+                    <div class="network-legend__item" style="margin-top: 6px;">
+                        <div class="network-legend__swatch" style="background: #3A2E4D; border: 3px dashed red;"></div>
+                        <span>NES not normalisable &mdash; no permutation reached this Key
+                              Event's enrichment score, so there is nothing to normalise
+                              against. Off the scale, not at zero; the ES in the results
+                              table carries the direction.</span>
+                    </div>
+                    <div class="network-legend__item">
+                        <div class="network-legend__swatch" style="background: #ffd9b3; border: 3px dotted #b25a00;"></div>
+                        <span>Permutation null not inspected &mdash; this Key Event's NES
+                              and p-value are unchecked.</span>
                     </div>
                 </div>
                 {% else %}
@@ -448,8 +482,20 @@ function defaultLogFCColor(logfc) {
 }
 
 // --- NES gradient for GSEA KE nodes (UI-SPEC §Color, locked stops) ---
+// Issue #117: a null NES is NOT zero. `parseFloat(null) || 0` used to fold the
+// beyond-permutation-resolution case — a Key Event whose observed score beat
+// every permutation, so there is nothing to normalise it against — onto
+// '#FFFFFF', the colour reserved for exactly no enrichment. The node was drawn
+// white with a significance border, saying the opposite of the result, and the
+// .cyjs export and the network PNG in both reports inherited it. A NES that is
+// not a finite number is now given its own colour and never enters the
+// gradient; the node style block below overrides it further for the case where
+// the reason is known.
+const NES_UNDEFINED_COLOR = '#3A2E4D';   // off-gradient: not blue, white or red
 function nesColor(nes) {
-    const v = Math.max(-3, Math.min(3, parseFloat(nes) || 0));
+    const parsed = parseFloat(nes);
+    if (!Number.isFinite(parsed)) return NES_UNDEFINED_COLOR;
+    const v = Math.max(-3, Math.min(3, parsed));
     if (v === 0) return '#FFFFFF';
     const t = (v + 3) / 6;
     const lerp = (a, b, k) => Math.round(a + (b - a) * k);
@@ -577,6 +623,36 @@ const cy = cytoscape({
         selector: 'node[method = "gsea"]',
         style: {
             'background-color': ele => nesColor(ele.data('nes'))
+        }
+    },
+    {
+        // Issue #117 — the Key Event beat every permutation, so its NES has no
+        // value at all. This is the strongest result the run can express, and
+        // before this rule it was drawn in the colour reserved for NES = 0.
+        // Solid off-gradient plum with a thick dashed ring: unmistakably not a
+        // point on the blue-white-red scale, and unmistakably not the muted
+        // grey of a Key Event that could not be assessed. Only the border
+        // *style* and width are set, so the red significance border from
+        // node.significant survives and the node still reads as a called
+        // result. The direction lives in `es`, which the tooltip and the .cyjs
+        // export carry.
+        // Ordered after the gradient rule so it wins.
+        selector: 'node[method = "gsea"][nes_status = "beyond_permutation_resolution"]',
+        style: {
+            'background-color': NES_UNDEFINED_COLOR,
+            'border-width': 5,
+            'border-style': 'dashed'
+        }
+    },
+    {
+        // Issue #117 — the permutation null could not be inspected for this
+        // Key Event, so nothing about its NES has been checked. Hatched via a
+        // dotted border rather than recoloured: the value is still gseapy's own.
+        selector: 'node[method = "gsea"][nes_status = "undiagnosed"]',
+        style: {
+            'border-width': 3,
+            'border-color': '#b25a00',
+            'border-style': 'dotted'
         }
     },
     {

--- a/templates/shared_results.html
+++ b/templates/shared_results.html
@@ -655,6 +655,24 @@ const cy = cytoscape({
             'border-style': 'dotted'
         }
     },
+    // Issue #117 follow-up — the GSEA gradient selector matches every
+    // `method = "gsea"` node, including Key Events that were never tested
+    // (`nes = null` → `nesColor(null)` → off-gradient plum). Ordered after the
+    // gradient rule, these re-assert the muted exclusion fills so an untested KE
+    // is not painted as the strongest result. Scoped to `[method="gsea"]` so
+    // legacy GSEA results still colour by gradient and ORA is untouched.
+    {
+        selector: 'node.no-genes[method = "gsea"]',
+        style: { 'background-color': '#cccccc' }
+    },
+    {
+        selector: 'node.unresolved-mapping[method = "gsea"]',
+        style: { 'background-color': '#f7e6d5' }
+    },
+    {
+        selector: 'node.too-few-genes[method = "gsea"]',
+        style: { 'background-color': '#e8e8e8' }
+    },
     {
         selector: 'node.gene',
         style: {

--- a/templates/shared_results.html
+++ b/templates/shared_results.html
@@ -135,7 +135,23 @@
                             'p_value_depleted': 'P-value (depletion)',
                             'FDR_depleted': 'FDR (depletion)',
                             'NES': 'NES',
+                            'ES': 'ES',
+                            'nes_status': 'NES status',
+                            'null_same_signed_n': 'Same-signed permutations',
                             'lead_genes': 'Lead Edge Genes'
+                        } %}
+                        {# Issue #117: a NES is only a magnitude when the permutation
+                           null had a usable same-signed tail. These labels say which
+                           of the three regimes each row is in. #}
+                        {% set nes_status_labels = {
+                            'ok': 'normalised',
+                            'unstable_normalisation': 'unstable magnitude',
+                            'beyond_permutation_resolution': 'beyond permutation resolution'
+                        } %}
+                        {% set nes_status_titles = {
+                            'ok': 'The permutation null had permutations on both sides of zero; the NES is an estimate.',
+                            'unstable_normalisation': 'Fewer than 10 permutations fell on the same side of zero as the observed score. The p-value stands; the NES magnitude is normalised against too few values to rank or threshold on.',
+                            'beyond_permutation_resolution': 'No permutation reached the observed side of zero, so the observed score beat every one of them. The NES cannot be normalised and is left blank; the p-value is an upper bound (1/permutations) and the ES column carries the direction.'
                         } %}
                         {% if table %}
                         {% for col in table[0].keys() %}
@@ -158,7 +174,14 @@
                             <td>—</td>
                             {% endif %}
                         {% elif col == 'NES' %}
-                            <td>{{ "%.2f"|format(val) if val is not none else '—' }}</td>
+                            {# Issue #117: a blank NES means "not normalisable", which the
+                               nes_status column names. It is never a weak result. #}
+                            <td>{{ "%.2f"|format(val) if val is not none else '—' }}</td>                        {% elif col == 'nes_status' %}
+                            <td title="{{ nes_status_titles.get(val, '') }}">{{ nes_status_labels.get(val, val) }}</td>
+                        {% elif col == 'ES' %}
+                            <td>{{ "%.3f"|format(val) if val is not none else '—' }}</td>
+                        {% elif col == 'null_same_signed_n' %}
+                            <td>{{ val|int if val is not none else '—' }}</td>
                         {% elif col == 'Representation' %}
                             {# Issue #70: which tail the Key Event fell on. Fixed at the
                                cutoff the analysis was run with — a shared link has no

--- a/tests/test_gsea_null_diagnostics.py
+++ b/tests/test_gsea_null_diagnostics.py
@@ -1,0 +1,545 @@
+"""Regression tests for the GSEA null-diagnostics mechanism (issue #117).
+
+The classification itself is tested in ``test_gsea_service.py``. This file
+covers the five ways the *mechanism around it* was shown to be wrong when the
+first cut of #117 was reviewed:
+
+R1  the capture patches a process-global and the app is concurrent, so two
+    overlapping runs crossed each other's diagnostics and one leaked the patch;
+R2  the batch / comparison path never learned about ``nes_status``, so the
+    recovered cells stayed invisible in the cross-condition view;
+R3  the network drew a recovered Key Event in the colour reserved for NES = 0;
+R4  the docs and the UI claimed the nominal p-value survives a short
+    same-signed tail — it does not, gseapy computes it on that same tail;
+R5  a failure to capture was labelled ``ok``, so a gseapy rename would have
+    reintroduced the whole bug under a clean bill of health.
+"""
+import importlib
+import json
+import math
+import threading
+import time
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from config import Config
+from services.comparison_service import (
+    BEYOND_RESOLUTION_DOWN,
+    BEYOND_RESOLUTION_UP,
+    build_comparison_matrix,
+    comparison_matrix_to_dataframe,
+    comparison_nes_display_dataframe,
+)
+from services.enrichment_service import format_ke_summary
+from services.gsea_service import (
+    NES_BEYOND_RESOLUTION,
+    NES_OK,
+    NES_UNDIAGNOSED,
+    NES_UNSTABLE,
+    _capture_prerank_summaries,
+    apply_null_diagnostics,
+    run_gsea_analysis,
+)
+from services.network_service import build_cytoscape_network, ke_accounting_from_network
+from services.report_service import format_nes, format_pvalue
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _one_signed_fixture(n_genes=200, set_size=100, heavy_tail=10, ke='KE:A'):
+    """A ranking whose permutation null lands entirely below zero (#117).
+
+    Same construction as ``test_gsea_service._one_signed_null_fixture``; kept
+    local so the concurrency tests can vary the KE id and the set size.
+    """
+    genes = [f"G{i:04d}" for i in range(n_genes)]
+    log2fcs = [1.0] * set_size + [-1.0] * (n_genes - set_size)
+    pvals = ([1e-4] * set_size
+             + [0.5] * (n_genes - set_size - heavy_tail)
+             + [1e-60] * heavy_tail)
+    df = pd.DataFrame({'ID': genes, 'log2FC': log2fcs, 'pval': pvals})
+    return df, {ke: set(genes[:set_size])}, {ke}, {ke: 'Maximally enriched KE'}
+
+
+def _healthy_fixture(ke='KE:A'):
+    """A ranking whose permutation null straddles zero — the ordinary case."""
+    rng = np.random.default_rng(7)
+    genes = [f"H{i:04d}" for i in range(300)]
+    df = pd.DataFrame({
+        'ID': genes,
+        'log2FC': rng.normal(0, 1.0, 300),
+        'pval': rng.uniform(1e-3, 0.9, 300),
+    })
+    return df, {ke: set(genes[:40])}, {ke}, {ke: 'Ordinary KE'}
+
+
+# ---------------------------------------------------------------------------
+# R1 — the capture must not cross runs, and must not leak the patch
+# ---------------------------------------------------------------------------
+
+class TestCaptureUnderConcurrency:
+    """R1: ``gseapy.gsea.prerank_rs`` is a process-global and this app is threaded."""
+
+    def test_overlapping_captures_keep_their_own_summaries_and_restore(self):
+        """Two overlapping captures must not see each other's summaries.
+
+        Without a lock the two patches nest, so *both* sinks receive *both*
+        runs' summaries. Since ``_null_tail_sizes`` is keyed by KE term — and
+        the KE ids are identical across conditions — the second run's tail count
+        then lands on the first run's row, where ``apply_null_diagnostics``
+        rewrites that row's NES, p and FDR on the strength of it.
+
+        The second defect is in the same block: the inner capture exits *after*
+        the outer one here (the normal case, since conditions differ in size),
+        so restoring "whatever was there on entry" leaves the global bound to a
+        dead wrapper appending to an abandoned list for the life of the process.
+        """
+        gsea_module = importlib.import_module('gseapy.gsea')
+        real = gsea_module.prerank_rs
+
+        class _Result:
+            def __init__(self, summaries):
+                self.summaries = summaries
+
+        def _fake_prerank_rs(tag, hold):
+            time.sleep(hold)
+            return _Result([tag])
+
+        results = {}
+        errors = []
+
+        def _worker(tag, start_delay, hold):
+            try:
+                time.sleep(start_delay)
+                sink = []
+                # The sink itself is stored, not a copy of it: a nested wrapper
+                # keeps appending to it long after its own block has returned,
+                # and snapshotting here would miss exactly that.
+                results[tag] = (sink, None)
+                with _capture_prerank_summaries(sink) as state:
+                    gsea_module.prerank_rs(tag, hold)
+                results[tag] = (sink, state['captured'])
+            except Exception as exc:  # pragma: no cover — surfaced by the assert
+                errors.append(exc)
+
+        gsea_module.prerank_rs = _fake_prerank_rs
+        try:
+            # 'first' finishes before 'second' — the out-of-order exit.
+            threads = [
+                threading.Thread(target=_worker, args=('first', 0.0, 0.15)),
+                threading.Thread(target=_worker, args=('second', 0.05, 0.35)),
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=30)
+            assert not errors, errors
+
+            # Read after both threads have finished, so a wrapper that outlives
+            # its block and keeps appending is visible.
+            assert results['first'] == (['first'], True), (
+                "the first capture received another run's summaries — the "
+                "process-global patch is not serialised"
+            )
+            assert results['second'] == (['second'], True), (
+                "the second capture received another run's summaries — the "
+                "process-global patch is not serialised"
+            )
+            assert gsea_module.prerank_rs is _fake_prerank_rs, (
+                "the patch leaked: the module global is still bound to a "
+                "wrapper appending to an abandoned sink"
+            )
+        finally:
+            gsea_module.prerank_rs = real
+
+    def test_two_gsea_runs_in_threads_get_their_own_tail_counts(self):
+        """End to end: a degenerate and a healthy condition, run concurrently.
+
+        Both use the same KE id, which is what makes the crossing invisible in
+        production: every condition in a batch analyses the same Key Events.
+        """
+        degenerate = _one_signed_fixture()
+        healthy = _healthy_fixture()
+
+        serial = {
+            'degenerate': run_gsea_analysis(*degenerate, permutation_num=100),
+            'healthy': run_gsea_analysis(*healthy, permutation_num=100),
+        }
+
+        concurrent = {}
+        errors = []
+
+        def _worker(name, fixture):
+            try:
+                concurrent[name] = run_gsea_analysis(*fixture, permutation_num=100)
+            except Exception as exc:  # pragma: no cover
+                errors.append((name, exc))
+
+        threads = [
+            threading.Thread(target=_worker, args=('degenerate', degenerate)),
+            threading.Thread(target=_worker, args=('healthy', healthy)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=120)
+        assert not errors, errors
+
+        for name in ('degenerate', 'healthy'):
+            got = concurrent[name].iloc[0]
+            want = serial[name].iloc[0]
+            assert got['null_same_signed_n'] == want['null_same_signed_n'], (
+                f"{name}: the same-signed tail count differs between a serial "
+                "and a concurrent run — one condition's null was attributed to "
+                "the other"
+            )
+            assert got['nes_status'] == want['nes_status']
+            assert got['p_value'] == pytest.approx(want['p_value'])
+
+        # And the two conditions really are in different regimes, so the test
+        # would have caught a swap rather than comparing two identical rows.
+        assert serial['degenerate'].iloc[0]['nes_status'] == NES_BEYOND_RESOLUTION
+        assert serial['healthy'].iloc[0]['null_same_signed_n'] > 0
+
+    def test_capture_is_reentrant_safe_against_a_foreign_patch(self):
+        """A stranger rebinding the global mid-block still ends with the real one."""
+        gsea_module = importlib.import_module('gseapy.gsea')
+        real = gsea_module.prerank_rs
+
+        with _capture_prerank_summaries([]):
+            gsea_module.prerank_rs = lambda *a, **k: None
+        assert gsea_module.prerank_rs is real
+
+
+# ---------------------------------------------------------------------------
+# R5 — a failed capture is not a clean result
+# ---------------------------------------------------------------------------
+
+class TestUndiagnosedIsNotOk:
+    """R5: failure to capture must be distinguishable from a healthy null."""
+
+    def test_a_renamed_entry_point_is_reported_loudly_not_silently(self, monkeypatch, caplog):
+        """The capture itself, when the name it wraps is gone.
+
+        Exercised on the context manager rather than through ``run_gsea_analysis``
+        because gseapy's own ``Prerank.run`` resolves the same name: deleting it
+        makes gseapy raise before the diagnostics matter. What this asserts is
+        the contract the run depends on — no capture, ``captured`` False, and an
+        error in the log naming the symbol.
+        """
+        gsea_module = importlib.import_module('gseapy.gsea')
+        monkeypatch.delattr(gsea_module, 'prerank_rs', raising=True)
+
+        sink = []
+        with caplog.at_level('ERROR', logger='services.gsea_service'):
+            with _capture_prerank_summaries(sink) as state:
+                pass
+
+        assert state['captured'] is False
+        assert sink == []
+        messages = ' '.join(r.getMessage() for r in caplog.records)
+        assert 'prerank_rs' in messages
+        assert NES_UNDIAGNOSED in messages
+
+    def test_unreadable_summaries_label_every_row_undiagnosed(self, monkeypatch, caplog):
+        """A capture that succeeds but yields nothing must not read as 'ok'.
+
+        This is the shape a gseapy upgrade takes in practice: the wrapper still
+        fires, but the summary objects no longer expose ``esnull``, so no tail
+        count can be derived. Every row is then unchecked — and labelling those
+        rows ``ok`` is exactly how #117 would come back under a clean bill of
+        health.
+        """
+        import services.gsea_service as gsea_service
+        monkeypatch.setattr(gsea_service, '_null_tail_sizes', lambda summaries: {})
+
+        df, reference_sets, ke_list, ke_title_map = _healthy_fixture()
+        with caplog.at_level('ERROR', logger='services.gsea_service'):
+            result = run_gsea_analysis(
+                df, reference_sets, ke_list, ke_title_map, permutation_num=50
+            )
+
+        assert set(result['nes_status']) == {NES_UNDIAGNOSED}
+        assert NES_OK not in set(result['nes_status'])
+        assert result['null_same_signed_n'].isna().all()
+        assert result.attrs['ke_summary']['nes_undiagnosed_kes'] == len(result)
+        messages = ' '.join(r.getMessage() for r in caplog.records)
+        assert NES_UNDIAGNOSED in messages
+
+    def test_undiagnosed_rows_are_surfaced_in_the_run_accounting(self):
+        """The admission has to reach the reader, not only the server log."""
+        res = pd.DataFrame({
+            'KE': ['KE:1'], 'NES': [1.0], 'p_value': [1.0], 'FDR': [0.44],
+        })
+        apply_null_diagnostics(res, {}, 1000, diagnostics_captured=False)
+
+        sentence = format_ke_summary({
+            'tested': 1, 'total_kes': 1, 'nes_undiagnosed_kes': 1,
+        })
+        assert 'permutation null could not be inspected' in sentence
+        assert 'unchecked' in sentence
+
+    def test_accounting_sentence_is_silent_when_everything_was_diagnosed(self):
+        """An ORA run must not grow a GSEA clause."""
+        sentence = format_ke_summary({'tested': 5, 'total_kes': 5})
+        assert 'permutation null' not in sentence
+
+
+# ---------------------------------------------------------------------------
+# R4 — the nominal p-value does NOT survive a short tail
+# ---------------------------------------------------------------------------
+
+class TestPValueIsCoarseOnAShortTail:
+    """R4: the retracted claim, and the replacement for it."""
+
+    def test_gseapy_computes_the_nominal_p_on_the_same_signed_tail(self):
+        """The measurement the retraction rests on.
+
+        If this ever fails, gseapy has changed its p-value denominator and the
+        whole ``p_value_resolution`` column should be revisited — so it is
+        asserted rather than left as a claim in a comment.
+        """
+        import gseapy as gp
+        gsea_module = importlib.import_module('gseapy.gsea')
+
+        genes = [f"G{i:04d}" for i in range(200)]
+        df = pd.DataFrame({
+            'ID': genes,
+            'log2FC': [1.0] * 100 + [-1.0] * 100,
+            'pval': [1e-4] * 100 + [0.5] * 90 + [1e-60] * 10,
+        })
+        metric = np.sign(df['log2FC']) * -np.log10(df['pval'].astype(float))
+        rnk = pd.Series(metric.values, index=df['ID']).sort_values(ascending=False)
+
+        sink = []
+        with _capture_prerank_summaries(sink):
+            res = gp.prerank(
+                rnk=rnk, gene_sets={'K': list(genes[:10])}, outdir=None,
+                min_size=5, max_size=1000, permutation_num=100, seed=1,
+                threads=1, no_plot=True, verbose=False,
+            )
+        assert sink, "the null was not captured; the measurement cannot be made"
+
+        summary = sink[0]
+        es = float(summary.es)
+        null = np.asarray(summary.esnull, dtype=float)
+        same_signed = int((null >= 0).sum() if es >= 0 else (null < 0).sum())
+        exceed = int((null >= es).sum() if es >= 0 else (null <= es).sum())
+        reported = float(res.res2d.iloc[0]['NOM p-val'])
+
+        assert same_signed > 0
+        assert reported == pytest.approx(exceed / same_signed), (
+            "gseapy's nominal p is no longer exceedances over the same-signed "
+            "tail — p_value_resolution is computed on that assumption"
+        )
+        # The point of the retraction: the same-signed denominator is not the
+        # permutation count, so the p-value is coarser than 1/permutation_num.
+        assert same_signed < 100
+
+    def test_unstable_rows_report_the_resolution_they_could_achieve(self):
+        """A p of 0.6 on a tail of five is 3/5, and must say so."""
+        res = pd.DataFrame({
+            'KE': ['KE:TINY', 'KE:ONE', 'KE:FINE'],
+            'NES': [1.1, 2.0, 1.5],
+            'p_value': [0.6, 0.0, 0.012],
+            'FDR': [0.6, 0.0, 0.02],
+        })
+
+        out = apply_null_diagnostics(res, {'KE:TINY': 5, 'KE:ONE': 1, 'KE:FINE': 500}, 1000)
+
+        tiny = out[out['KE'] == 'KE:TINY'].iloc[0]
+        assert tiny['nes_status'] == NES_UNSTABLE
+        assert tiny['p_value_resolution'] == pytest.approx(0.2)
+        one = out[out['KE'] == 'KE:ONE'].iloc[0]
+        assert one['p_value_resolution'] == pytest.approx(1.0)
+        fine = out[out['KE'] == 'KE:FINE'].iloc[0]
+        assert fine['nes_status'] == NES_OK
+        assert fine['p_value_resolution'] == pytest.approx(1 / 500)
+
+    def test_beyond_resolution_reports_the_permutation_bound(self):
+        res = pd.DataFrame({
+            'KE': ['KE:MAX'], 'NES': [1.0], 'p_value': [1.0], 'FDR': [0.44],
+        })
+
+        out = apply_null_diagnostics(res, {'KE:MAX': 0}, 200)
+
+        assert out.iloc[0]['p_value_resolution'] == pytest.approx(1 / 200)
+
+    def test_report_qualifies_the_pvalue_not_only_the_nes(self):
+        """The reports are what leaves the tool; the qualifier travels with it."""
+        assert 'do not threshold' in format_pvalue(0.6, NES_UNSTABLE, 0.2)
+        assert '0.2' in format_pvalue(0.6, NES_UNSTABLE, 0.2)
+        assert format_pvalue(0.6, NES_OK) == '0.6000'
+        assert 'bound' in format_pvalue(0.001, NES_BEYOND_RESOLUTION)
+        assert 'not inspected' in format_pvalue(0.4, NES_UNDIAGNOSED)
+        assert 'not inspected' in format_nes(1.2, NES_UNDIAGNOSED)
+
+    def test_no_source_still_claims_the_pvalue_stands(self):
+        """The retracted sentence must not survive anywhere it was written."""
+        import pathlib
+        root = pathlib.Path(__file__).resolve().parent.parent
+        offenders = []
+        for path in list(root.glob('services/*.py')) + list(root.glob('templates/*.html')) \
+                + [root / 'CHANGELOG.md']:
+            text = path.read_text(encoding='utf-8')
+            for phrase in ('The p-value stands', 'the p-value stands',
+                           'a sound p-value', 'the nominal p-value is\n    sound'):
+                if phrase in text:
+                    offenders.append((path.name, phrase))
+        assert not offenders, offenders
+
+
+# ---------------------------------------------------------------------------
+# R2 — the cross-condition view
+# ---------------------------------------------------------------------------
+
+def _condition(label, enrichment, position=0):
+    return SimpleNamespace(
+        condition_label=label,
+        enrichment_json=json.dumps(enrichment),
+        ke_gene_json=None,
+        position=position,
+        gene_count=None,
+        significant_genes=None,
+        dose='',
+        timepoint='',
+    )
+
+
+class TestComparisonCarriesTheStatus:
+    """R2: the 5x9 grid in the manuscript is built from this path."""
+
+    def _batch(self):
+        beyond = {
+            'KE': 'KE:1194', 'Title': 'Increase, DNA damage', 'FDR': 0.0,
+            'NES': None, 'ES': 0.95, 'nes_status': NES_BEYOND_RESOLUTION,
+        }
+        ordinary = {
+            'KE': 'KE:177', 'Title': 'Mitochondrial dysfunction', 'FDR': 0.01,
+            'NES': -1.8, 'ES': -0.5, 'nes_status': NES_OK,
+        }
+        return [_condition('Carboplatin 48h', [beyond, ordinary])]
+
+    def test_status_and_es_reach_the_matrix(self):
+        m = build_comparison_matrix(self._batch(), method='gsea')
+
+        row = m['ke_labels'].index('KE:1194')
+        assert m['nes_matrix'][row][0] is None
+        # Before this, a None NES here was indistinguishable from an untested KE.
+        assert m['nes_status_matrix'][row][0] == NES_BEYOND_RESOLUTION
+        assert m['es_matrix'][row][0] == pytest.approx(0.95)
+
+        other = m['ke_labels'].index('KE:177')
+        assert m['nes_status_matrix'][other][0] == NES_OK
+
+    def test_ora_batches_carry_no_status(self):
+        """An ORA batch has no NES and must not grow a phantom status."""
+        conds = [_condition('C1', [{'KE': 'KE:1', 'Title': 'E', 'FDR': 0.01}])]
+        m = build_comparison_matrix(conds, method='ora')
+        assert m['nes_status_matrix'] == [[None]]
+        assert m['es_matrix'] == [[None]]
+
+    def test_report_table_marks_the_cell_instead_of_leaving_it_blank(self):
+        """The captions claimed "every NES value" — this is what makes that true."""
+        m = build_comparison_matrix(self._batch(), method='gsea')
+
+        numeric = comparison_matrix_to_dataframe(m, which='nes')
+        display = comparison_nes_display_dataframe(m)
+
+        row = list(display['Key Event ID']).index('KE:1194')
+        # The numeric export is still blank there — it is a numeric record.
+        assert pd.isna(numeric['Carboplatin 48h'].iloc[row])
+        # The report cell is not.
+        assert display['Carboplatin 48h'].iloc[row] == BEYOND_RESOLUTION_UP
+        other = list(display['Key Event ID']).index('KE:177')
+        assert display['Carboplatin 48h'].iloc[other] == '-1.80'
+
+    def test_display_marks_direction_from_the_es(self):
+        cond = _condition('C1', [{
+            'KE': 'KE:1', 'Title': 'Down', 'FDR': 0.0, 'NES': None,
+            'ES': -0.9, 'nes_status': NES_BEYOND_RESOLUTION,
+        }])
+        m = build_comparison_matrix([cond], method='gsea')
+        display = comparison_nes_display_dataframe(m)
+        assert display['C1'].iloc[0] == BEYOND_RESOLUTION_DOWN
+        ascii_display = comparison_nes_display_dataframe(m, ascii_only=True)
+        assert ascii_display['C1'].iloc[0] == '- beyond res.'
+
+    def test_unstable_and_undiagnosed_cells_are_flagged_in_the_report(self):
+        cond = _condition('C1', [
+            {'KE': 'KE:1', 'Title': 'A', 'FDR': 0.01, 'NES': 1.9, 'ES': 0.8,
+             'nes_status': NES_UNSTABLE},
+            {'KE': 'KE:2', 'Title': 'B', 'FDR': 0.02, 'NES': -1.2, 'ES': -0.4,
+             'nes_status': NES_UNDIAGNOSED},
+        ])
+        m = build_comparison_matrix([cond], method='gsea')
+        display = comparison_nes_display_dataframe(m)
+        cells = dict(zip(display['Key Event ID'], display['C1']))
+        assert cells['KE:1'] == '+1.90 !'
+        assert cells['KE:2'] == '-1.20 ?'
+
+
+# ---------------------------------------------------------------------------
+# R3 — the network figure
+# ---------------------------------------------------------------------------
+
+class TestNetworkCarriesTheStatus:
+    """R3: ``nesColor(null)`` renders white, the colour reserved for NES = 0."""
+
+    def _network(self, nes_status=NES_BEYOND_RESOLUTION, nes=None, es=0.95):
+        enrichment = pd.DataFrame([{
+            'KE': 'KE:1194', 'Title': 'Increase, DNA damage', 'NES': nes,
+            'ES': es, 'p_value': 0.001, 'FDR': 0.0, 'nes_status': nes_status,
+        }])
+        return build_cytoscape_network(
+            ke_list={'KE:1194'},
+            edges=pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID']),
+            enrichment_results=enrichment,
+            ke_title_map={'KE:1194': 'Increase, DNA damage'},
+            ke_type_map={'KE:1194': 'intermediate'},
+            reference_sets={'KE:1194': {'A', 'B'}},
+            method='gsea',
+        )
+
+    def test_node_carries_status_and_direction(self):
+        node = self._network()['nodes'][0]
+
+        assert node['data']['nes'] is None
+        # Without these two the frontend cannot tell a recovered Key Event from
+        # a NES of exactly zero, and neither can the .cyjs export or the PNG.
+        assert node['data']['nes_status'] == NES_BEYOND_RESOLUTION
+        assert node['data']['es'] == pytest.approx(0.95)
+        assert 'significant' in node['classes']
+
+    def test_ordinary_gsea_node_is_unchanged_in_meaning(self):
+        node = self._network(nes_status=NES_OK, nes=-1.8, es=-0.5)['nodes'][0]
+        assert node['data']['nes'] == pytest.approx(-1.8)
+        assert node['data']['nes_status'] == NES_OK
+
+    def test_ora_nodes_carry_no_gsea_fields(self):
+        enrichment = pd.DataFrame([{
+            'KE': 'KE:1', 'Title': 'T', 'odds_ratio': 2.0,
+            'p_value': 0.01, 'FDR': 0.02,
+        }])
+        network = build_cytoscape_network(
+            ke_list={'KE:1'},
+            edges=pd.DataFrame(columns=['Source_KE', 'Target_KE', 'KER_ID']),
+            enrichment_results=enrichment,
+            ke_title_map={'KE:1': 'T'},
+            ke_type_map={'KE:1': 'intermediate'},
+            reference_sets={'KE:1': {'A'}},
+            method='ora',
+        )
+        assert 'nes_status' not in network['nodes'][0]['data']
+        assert 'es' not in network['nodes'][0]['data']
+
+    def test_undiagnosed_count_survives_into_a_stored_network(self):
+        network = self._network(nes_status=NES_UNDIAGNOSED, nes=1.2, es=0.4)
+        summary = ke_accounting_from_network(json.dumps(network))
+        assert summary['nes_undiagnosed_kes'] == 1
+        assert 'permutation null could not be inspected' in format_ke_summary(summary)

--- a/tests/test_gsea_service.py
+++ b/tests/test_gsea_service.py
@@ -17,8 +17,10 @@ from services.enrichment_service import (
     format_ke_summary,
 )
 from services.gsea_service import (
+    MIN_SAME_SIGNED_NULL,
     NES_BEYOND_RESOLUTION,
     NES_OK,
+    NES_UNDIAGNOSED,
     NES_UNSTABLE,
     _build_ranking,
     _capture_prerank_summaries,
@@ -149,8 +151,8 @@ class TestRunGseaAnalysis:
         result = run_gsea_analysis(df, reference_sets, ke_list, ke_title_map)
 
         expected_cols = ['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value',
-                         'FDR', 'null_same_signed_n', 'lead_genes',
-                         'total_KE_genes_in_dataset']
+                         'p_value_resolution', 'FDR', 'null_same_signed_n',
+                         'lead_genes', 'total_KE_genes_in_dataset']
         assert list(result.columns) == expected_cols
 
     def test_min_size_filter(self, caplog):
@@ -289,9 +291,15 @@ class TestOneSignedNull:
 
         out = apply_null_diagnostics(res, {}, 1000)
 
-        assert out.iloc[0]['nes_status'] == NES_OK
+        # gseapy's numbers are untouched...
         assert out.iloc[0]['NES'] == 1.0
+        assert out.iloc[0]['p_value'] == 1.0
         assert math.isnan(out.iloc[0]['null_same_signed_n'])
+        # ...but the row does NOT claim to have been checked. Labelling this
+        # 'ok' is how a gseapy rename would reintroduce the whole of #117 under
+        # a clean bill of health.
+        assert out.iloc[0]['nes_status'] == NES_UNDIAGNOSED
+        assert out.iloc[0]['nes_status'] != NES_OK
 
     def test_null_tail_sizes_counts_the_observed_side(self):
         """Same-signed means the side the observed ES fell on, not the majority."""

--- a/tests/test_gsea_service.py
+++ b/tests/test_gsea_service.py
@@ -4,12 +4,28 @@ Covers D-15 determinism (D-15.1), ranking metric (D-15.2), and
 zero-p clamp (D-15.3) as well as column shape, min_size filter, and
 NES clamping.
 """
+import importlib
 import math
 import logging
 import pytest
 import pandas as pd
 import numpy as np
-from services.gsea_service import run_gsea_analysis, _build_ranking
+from services.enrichment_service import (
+    EXCLUDED_TOO_FEW_GENES,
+    EXCLUDED_TOO_MANY_GENES,
+    KE_SUMMARY_ATTR,
+    format_ke_summary,
+)
+from services.gsea_service import (
+    NES_BEYOND_RESOLUTION,
+    NES_OK,
+    NES_UNSTABLE,
+    _build_ranking,
+    _capture_prerank_summaries,
+    _null_tail_sizes,
+    apply_null_diagnostics,
+    run_gsea_analysis,
+)
 
 
 def _make_ranked_df(genes, log2fcs, pvals):
@@ -132,7 +148,8 @@ class TestRunGseaAnalysis:
 
         result = run_gsea_analysis(df, reference_sets, ke_list, ke_title_map)
 
-        expected_cols = ['KE', 'Title', 'NES', 'p_value', 'FDR', 'lead_genes',
+        expected_cols = ['KE', 'Title', 'NES', 'nes_status', 'ES', 'p_value',
+                         'FDR', 'null_same_signed_n', 'lead_genes',
                          'total_KE_genes_in_dataset']
         assert list(result.columns) == expected_cols
 
@@ -170,3 +187,215 @@ class TestRunGseaAnalysis:
 
         for nes in result["NES"]:
             assert -3.0 <= nes <= 3.0, f"NES value {nes} is outside ±3 clamp range"
+
+
+def _one_signed_null_fixture(n_genes=200, set_size=100, heavy_tail=10):
+    """A ranking whose permutation null lands entirely below zero (issue #117).
+
+    The condition needs two things together: a gene set large relative to the
+    ranking (half of it here), and a handful of genes carrying most of the
+    ranking weight at the bottom. Any random set of that size then walks
+    steeply down before it can recover, so every permuted enrichment score is
+    negative — while the real set, sitting entirely at the top, scores +1.0.
+    That is the maximally enriched case, and it is the one gseapy reports as
+    NES = 1.0 with p = 1.0.
+
+    Verified against origin/main (db31a90), which returns exactly
+    ``NES 1.0, p_value 1.0`` for KE:A on this fixture.
+
+    Returns:
+        tuple: (df, reference_sets, ke_list, ke_title_map)
+    """
+    genes = [f"G{i:04d}" for i in range(n_genes)]
+    log2fcs = [1.0] * set_size + [-1.0] * (n_genes - set_size)
+    # The heavy tail is what tightens the null onto one side of zero.
+    pvals = ([1e-4] * set_size
+             + [0.5] * (n_genes - set_size - heavy_tail)
+             + [1e-60] * heavy_tail)
+    df = pd.DataFrame({'ID': genes, 'log2FC': log2fcs, 'pval': pvals})
+    reference_sets = {'KE:A': set(genes[:set_size])}
+    return df, reference_sets, {'KE:A'}, {'KE:A': 'Maximally enriched KE'}
+
+
+class TestOneSignedNull:
+    """Issue #117 — the degenerate and near-degenerate NES regimes."""
+
+    def test_empty_same_signed_tail_is_not_reported_as_null(self, caplog):
+        """The maximally enriched KE must not come back as NES 1.0 / p 1.0."""
+        df, reference_sets, ke_list, ke_title_map = _one_signed_null_fixture()
+
+        with caplog.at_level(logging.WARNING, logger="services.gsea_service"):
+            result = run_gsea_analysis(
+                df, reference_sets, ke_list, ke_title_map, permutation_num=100
+            )
+
+        row = result[result['KE'] == 'KE:A'].iloc[0]
+        assert row['null_same_signed_n'] == 0, (
+            "fixture no longer produces a one-signed null; the test is not "
+            "exercising issue #117 any more"
+        )
+        assert row['nes_status'] == NES_BEYOND_RESOLUTION
+        # The pair that reads as "tested, not enriched" must be gone.
+        assert not (row['NES'] == 1.0 and row['p_value'] == 1.0)
+        # NES is not normalisable and must not be a number that can be ranked.
+        assert math.isnan(row['NES'])
+        # p is the resolution bound, not 1.0; FDR is the limit, not mid-range.
+        assert row['p_value'] == pytest.approx(1.0 / 100)
+        assert row['FDR'] == 0.0
+        # Direction survives, so the reader still knows which way it went.
+        assert row['ES'] > 0
+        assert any('issue #117' in r.getMessage() for r in caplog.records)
+
+    def test_unstable_tail_keeps_the_pvalue_but_flags_the_magnitude(self):
+        """A tail of 1-9 permutations is a real call with an unusable NES."""
+        res = pd.DataFrame({
+            'KE': ['KE:1', 'KE:2', 'KE:3'],
+            'NES': [1.12, 2.4, 1.0],
+            'p_value': [0.0, 0.001, 1.0],
+            'FDR': [0.23, 0.001, 0.44],
+        })
+
+        out = apply_null_diagnostics(res, {'KE:1': 3, 'KE:2': 400, 'KE:3': 0}, 1000)
+
+        unstable = out[out['KE'] == 'KE:1'].iloc[0]
+        assert unstable['nes_status'] == NES_UNSTABLE
+        # Nothing is rewritten: gseapy's p-value is sound in this regime.
+        assert unstable['NES'] == 1.12
+        assert unstable['p_value'] == 0.0
+        assert unstable['FDR'] == 0.23
+        assert out[out['KE'] == 'KE:2'].iloc[0]['nes_status'] == NES_OK
+        assert out[out['KE'] == 'KE:3'].iloc[0]['nes_status'] == NES_BEYOND_RESOLUTION
+
+    def test_value_based_detection_would_miss_the_unstable_regime(self):
+        """A NES of exactly 1.0 is not the condition — the tail size is.
+
+        Guards the choice of test: KE:1 carries a plausible NES of 1.12 and a
+        p-value of 0.0, so no check on the reported values can find it, yet its
+        magnitude rests on three permutations.
+        """
+        res = pd.DataFrame({
+            'KE': ['KE:1'], 'NES': [1.12], 'p_value': [0.0], 'FDR': [0.23],
+        })
+
+        out = apply_null_diagnostics(res, {'KE:1': 3}, 1000)
+
+        assert out.iloc[0]['nes_status'] == NES_UNSTABLE
+
+    def test_missing_diagnostics_leave_the_numbers_alone(self):
+        """No captured null means "not assessed", never "tail of zero"."""
+        res = pd.DataFrame({
+            'KE': ['KE:1'], 'NES': [1.0], 'p_value': [1.0], 'FDR': [0.44],
+        })
+
+        out = apply_null_diagnostics(res, {}, 1000)
+
+        assert out.iloc[0]['nes_status'] == NES_OK
+        assert out.iloc[0]['NES'] == 1.0
+        assert math.isnan(out.iloc[0]['null_same_signed_n'])
+
+    def test_null_tail_sizes_counts_the_observed_side(self):
+        """Same-signed means the side the observed ES fell on, not the majority."""
+        class _Summary:
+            def __init__(self, term, es, esnull):
+                self.term, self.es, self.esnull = term, es, esnull
+
+        sizes = _null_tail_sizes([
+            _Summary('KE:POS', 0.33, [-0.5, -0.4, -0.3]),
+            _Summary('KE:NEG', -0.33, [-0.5, 0.4, 0.3]),
+            _Summary('KE:BROKEN', 'x', [0.1]),
+        ])
+
+        assert sizes['KE:POS'] == 0
+        assert sizes['KE:NEG'] == 1
+        assert 'KE:BROKEN' not in sizes
+
+    def test_prerank_summaries_are_captured_and_the_patch_reverted(self):
+        """The capture must not leave gseapy patched, whatever happens."""
+        gsea_module = importlib.import_module('gseapy.gsea')
+        original = gsea_module.prerank_rs
+
+        sink = []
+        with _capture_prerank_summaries(sink):
+            assert gsea_module.prerank_rs is not original
+        assert gsea_module.prerank_rs is original
+
+        with pytest.raises(RuntimeError):
+            with _capture_prerank_summaries(sink):
+                raise RuntimeError('boom')
+        assert gsea_module.prerank_rs is original
+
+    def test_capture_populates_the_sink_on_a_real_run(self):
+        """The wrapper actually sees the summaries gseapy discards."""
+        df, reference_sets, ke_list, ke_title_map = _one_signed_null_fixture()
+
+        result = run_gsea_analysis(
+            df, reference_sets, ke_list, ke_title_map, permutation_num=100
+        )
+
+        assert result['null_same_signed_n'].notna().all(), (
+            "null diagnostics were not captured — the gseapy entry point this "
+            "wraps has probably been renamed"
+        )
+
+
+class TestMaxSizeExclusion:
+    """Issue #120 — a KE above the GSEA ceiling is dropped, and must say so."""
+
+    def _fixture(self):
+        genes = [f"G{i:04d}" for i in range(200)]
+        df = pd.DataFrame({
+            'ID': genes,
+            'log2FC': [1.0] * 100 + [-1.0] * 100,
+            'pval': [1e-4] * 100 + [0.5] * 100,
+        })
+        reference_sets = {'KE:BIG': set(genes[:60]), 'KE:OK': set(genes[:20])}
+        return df, reference_sets, {'KE:BIG', 'KE:OK'}, {}
+
+    def test_over_ceiling_ke_is_not_reported_as_under_measured(self, caplog):
+        """60 measured genes must not be reported as "fewer than 5"."""
+        df, reference_sets, ke_list, ke_title_map = self._fixture()
+
+        with caplog.at_level(logging.INFO, logger="services.gsea_service"):
+            result = run_gsea_analysis(
+                df, reference_sets, ke_list, ke_title_map,
+                permutation_num=50, max_size=30,
+            )
+
+        summary = result.attrs[KE_SUMMARY_ATTR]
+        assert summary['excluded_reasons']['KE:BIG'] == EXCLUDED_TOO_MANY_GENES
+        assert summary['excluded_too_many_genes'] == 1
+        assert summary['excluded_too_few_genes'] == 0
+        assert summary['max_ke_genes'] == 30
+        # The log must name the real cause and the real count.
+        messages = [r.getMessage() for r in caplog.records]
+        assert any('max_size=30' in m and '60 measured genes' in m
+                   for m in messages), messages
+        assert not any('min_size' in m and 'KE:BIG' in m for m in messages)
+
+    def test_accounting_sentence_names_the_ceiling(self):
+        """The user-facing sentence must not say the KE was under-measured."""
+        df, reference_sets, ke_list, ke_title_map = self._fixture()
+
+        result = run_gsea_analysis(
+            df, reference_sets, ke_list, ke_title_map,
+            permutation_num=50, max_size=30,
+        )
+
+        sentence = format_ke_summary(result.attrs[KE_SUMMARY_ATTR])
+        assert 'more than 30 measured genes' in sentence
+        assert 'fewer than' not in sentence
+
+    def test_min_size_drop_still_reads_as_too_few(self):
+        """The existing min_size accounting is unchanged."""
+        df, reference_sets, ke_list, ke_title_map = self._fixture()
+        reference_sets = dict(reference_sets)
+        reference_sets['KE:TINY'] = set(df['ID'][:3])
+        ke_list = set(ke_list) | {'KE:TINY'}
+
+        result = run_gsea_analysis(
+            df, reference_sets, ke_list, ke_title_map, permutation_num=50,
+        )
+
+        summary = result.attrs[KE_SUMMARY_ATTR]
+        assert summary['excluded_reasons']['KE:TINY'] == EXCLUDED_TOO_FEW_GENES
+        assert summary['excluded_too_many_genes'] == 0

--- a/tests/test_gsea_untested_node_colour.py
+++ b/tests/test_gsea_untested_node_colour.py
@@ -1,0 +1,70 @@
+"""Issue #117 follow-up — an untested Key Event must not be painted in the
+GSEA gradient's off-gradient plum.
+
+The GSEA colour rule `selector: 'node[method = "gsea"]'` calls
+`nesColor(ele.data('nes'))` on every node carrying `method = "gsea"`. An
+untested Key Event still carries that attribute (with `nes = null`), and
+`nesColor(null)` returns `NES_UNDEFINED_COLOR` — the plum reserved for a Key
+Event that beat every permutation. Because the gradient rule is ordered after
+the `.no-genes` / `.too-few-genes` / `.unresolved-mapping` rules, it overrides
+their muted fills, so an uncurated or untestable KE (including the MIE and AO,
+unmapped by design) would render as the single most salient node in every GSEA
+network figure and .cyjs export.
+
+These tests pin the fix: a per-exclusion override scoped to `[method="gsea"]`,
+ordered *after* the gradient rule, that restores the muted fill. They are
+static assertions over the template's Cytoscape stylesheet because the defect
+is one of rule ordering in the cascade, which no Python-level render exercises.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATES = Path(__file__).resolve().parent.parent / "templates"
+
+
+def _stylesheet_selectors(html: str):
+    """Ordered list of every `selector: '...'` string in the file."""
+    return re.findall(r"selector:\s*'([^']+)'", html)
+
+
+@pytest.mark.parametrize("template", ["results.html", "shared_results.html"])
+class TestUntestedGseaNodeKeepsItsMutedFill:
+    def _selectors(self, template):
+        html = (TEMPLATES / template).read_text()
+        return html, _stylesheet_selectors(html)
+
+    @pytest.mark.parametrize(
+        "cls,fill",
+        [("no-genes", "#cccccc"), ("unresolved-mapping", "#f7e6d5"),
+         ("too-few-genes", "#e8e8e8")],
+    )
+    def test_each_exclusion_has_a_gsea_scoped_background_override(
+        self, template, cls, fill
+    ):
+        html, _ = self._selectors(template)
+        # The override rule exists, is scoped to GSEA, and re-asserts the fill.
+        block = re.search(
+            r"selector:\s*'node\." + re.escape(cls)
+            + r"\[method = \"gsea\"\]'\s*,\s*style:\s*\{([^}]*)\}",
+            html,
+        )
+        assert block, f"{template}: no [method=gsea] override for .{cls}"
+        assert fill in block.group(1), (
+            f"{template}: .{cls} GSEA override does not restore {fill}"
+        )
+
+    @pytest.mark.parametrize(
+        "cls", ["no-genes", "unresolved-mapping", "too-few-genes"]
+    )
+    def test_the_override_is_ordered_after_the_gradient_rule(self, template, cls):
+        _, selectors = self._selectors(template)
+        gradient = selectors.index('node[method = "gsea"]')
+        override = selectors.index(f'node.{cls}[method = "gsea"]')
+        # Cytoscape resolves equal-specificity conflicts by document order, so
+        # the muted fill only wins if it comes after the gradient rule.
+        assert override > gradient, (
+            f"{template}: .{cls} GSEA override at {override} must follow the "
+            f"gradient rule at {gradient}, or the plum fill wins"
+        )


### PR DESCRIPTION
Closes #117. Closes #120.

## Root cause, sharpened

The issue's diagnosis is right about the mechanism and slightly wrong about where the boundary is.

Right: gseapy normalises an observed ES by the mean of the **same-signed** tail of that gene set's permutation null, and when the null lands entirely on the other side of zero that tail is empty. The arithmetic is undefined and gseapy substitutes `NES = 1.0`, `p = 1.0` — which are the values a thoroughly unenriched set produces.

The correction is that **there is no fully degenerate case to detect as a value**. The regime is continuous in the size of that tail, and the reported numbers stop being trustworthy well before the tail reaches zero:

| same-signed tail | gseapy output | what it means |
|---|---|---|
| 0 | `NES 1.0`, `p 1.0` | maximally significant, printed as null |
| 1–9 | finite NES, `p ~ 0` | **both** the magnitude and the nominal p are computed against a handful of values |
| ≥10 | finite NES | trustworthy |

The middle row is invisible to *any* check on the output: on the real data it produces NES values of 1.02, 1.12, 1.21, 1.76, 1.93, 2.04 — all of them ordinary-looking, several of them at the top of their condition's ranking, every one normalised against 1–9 permutations. Detection therefore has to come from the null distribution, exactly as the second comment in #117 argued.

The practical obstacle is that gseapy throws the null away. `Prerank.run()` binds the extension's result to a local, hands the summaries to `to_df`, and returns `None`; `res2d` carries ES/NES/p/FDR but not `esnull`. Rather than reimplement prerank, the extension entry point `gseapy.gsea.prerank_rs` is wrapped for the duration of one call and the summaries kept. Verified against gseapy 1.1.4 and the pinned 1.3.0 — both resolve that name as a module global at call time. If it is ever renamed, or `method='multilevel'` routes through `fgsea_rs` instead, the diagnostics go missing and the analysis proceeds on gseapy's own numbers rather than failing.

## What changed

`services/gsea_service.py`

- Captures the per-term permutation null and counts the same-signed tail.
- New `nes_status` column: `ok`, `unstable_normalisation` (tail 1–9), `beyond_permutation_resolution` (tail 0), `undiagnosed` (null not readable). New `null_same_signed_n` and `p_value_resolution` columns carrying the evidence, and the raw `ES` so direction survives where the NES does not.
- **Empty tail:** NES is reported as undefined (NaN → `null` on the wire), because it is genuinely not normalisable and any number there would be indistinguishable from a real result. `p_value` becomes the resolution bound `1/permutation_num` and `FDR` its limit of 0 — no permutation was as extreme as the observation, so the cell reads as maximally significant, which is what it is.
- **Tiny tail:** nothing is rewritten — the numbers stay gseapy's own — but *both* are flagged. See the correction below: the nominal p-value does not survive a short tail either.
- **Missing diagnostics:** status is `undiagnosed` and the count is NaN. "Not assessed", "tail of zero" and "healthy tail" are three different statements and must not be conflated.
- The classification is a separate function, `apply_null_diagnostics`, so both regimes are testable without paying for a thousand permutations.

`services/enrichment_service.py`, `services/network_service.py`, `config.py` — #120. `gseapy.prerank` discards a gene set larger than `max_size` before computing anything, and the exclusion accounting attributed *every* size-based drop to `min_size`. Confirmed on `origin/main`: a KE with 60 measured genes under `max_size=30` is reported as `1 excluded (fewer than 5 measured genes)`. New `EXCLUDED_TOO_MANY_GENES` reason with its own counter and accounting clause, a log line naming the real bound and gene count, and the ceiling promoted to `Config.GSEA_MAX_KE_GENES` so a run can report it. The value stays at 1000 rather than the Broad convention of 500 — three of the seven testable AOP 472 Key Events already exceed 500 measured genes, and dropping them costs more than dilution does.

Templates and reports render the new columns, and a NES that is not a number renders as "—" with the status beside it, never as a blank that could be read as a weak result. The PDF/HTML reports carry the qualifier inline, since a reader with only the report has no status column to consult.

## Verification

Reference implementation: `Results/verification/recompute_gsea.py` (from-scratch Subramanian et al. 2005, deliberately not gseapy).

**Before — `origin/main` @ db31a90, gseapy 1.3.0 (the pinned version), full AOP 472 grid: 5 gene-set pools × 9 conditions = 315 cells**

```
cells: 315 | NES==1.0 AND p==1.0 cells: 6
run       condition      KE  NES  p_value      FDR  total_KE_genes_in_dataset
 G1 Carboplatin 48h KE:1194  1.0      1.0 0.438053                        817
 G1 Carboplatin 72h KE:1194  1.0      1.0 0.523077                        817
 G1 Carboplatin 72h  KE:177  1.0      1.0 0.523077                        379
 G3 Carboplatin 72h KE:1194  1.0      1.0 0.431525                        718
 G5 Carboplatin 48h KE:1194  1.0      1.0 0.421525                        817
 G5 Carboplatin 72h KE:1194  1.0      1.0 0.483444                        817
```

Same six cells and the same FDRs as reported in #117.

**After — this branch, same data, same gseapy 1.3.0**

```
cells: 315
NES==1.0 AND p==1.0 cells: 0

nes_status
ok                               294
unstable_normalisation            15
beyond_permutation_resolution      6
```

The acceptance case, KE:1194 in carboplatin at 48 h, across all five gene-set pools:

```
run      NES       ES  p_value      FDR                    nes_status  measured
 G1      NaN 0.430099    0.001 0.000000 beyond_permutation_resolution       817
 G2 2.202195 0.650003    0.000 0.000000                            ok        64
 G3 1.817630 0.403655    0.000 0.025197        unstable_normalisation       718
 G4 1.950894 0.467249    0.000 0.000000                            ok       320
 G5      NaN 0.430099    0.001 0.000000 beyond_permutation_resolution       817
```

It was `NES 1.00, p 1.00, FDR 0.438` in G1 and `FDR 0.422` in G5. It is now significant in every pool and explicitly flagged where the NES cannot be normalised. The independent implementation puts the same cell at NES +1.83, FDR 0.000.

Re-run on gseapy 1.1.4 as well (the permutation draw differs, so the six cells are not the same six): 315 cells, 0 with `NES == 1.0 and p == 1.0`, 6 beyond resolution, 13 unstable.

**Gene-set size.** Every one of the 21 flagged cells carries between 255 and 817 measured genes; nothing below 255 is affected in either draw. The mechanism is that a larger set tightens the permutation null, so a tight null sitting off zero in a skewed ranking is exactly the one-signed case. This gets **more** likely as Key Event curation grows the gene sets — the opposite of what a curation improvement should do — which is why the ceiling in #120 sits at the same end of the size range and why the two are fixed together.

**#120 reproduction.** On `origin/main`, a KE with 60 measured genes run under `max_size=30`:

```
INFO services.gsea_service: GSEA dropped 1 KEs due to min_size=5 filter: ['KE:BIG']
BASELINE ke_summary: {... 'excluded_too_few_genes': 1, 'excluded_reasons': {'KE:BIG': 'too_few_genes'}}
BASELINE sentence: 1 of 2 Key Events tested; 1 excluded (fewer than 5 measured genes)
```

On this branch: reason `too_many_genes`, `excluded_too_few_genes: 0`, sentence `1 of 2 Key Events tested; 1 excluded (more than 30 measured genes, above the GSEA gene-set ceiling)`, log line `GSEA dropped 1 KEs due to max_size=30 filter: ['KE:BIG (60 measured genes)']`.

**Tests.** 10 new tests in `tests/test_gsea_service.py`, including an end-to-end fixture that produces a genuinely empty same-signed tail (verified to return `NES 1.0, p 1.0` on `origin/main`) and one that pins the tail-size detection against a value-based check.

```
603 passed in 63.84s   (593 on origin/main)
Total coverage: 81.82%
```

## Review round 2 — five defects found and fixed (commit 2)

Three independent adversarial reviews confirmed the core fix reproduces exactly (315 cells, 6 degenerate cells recovered, the other 309 identical to <1e-12) and returned five findings against the machinery around it. All five are fixed in the second commit; every one has a test that fails on commit 1 and passes on commit 2.

**1. The capture fabricated statistics under concurrency.** `_capture_prerank_summaries` rebinds `gseapy.gsea.prerank_rs`, a process global, and this app is threaded — `app.py:3218` runs Flask with `threaded=True` and `app.py:2393` dispatches every batch condition on its own `threading.Thread`. Unserialised, the patches nest, both sinks receive both runs' summaries, and since `_null_tail_sizes` is keyed by KE term — identical across conditions — the counts are last-write-wins *across runs*. Carboplatin 48 h and cisplatin 24 h run serially and then in threads:

```
KE:1194  serial  NES 1.971  p 0.000  tail 8  unstable_normalisation
         conc    NES NaN    p 0.001  tail 0  beyond_permutation_resolution
```

Cisplatin 24 h had its NES overwritten to NaN, its p to 0.001 and its FDR to 0.0 on the strength of a tail count belonging to a different condition, with nothing in the output distinguishing it. On `main` this class of error could only mislabel a cell as null; commit 1 made it write invented numbers into the wrong cell, which is strictly worse than the bug being fixed. Second defect in the same block: when the inner context manager exits after the outer one — the normal case, since conditions differ in size — the global is left permanently bound to a dead wrapper appending to an abandoned list.

Fixed with a module-level `threading.Lock` held across the patch *and* the `gp.prerank` call, taken **before** the global is read (reading first and locking after is the same defect in slower motion: the late arrival captures the other run's wrapper as its "original"), plus an identity check on restore. Regression test runs two captures in threads with an out-of-order exit and asserts each sink holds only its own summaries and the global is the real function afterwards; a second test runs two full `run_gsea_analysis` calls in threads and asserts each matches its serial counterpart's tail count. Both reproduce the crossing *and* the leak on commit 1.

**2. The batch / comparison path never learned about `nes_status`** — which is the path the 5×9 grid in the manuscript is built from. `services/comparison_service.py` emitted no status and NES arrived as `None`; `build_comparison_matrix` on a beyond-resolution row gave `nes_matrix [[None]]`, `fdr_matrix [[0.0]]`, and `templates/compare.html` rendered that as an em-dash with `isSig=false` and `sortVal='Infinity'` — dropping even the `q=` FDR that every other cell carries, sorting the strongest cell last, and blanking it in the heatmap. After the fix the six recovered cells were still invisible in the cross-condition view and carried *less* information there than before.

`nes_status` and `ES` now travel through `build_comparison_matrix` as `nes_status_matrix` / `es_matrix` and into: the comparison table (a boxed, hatched `▲ beyond res.` cell with the FDR beside it, sorted to the extreme of its own direction rather than last), the heatmap (ringed with a legend entry rather than coloured — there is no magnitude to put on a diverging scale, only a direction), and both batch reports via a new `comparison_nes_display_dataframe`. The numeric export stays numeric; the report tables are text. The two captions that promised *"The table below carries every NES value, significant or not"* (`batch_report_service.py` HTML and PDF) and the heatmap caption in `compare.html` are corrected.

**3. The network figure said the opposite of the fix.** `build_cytoscape_network` yielded `{"nes": null, "fdr": 0.0, "classes": "significant"}`, and the frontend does `nesColor(ele.data('nes'))` where `nesColor` is `Math.max(-3, Math.min(3, parseFloat(nes) || 0))` — `null` becomes `0` becomes `#FFFFFF`, the colour **reserved for NES = 0**. The recovered Key Event was drawn white ("no enrichment") with a significance border, and the `.cyjs` export and the network PNG in both reports inherited it. The node now carries `nes_status` and `es`; `nesColor` returns a distinct off-gradient colour for any non-finite value instead of folding it onto zero; the state has its own Cytoscape rule (solid plum, thick dashed border, keeping the red significance ring) and its own legend entry in both templates.

**4. A false claim shipped in the docs and the UI.** The docstring, the CHANGELOG, the `NES_UNSTABLE` comment and both UI tooltips asserted that the nominal p survives a tiny tail. It does not — gseapy computes the nominal p on the **same same-signed tail it normalises against**. From the post-fix grid:

```
G1 Carboplatin 48h KE:177   p 0.600  tail 5  -> p is literally 3/5
G1 Carboplatin 48h KE:149   p 0.000  tail 1  -> p is 0/1
G4 Carboplatin 72h KE:1194  p 0.000  tail 2,  FDR 0.008
G3 Carboplatin 48h KE:1194  p 0.000  tail 2,  FDR 0.025
```

Measured directly on gseapy 1.1.4: a term with a same-signed tail of 56 and one exceedance returns exactly 1/56 = 0.017857…, not the pooled 1/100 = 0.01. The classification was right; the claim attached to it was wrong, and wrong in the direction that keeps a reader thresholding on the number. The claim is retracted in the module header, the `NES_UNSTABLE` docstring, `run_gsea_analysis`, the CHANGELOG and both UI tooltips; rows carry a new `p_value_resolution` column (the step size the p was quantised to, `1/tail`, or `1/permutations` beyond resolution); the reports print the p-value through a new `format_pvalue` that attaches the qualifier; and the compare table marks such cells. A test asserts gseapy's `p == exceedances / same_signed_tail` on a real run, so a future gseapy cannot change the denominator quietly, and a second test greps the source for the retracted sentence.

**5. Silent failure mode.** When the capture cannot fire — gseapy renames `prerank_rs`, or `method='multilevel'` routes through `fgsea_rs` — every row was labelled `ok`, so a future gseapy bump would have quietly reintroduced the original misreporting under a clean bill of health. Those rows are now `undiagnosed`: the context manager reports whether the wrapper actually ran, `apply_null_diagnostics` labels any row with no tail count `undiagnosed` rather than `ok`, the failure is logged at **error** level naming the symbol, and the count is carried into `ke_summary` (and recovered from a stored network) so the Key Event accounting sentence the reader sees says *"The permutation null could not be inspected for N tested Key Event(s), so their NES and p-value are unchecked."*

**Tests.** 21 new tests in `tests/test_gsea_null_diagnostics.py`, plus two existing tests updated to the corrected behaviour (`nes_status` for a missing null is now `undiagnosed`, not `ok`; the column list gains `p_value_resolution`).

```
624 passed in 46.91s   (603 on commit 1, 593 on origin/main)
Total coverage: 82.10%
```

## What this does not fix

- **gseapy's own FDR for the *unaffected* terms** is computed from a pooled null that still contains the degenerate terms' substituted `NES = 1.0`. Correcting it means recomputing the FDR outside gseapy, which is a larger change than this PR; the effect is small (one or two terms in a pool of seven) but it is not zero. Tracked as #122.
- Runs stored before this change keep their `NES 1.0` rows. Nothing back-fills them.
- The trend arrows and delta mode on the comparison page still read from the NES matrix, so a beyond-resolution cell has no delta and no trend contribution. That is correct — there is no NES to difference — but it means such a cell is absent rather than marked in those two views.
