### PR TITLE
Stop the demo copy from expiring the moment it is made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The demo datasets were unusable: "Confirm Column Selection" did nothing.** Picking a
+  dataset on `/demos` rendered the preview correctly, and then the button below it was dead —
+  no error, no swap, nothing. The demo path was the *only* way into the tool that broke this
+  way; uploading your own file worked throughout, which is why it survived so long.
+
+  `/preview` sweeps `uploads/` of anything older than `Config.UPLOAD_RETENTION_HOURS` before
+  it resolves the requested file, and the demo copy was made with `shutil.copy2` — which
+  preserves the source mtime. A demo file shipped in `data/` therefore arrived in `uploads/`
+  carrying the mtime of whenever that file was last written, already far outside the retention
+  window. The first request rendered fine (the copy existed for the length of that request);
+  the second request — the Confirm button — swept it away *before* looking for it and answered
+  `400 File not found`. HTMX does not swap on a 4xx, so the page simply sat there.
+
+  The copy is now made with `shutil.copy` plus an explicit `os.utime`, so the retention clock
+  starts at the copy rather than at the shipped file's age. The same trap hit the guided tour
+  (which preloads a demo dataset) and any second `/preview` render such as "Update Plot".
+  Batch demo copies use `copy2` too but are unaffected — batch directories expire from
+  database timestamps, not mtime.
+
+  Worth noting how the timing hid this in production: `COPY` carries the build context's
+  mtimes into the image, so a freshly built image has fresh demo files and the demo flow works
+  — until the image is a day old, at which point every demo click starts failing. The
+  regression test ages the source file deliberately rather than trusting it, because a fresh
+  git checkout stamps `data/` with the checkout time and would let the old behaviour pass on
+  CI.
+
 ### Added
 
 - **Batch analysis can now run GSEA, not only Fisher/ORA** (#76). Batch mode existed to

--- a/app.py
+++ b/app.py
@@ -550,9 +550,18 @@ def preview():
         filename = requested.name
         filepath = os.path.join(app.config['UPLOAD_FOLDER'], filename)
 
-        # Copy demo file from data directory to uploads directory
+        # Copy demo file from data directory to uploads directory.
+        # NOT copy2: that preserves the source mtime, and the shipped demo files
+        # are years older than Config.UPLOAD_RETENTION_HOURS. The copy would land
+        # already "expired", so the very next /preview request — the user pressing
+        # "Confirm Column Selection" — swept it away in cleanup_old_uploads() above
+        # and 400'd with "File not found". shutil.copy stamps the copy with now;
+        # the explicit os.utime states that the retention clock must start at the
+        # copy, so a future switch back to a metadata-preserving copy can't
+        # silently reintroduce this.
         import shutil
-        shutil.copy2(str(requested), filepath)
+        shutil.copy(str(requested), filepath)
+        os.utime(filepath, None)
         logger.info(f"Copied demo file {demo_filename} to {filepath}")
 
         # Seed a meaningful default dataset_id from the demo file stem when the

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -68,6 +68,59 @@ class TestFlaskRoutes:
             assert b'Preview top 5 rows' in response.data
             assert b'Gene Symbol / ID column' in response.data
     
+    def test_demo_copy_survives_the_next_request(self, flask_client):
+        """A demo dataset must not land in uploads/ already expired (#demo-preview).
+
+        /preview sweeps uploads/ by mtime (Config.UPLOAD_RETENTION_HOURS) *before*
+        it resolves the requested file. The demo copy was made with shutil.copy2,
+        which carries the source mtime across, so a demo file shipped in data/ long
+        ago arrived in uploads/ older than the retention window — and the very next
+        request, the user pressing "Confirm Column Selection" below the preview,
+        swept it away and answered 400 "File not found". The retention clock has to
+        start at the copy, not at whenever the shipped file was last written.
+
+        The source mtime is aged deliberately rather than trusted: a fresh git
+        checkout stamps data/ with the checkout time, which would let the old
+        copy2 behaviour pass this test on CI.
+        """
+        import os
+        import time
+        from pathlib import Path
+        from config import Config
+
+        source = Path('data') / 'GSE90122_TO90137.tsv'
+        dest = Path(Config.UPLOAD_FOLDER) / source.name
+        original_times = (os.path.getatime(source), os.path.getmtime(source))
+        stale = time.time() - (Config.UPLOAD_RETENTION_HOURS + 24) * 3600
+        os.utime(source, (stale, stale))
+
+        try:
+            first = flask_client.post('/preview', data={'demo_file': source.name})
+            assert first.status_code == 200
+
+            age_seconds = time.time() - os.path.getmtime(dest)
+            assert age_seconds < 3600, (
+                f"Demo copy landed with a {age_seconds / 3600:.1f}h-old mtime; it must "
+                f"be stamped at copy time or the uploads sweep expires it immediately."
+            )
+
+            # The follow-up request the Confirm button makes.
+            second = flask_client.post('/preview', data={
+                'filename': source.name,
+                'columns_confirmed': 'true',
+                'id_column': 'GENE_SYMBOL',
+                'fc_column': 'logFC',
+                'pval_column': 'P.Value',
+            })
+            assert second.status_code == 200, (
+                f"Confirm Column Selection returned {second.status_code}: "
+                f"{second.data[:200]!r}"
+            )
+        finally:
+            os.utime(source, original_times)
+            if dest.exists():
+                dest.unlink()
+
     def test_preview_route_missing_file(self, flask_client):
         """Test preview route with missing file."""
         response = flask_client.post('/preview', data={})


### PR DESCRIPTION
Picking a dataset on `/demos` renders the preview, and then **Confirm Column Selection** below it does nothing — no error, no swap. Reproduces on production right now:

```
$ POST /preview  demo_file=GSE90122_TO90137.tsv    → 200, preview renders
$ POST /preview  filename=GSE90122_TO90137.tsv …   → 400 "File not found: uploads/GSE90122_TO90137.tsv"
```

## Cause

`/preview` sweeps `uploads/` of anything older than `Config.UPLOAD_RETENTION_HOURS` **before** it resolves the requested file (`app.py:519`, then `app.py:555`). The demo copy was made with `shutil.copy2`, which preserves the source mtime — so a demo file shipped in `data/` arrived in `uploads/` carrying the mtime of whenever that file was last written, already far outside the retention window.

The first request rendered fine (the copy existed for the length of that request). The second request — the Confirm button — swept it away before looking for it, and returned 400. HTMX does not swap on a 4xx, so the page just sat there. Uploading your own file was never affected: `file.save()` stamps the current time.

`COPY` carries build-context mtimes into the image, so a freshly built image has fresh demo files and the demo flow works — until the image is a day old, at which point every demo click starts failing.

## Fix

`shutil.copy` plus an explicit `os.utime`, so the retention clock starts at the copy rather than at the shipped file's age. The guided tour (which preloads a demo dataset) and any second `/preview` render such as "Update Plot" were broken the same way.

Batch demo copies use `copy2` too, but batch directories expire from database timestamps (`cleanup_expired_batches`) rather than mtime, so they are unaffected and left alone.

## Verification

End-to-end against a local server: preview → Confirm Column Selection (200) → Update Plot (200) → Analyse (200, results table rendered).

New regression test `test_demo_copy_survives_the_next_request` ages the source file deliberately rather than trusting it — a fresh git checkout stamps `data/` with the checkout time, which would let the old `copy2` behaviour pass on CI. Confirmed failing against the unfixed code and passing after. Full suite: 646 passed.