### PR TITLE
Back up the deployed SQLite database nightly (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   with no recoverable prior state.
 
   `scripts/backup_db.py` uses SQLite's Online Backup API, which is safe while the app is
-  writing, and runs as the Swarm cron job `cronjobs_molaop-analyser-backup` (daily 03:00 UTC,
+  writing, and runs as the Swarm cron job `cronjobs_molaop-analyser-backup` (daily 03:30 UTC,
   seven-day retention) off this repo's own image — the same pattern as the Builder's, so the
   backup logic stays versioned with the schema it belongs to. It reads the database file
   directly on GlusterFS rather than exec'ing into the running container, so it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,30 @@ via `ghcr.io/marvinm2/molaop-analyser`.
   precomputed snapshot, which had gone four months without a refresh and was undercounting
   (AOP 625: 15 KEs of 18) until builder #207 regenerated it.
 
+- **Nightly backup of the deployed database** (#114). `/data/molAOP_analyser.db` holds
+  shared-result links and batch history — state that has survived redeploys by design since
+  2026-07-21 — and nothing copied it anywhere. GlusterFS replica 2 is not a backup: it
+  protects against a node dying, not against deletion, corruption or a bad schema migration,
+  because both replicas take the same write. The service had taken three additive migrations
+  with no recoverable prior state.
+
+  `scripts/backup_db.py` uses SQLite's Online Backup API, which is safe while the app is
+  writing, and runs as the Swarm cron job `cronjobs_molaop-analyser-backup` (daily 03:00 UTC,
+  seven-day retention) off this repo's own image — the same pattern as the Builder's, so the
+  backup logic stays versioned with the schema it belongs to. It reads the database file
+  directly on GlusterFS rather than exec'ing into the running container, so it is
+  node-independent.
+
+  Three of its checks exist because the obvious ones pass on the failure they are meant to
+  catch. SQLite treats a zero-length file as a valid empty database, so `integrity_check`
+  returns `ok` on an aborted backup — a byte floor runs first. A structurally valid database
+  with no rows is not a backup of *this* database — `experiments` and `batches` must be
+  non-empty. And `Connection.backup()` retries a locked source *forever* rather than honouring
+  the connection timeout, so the read lock is taken separately under a bounded wait: a job
+  that hangs would, with `skip-running=true`, silently suppress every run after it. Any check
+  that fails deletes the partial file, so a failed run never leaves something that sorts as
+  the newest backup.
+
 - Repository tooling brought in line with the molAOP Builder: CI workflow (test matrix,
   flake8, coverage, startup smoke test), code-quality workflow (ruff/black/isort, bandit,
   pip-audit), Dependabot, CODEOWNERS, issue and pull-request templates, `LICENSE` (GPL-2.0),

--- a/scripts/backup_db.py
+++ b/scripts/backup_db.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Back up the analyser's SQLite database using the Online Backup API.
+
+Scheduled daily as a Swarm cron job (`cronjobs_molaop-analyser-backup`), which
+runs this script in a one-shot container off this same image with
+/mnt/gluster/docker/molaop-analyser/data bind-mounted at /data. It reads the
+database file directly on GlusterFS rather than exec'ing into the running
+container, so it works on whichever node the scheduler picks and regardless of
+where molaop-analyser itself is running.
+
+Run it by hand before a schema migration:
+    ssh tgx1 "docker exec \\$(docker ps -qf name=molaop-analyser) \\
+        python /app/scripts/backup_db.py"
+
+sqlite3's backup API (https://sqlite.org/backup.html) is safe while the app is
+writing; copying the .db file alone is not, because it leaves the -wal and -shm
+sidecars behind. Every check below removes the output on failure, so a run that
+dies never leaves a file that sorts as the newest backup.
+"""
+import os
+import sqlite3
+import sys
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+DB_PATH = Path(os.environ.get("DB_PATH", "/data/molAOP_analyser.db"))
+BACKUP_DIR = Path(os.environ.get("BACKUP_DIR", "/data/backups"))
+RETENTION_DAYS = int(os.environ.get("RETENTION_DAYS", "7"))
+# How long to wait for the live writer to release its lock before giving up.
+BUSY_TIMEOUT_S = float(os.environ.get("BUSY_TIMEOUT_MS", "60000")) / 1000
+# A real backup of this database is >100 MB. Anything under a few pages is a
+# failed one, whatever PRAGMA integrity_check says about it — SQLite treats a
+# zero-length file as a valid, empty database, so integrity_check returns "ok"
+# on precisely the failure it would need to catch. Check the size first.
+MIN_BACKUP_BYTES = int(os.environ.get("MIN_BACKUP_BYTES", "65536"))
+# Tables that must hold rows for the file to be a backup *of this database*.
+# shared_results is deliberately not here: links expire after 30 days, so an
+# empty one is a normal state rather than evidence of a truncated copy.
+REQUIRED_NONEMPTY = ("experiments", "batches")
+
+
+def fail(backup_file, message):
+    backup_file.unlink(missing_ok=True)
+    print(f"[BACKUP ERROR] {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main():
+    if not DB_PATH.exists():
+        print(f"[BACKUP ERROR] no database at {DB_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+    BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = time.strftime("%Y%m%d_%H%M%S")
+    backup_file = BACKUP_DIR / f"molAOP_analyser_{timestamp}.db"
+
+    source = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True,
+                             timeout=BUSY_TIMEOUT_S)
+    try:
+        # Take the read lock ourselves, under the connection's busy timeout,
+        # before handing the connection to backup(). Connection.backup() retries
+        # a locked source *forever* — it does not honour the timeout — so
+        # calling it first would turn a stuck writer into a job that never
+        # returns, and with skip-running=true a job that never returns silently
+        # suppresses every run after it. Failing loudly is the safer end state.
+        source.execute("BEGIN")
+        source.execute("SELECT COUNT(*) FROM sqlite_master")
+    except sqlite3.Error as exc:
+        source.close()
+        fail(backup_file, f"could not read {DB_PATH} within "
+                          f"{BUSY_TIMEOUT_S:g}s: {exc}")
+
+    try:
+        target = sqlite3.connect(backup_file)
+        with target:
+            # pages=-1 copies in a single step, and the read transaction above
+            # is still open, so a concurrent write can neither block nor
+            # restart the copy partway through.
+            source.backup(target, pages=-1)
+        target.close()
+        source.rollback()
+    except sqlite3.Error as exc:
+        fail(backup_file, f"sqlite backup failed for {DB_PATH}: {exc}")
+    finally:
+        source.close()
+
+    backup_bytes = backup_file.stat().st_size
+    if backup_bytes < MIN_BACKUP_BYTES:
+        fail(backup_file, f"{backup_file} is {backup_bytes} bytes, "
+                          f"under the {MIN_BACKUP_BYTES}-byte floor")
+
+    check = sqlite3.connect(backup_file)
+    try:
+        result = check.execute("PRAGMA integrity_check;").fetchone()[0]
+        if result != "ok":
+            fail(backup_file, f"integrity check failed for {backup_file}: {result}")
+
+        counts = {}
+        for table in REQUIRED_NONEMPTY:
+            try:
+                counts[table] = check.execute(
+                    f'SELECT COUNT(*) FROM "{table}"').fetchone()[0]
+            except sqlite3.Error as exc:
+                fail(backup_file, f"{backup_file} has no usable {table} table: {exc}")
+            if counts[table] < 1:
+                fail(backup_file, f"{backup_file} holds no rows in {table}")
+    finally:
+        check.close()
+
+    summary = ", ".join(f"{n} {t}" for t, n in counts.items())
+    print(f"[BACKUP OK] {backup_file} — {backup_bytes} bytes, "
+          f"integrity ok, {summary}")
+
+    # Prune by age. The glob covers "-wal"/"-shm" sidecars too: a clean close
+    # removes them, but one left behind by an interrupted read would otherwise
+    # match no prune pattern and stay forever.
+    cutoff = datetime.now() - timedelta(days=RETENTION_DAYS)
+    for old in BACKUP_DIR.glob("molAOP_analyser_*.db*"):
+        if datetime.fromtimestamp(old.stat().st_mtime) < cutoff:
+            old.unlink(missing_ok=True)
+            print(f"[BACKUP PRUNE] removed {old.name} (older than "
+                  f"{RETENTION_DAYS} days)")
+    # Prune empty backups regardless of age — one left by a run predating the
+    # checks above would otherwise sit there for a full retention period,
+    # sorting as the newest.
+    for empty in BACKUP_DIR.glob("molAOP_analyser_*.db"):
+        if empty.stat().st_size == 0:
+            empty.unlink(missing_ok=True)
+            print(f"[BACKUP PRUNE] removed empty {empty.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backup_db.py
+++ b/tests/test_backup_db.py
@@ -1,0 +1,171 @@
+"""Tests for scripts/backup_db.py (issue #114).
+
+Each guard in the backup script exists because the obvious version of the check
+passes on the failure it is meant to catch. These tests assert the failing
+behaviour, not just the happy path:
+
+- PRAGMA integrity_check returns "ok" on a zero-length file, so it cannot tell a
+  finished backup from an aborted one — hence the byte floor.
+- A structurally valid database with no rows is not a backup of this database —
+  hence the content check.
+- Connection.backup() retries a locked source forever, so the wait for a
+  concurrent writer has to be bounded outside it.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "backup_db.py"
+
+
+def make_db(path, experiments=3, batches=2):
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE experiments (id INTEGER PRIMARY KEY)")
+    conn.execute("CREATE TABLE batches (id INTEGER PRIMARY KEY)")
+    conn.executemany("INSERT INTO experiments (id) VALUES (?)",
+                     [(i,) for i in range(experiments)])
+    conn.executemany("INSERT INTO batches (id) VALUES (?)",
+                     [(i,) for i in range(batches)])
+    conn.commit()
+    conn.close()
+    return path
+
+
+def run_backup(db_path, backup_dir, **env_overrides):
+    env = {**os.environ, "DB_PATH": str(db_path), "BACKUP_DIR": str(backup_dir),
+           "MIN_BACKUP_BYTES": "1024"}
+    env.update({k: str(v) for k, v in env_overrides.items()})
+    return subprocess.run([sys.executable, str(SCRIPT)], env=env,
+                          capture_output=True, text=True, timeout=120)
+
+
+def backups_in(backup_dir):
+    return sorted(Path(backup_dir).glob("molAOP_analyser_*.db"))
+
+
+def test_backup_is_restorable(tmp_path):
+    db = make_db(tmp_path / "src.db", experiments=7)
+    out = tmp_path / "backups"
+
+    result = run_backup(db, out)
+
+    assert result.returncode == 0, result.stderr
+    copies = backups_in(out)
+    assert len(copies) == 1
+    restored = sqlite3.connect(copies[0])
+    assert restored.execute("SELECT COUNT(*) FROM experiments").fetchone()[0] == 7
+    restored.close()
+
+
+def test_integrity_check_alone_would_accept_an_empty_file(tmp_path):
+    """The premise of the byte floor, asserted rather than assumed."""
+    empty = tmp_path / "zero.db"
+    empty.touch()
+    conn = sqlite3.connect(empty)
+    assert conn.execute("PRAGMA integrity_check;").fetchone()[0] == "ok"
+    conn.close()
+
+
+def test_undersized_backup_is_rejected_and_removed(tmp_path):
+    db = make_db(tmp_path / "src.db")
+    out = tmp_path / "backups"
+
+    result = run_backup(db, out, MIN_BACKUP_BYTES=50_000_000)
+
+    assert result.returncode == 1
+    assert "under the" in result.stderr
+    assert backups_in(out) == []
+
+
+def test_database_without_rows_is_rejected(tmp_path):
+    db = make_db(tmp_path / "src.db", experiments=0)
+    out = tmp_path / "backups"
+
+    result = run_backup(db, out)
+
+    assert result.returncode == 1
+    assert "holds no rows in experiments" in result.stderr
+    assert backups_in(out) == []
+
+
+def test_missing_database_fails_loudly(tmp_path):
+    result = run_backup(tmp_path / "absent.db", tmp_path / "backups")
+
+    assert result.returncode == 1
+    assert "no database" in result.stderr
+
+
+@pytest.mark.parametrize("patience_ms,lock_seconds,expect_success", [
+    (1000, 6, False),   # writer outlasts our patience — fail, do not hang
+    (20000, 2, True),   # writer releases in time — wait it out, then back up
+])
+def test_bounded_wait_for_a_concurrent_writer(tmp_path, patience_ms,
+                                              lock_seconds, expect_success):
+    db = make_db(tmp_path / "src.db")
+    out = tmp_path / "backups"
+
+    holder = subprocess.Popen(
+        [sys.executable, "-c",
+         f"import sqlite3,time\n"
+         f"c=sqlite3.connect({str(db)!r},isolation_level=None)\n"
+         f"c.execute('BEGIN EXCLUSIVE')\n"
+         f"time.sleep({lock_seconds})\n"
+         f"c.execute('ROLLBACK')"])
+    time.sleep(0.5)
+    try:
+        started = time.monotonic()
+        result = run_backup(db, out, BUSY_TIMEOUT_MS=patience_ms)
+        elapsed = time.monotonic() - started
+    finally:
+        holder.wait(timeout=30)
+
+    if expect_success:
+        assert result.returncode == 0, result.stderr
+        assert len(backups_in(out)) == 1
+    else:
+        assert result.returncode == 1
+        assert "database is locked" in result.stderr
+        assert backups_in(out) == []
+        # The point of the guard: it returns rather than retrying forever.
+        assert elapsed < lock_seconds
+
+
+def test_retention_prunes_aged_backups_and_stray_sidecars(tmp_path):
+    db = make_db(tmp_path / "src.db")
+    out = tmp_path / "backups"
+    out.mkdir()
+    aged = out / "molAOP_analyser_20260101_020000.db"
+    sidecar = out / "molAOP_analyser_20260101_020000.db-wal"
+    recent = out / "molAOP_analyser_20260803_020000.db"
+    for path in (aged, sidecar, recent):
+        path.write_bytes(b"x" * 2048)
+    old = time.time() - 30 * 86400
+    os.utime(aged, (old, old))
+    os.utime(sidecar, (old, old))
+
+    result = run_backup(db, out, RETENTION_DAYS=7)
+
+    assert result.returncode == 0, result.stderr
+    assert not aged.exists()
+    assert not sidecar.exists()
+    assert recent.exists()
+
+
+def test_empty_backups_are_pruned_regardless_of_age(tmp_path):
+    db = make_db(tmp_path / "src.db")
+    out = tmp_path / "backups"
+    out.mkdir()
+    # What a pre-fix run left behind: 0 bytes, today's date, sorting newest.
+    stale = out / "molAOP_analyser_20260804_010000.db"
+    stale.touch()
+
+    result = run_backup(db, out, RETENTION_DAYS=7)
+
+    assert result.returncode == 0, result.stderr
+    assert not stale.exists()


### PR DESCRIPTION
Closes #114.

`/mnt/gluster/docker/molaop-analyser/data/molAOP_analyser.db` (now ~131 MB) holds shared-result links and batch history — user-facing state that survives redeploys by design — and nothing copies it anywhere. Confirmed still true on the cluster today: `docker service ls` shows `cronjobs_molaop-builder-backup` for the Builder and no equivalent for this service, and `find /mnt/hidrive -iname '*molaop*'` is empty.

GlusterFS replica 2 is not a backup. It protects against a node dying; it does not protect against deletion, corruption or a bad schema migration, because both replicas take the same write.

## Approach

`scripts/backup_db.py` follows the Builder's pattern: the job runs **this repo's own image** and calls a script already inside it, so backup logic stays versioned with the schema it belongs to, and the job needs no GHCR auth. It reads the database file directly on GlusterFS rather than exec'ing into the running container, so it is node-independent — it works wherever the scheduler places it, and regardless of which node `molaop-analyser` is on.

Python rather than the Builder's `sqlite3` shell script because this image has no `sqlite3` CLI (`python:3.14-bookworm` ships the module, not the binary), and adding an apt package to carry a backup script is a worse trade than using the module's `Connection.backup()` — the same Online Backup API.

## The guards, and why the obvious ones don't work

- **Byte floor before `integrity_check`.** SQLite treats a zero-length file as a valid, empty database, so `integrity_check` returns `ok` on precisely the failure it would need to catch. It is a corruption guard, not a completion guard. (Asserted directly in `test_integrity_check_alone_would_accept_an_empty_file`.)
- **Content check.** A structurally valid database with no rows is not a backup *of this* database. `experiments` and `batches` must be non-empty; `shared_results` deliberately is not checked, since links expire after 30 days and an empty table is a normal state.
- **Bounded wait for the live writer.** `Connection.backup()` retries a locked source **forever** — it does not honour the connection timeout — so calling it directly turns a stuck writer into a job that never returns, and with `skip-running=true` a job that never returns silently suppresses every run after it. The read lock is therefore taken separately, under the busy timeout, before the connection is handed to `backup()`.
- Every failing check deletes the partial file, so a run that dies never leaves something that sorts as the newest backup. Zero-byte files are also pruned regardless of age.

## Verification

9 new tests; full suite 602 passed. The tests were run against a naive implementation (`backup()` + `integrity_check`, no floor, no content check, no bounded wait) and **6 of the 9 fail against it**, including the hang leg — the three that pass on both sides are the happy path and the two that assert SQLite's own behaviour.

## Not addressed here

The backup lands in `data/backups/` beside the live database, which is the Builder's arrangement too: it survives node loss but not an `rm -rf` of the data directory, and nothing copies it off-cluster. `/mnt/hidrive` was the obvious destination but is root-owned on both nodes (cifs `uid=0,dir_mode=0755`) and this image runs as `appuser`. Off-site copies are a cluster-wide gap tracked in `operations/backup-strategy.md`, and they apply equally to the Builder.