### PR TITLE
Keep the AOP choice and log2FC threshold across an HTMX re-render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,43 @@ via `ghcr.io/marvinm2/molaop-analyser`.
 
 ### Fixed
 
+- **Choosing an AOP and then touching a threshold silently reverted you to the demo's AOP.**
+  On a demo dataset: press "Show all AOPs", pick something other than the recommended one,
+  then click any log2FC quick button or "Update Plot" — and the picker snapped back to
+  `AOP:DEMO` with the filter toggle back on "recommended". The threshold buttons auto-submit,
+  so this happened without the user knowingly pressing anything, and the analysis then ran
+  against an AOP they had not chosen.
+
+  The threshold controls submit `#volcanoForm`; the AOP picker lives in `#enrichmentForm`.
+  That split is why the resource checkboxes (#55) and the confidence select (#60) each needed
+  a mirror — `aop_selection` and `aop_filter_mode` never got one, so they were not posted,
+  `/preview` had nothing to echo, and the picker re-rendered with no value. The
+  recommended-AOP auto-select then read the empty picker as "never chosen" and overwrote the
+  pick, doing precisely what its own comment promised it would not:
+
+  ```js
+  // Only kicks in when the picker is empty (so we never clobber a manual selection …)
+  if (recommendedAops.length === 1 && !hiddenInput.value && !searchInput.value) {
+  ```
+
+  The guard was correct in intent and could never hold, because after a swap the picker was
+  always empty. Fixed by mirroring the selection, its label and the filter mode into
+  `#volcanoForm`, and having `/preview` round-trip all three. Only the browser knows the
+  display label — the server has the id — so the label rides along with it.
+
+  The mirror is written both as hidden inputs and, authoritatively, into
+  `evt.detail.parameters` on `htmx:configRequest`. Hidden inputs alone were not enough: they
+  are only refreshed at the call sites that mutate the picker, so any other path that sets it
+  (`tour.js`'s `preselectPxrAop`, for one) left them stale. This was caught by testing that
+  path rather than reasoning about it.
+
+- **A custom log2FC threshold was ignored unless you pressed "Update Plot" first.** The
+  threshold inputs are in `#volcanoForm` and the Analyse button is in `#enrichmentForm`;
+  `pval_threshold` had a hidden `#pval-mirror` kept in sync on every keystroke, `logfc_threshold`
+  had no mirror at all. Typing `2.5` into Custom and pressing "Run Enrichment Analysis"
+  therefore ran on the *previous* threshold while the box on screen read `2.5` — wrong numbers,
+  no error, nothing on the results page to reveal it. Given the same mirror the p-value box has.
+
 - **The demo datasets were unusable: "Confirm Column Selection" did nothing.** Picking a
   dataset on `/demos` rendered the preview correctly, and then the button below it was dead —
   no error, no swap, nothing. The demo path was the *only* way into the tool that broke this

--- a/app.py
+++ b/app.py
@@ -716,6 +716,20 @@ def preview():
             if request.form.get('min_confidence', '').strip().lower() in VALID_MIN_CONFIDENCE
             else DEFAULT_MIN_CONFIDENCE
         ),
+        # Preserve the chosen AOP and the recommended/all filter mode across HTMX
+        # re-renders, the same way resources (#55) and min_confidence (#60) are.
+        # Without this the picker re-rendered with no value, and the
+        # recommended-AOP auto-select in _single_analysis_scripts.html read that
+        # empty picker as "never chosen" and overwrote the user's pick with the
+        # demo's AOP on every "Update Plot". The label rides along because only
+        # the browser knows it — the server has the id, not the display text.
+        selected_aop=request.form.get('aop_selection', '').strip(),
+        selected_aop_label=request.form.get('aop_label', '').strip(),
+        aop_filter_mode=(
+            request.form.get('aop_filter_mode', '').strip().lower()
+            if request.form.get('aop_filter_mode', '').strip().lower() in VALID_AOP_FILTER_MODES
+            else DEFAULT_AOP_FILTER_MODE
+        ),
     )
 
     # HTMX swaps in just the partial — no full-page reload, no scroll-to-top.
@@ -1448,6 +1462,12 @@ REFERENCE_CACHE_KEY = "reference_sets_v1"
 # collide, then merged (union per KE) for enrichment.
 VALID_RESOURCES = ("WikiPathways", "GO_BP", "Reactome")
 DEFAULT_RESOURCES = ("WikiPathways",)
+
+# The /demos CTA sends recommended_aops, which puts the AOP picker into
+# "recommended" mode with a "Show all AOPs" toggle. The mode has to round-trip
+# through /preview or the toggle snaps back on every HTMX re-render.
+VALID_AOP_FILTER_MODES = ("recommended", "all")
+DEFAULT_AOP_FILTER_MODE = "recommended"
 _GMT_RESOURCE_CACHE_KEYS = {
     "GO_BP": "reference_sets_go_v1",
     "Reactome": "reference_sets_reactome_v1",

--- a/templates/_single_analysis.html
+++ b/templates/_single_analysis.html
@@ -400,7 +400,7 @@
         <input type="hidden" name="fc_column" value="{{ selected_columns.fc }}">
         <input type="hidden" name="pval_column" value="{{ selected_columns.pval }}">
         <input type="hidden" name="pval_adj_column" value="{{ selected_columns.pval_adj or '' }}">
-        <input type="hidden" name="logfc_threshold" value="{{ logfc_threshold or '' }}">
+        <input type="hidden" name="logfc_threshold" id="logfc-mirror" value="{{ logfc_threshold or '' }}">
         <input type="hidden" name="method" id="method-mirror" value="{{ method or 'ora' }}">
         <input type="hidden" name="pval_threshold" id="pval-mirror" value="{{ pval_threshold or '0.05' }}">
 
@@ -428,14 +428,20 @@
                 <span class="aop-filter-toggle__label" id="aop_filter_label">Showing recommended AOPs for this demo</span>
                 <button type="button" class="aop-filter-toggle__btn" id="aop_filter_btn">Show all AOPs</button>
             </div>
-            <input type="hidden" name="aop_filter_mode" id="aop_filter_mode" value="recommended">
+            <input type="hidden" name="aop_filter_mode" id="aop_filter_mode"
+                   value="{{ aop_filter_mode or 'recommended' }}">
             {% endif %}
             <div class="typeahead-wrapper" style="position: relative;"
                  data-tour-target="aop-picker">
+                {# The picker must re-render with whatever was chosen before the swap.
+                   Rendering it empty is what let the recommended-AOP auto-select
+                   overwrite a manual pick on every "Update Plot". #}
                 <input type="text" id="aop_search" placeholder="Search AOPs by name or ID..."
                        autocomplete="off" class="wide-dropdown"
+                       value="{{ selected_aop_label or '' }}"
                        style="width: 100%; padding: 10px; font-size: 14px; box-sizing: border-box;">
-                <input type="hidden" id="aop_selection" name="aop_selection" required>
+                <input type="hidden" id="aop_selection" name="aop_selection"
+                       value="{{ selected_aop or '' }}" required>
                 <ul id="aop_suggestions" class="typeahead-dropdown" hidden></ul>
             </div>
         </div>

--- a/templates/_single_analysis_scripts.html
+++ b/templates/_single_analysis_scripts.html
@@ -213,6 +213,12 @@
     const methodMirror = document.getElementById('method-mirror');
     const pvalMirror = document.getElementById('pval-mirror');
     const pvalInput = document.getElementById('pval_threshold');
+    // The log2FC box needs the same mirror as the p-value box. Without it,
+    // typing a custom threshold and pressing "Run Enrichment Analysis" without
+    // first pressing "Update Plot" ran the analysis on the *previous* threshold
+    // while the box on screen showed the new one — wrong numbers, no error.
+    const logfcMirror = document.getElementById('logfc-mirror');
+    const logfcInput = document.getElementById('logfc_threshold');
 
     function applyMethod() {
         const selected = document.querySelector('input[name="method"]:checked');
@@ -221,12 +227,18 @@
         wrapper.querySelectorAll('input').forEach(i => { i.disabled = isGsea; });
         if (methodMirror && selected) methodMirror.value = selected.value;
         if (pvalMirror && pvalInput) pvalMirror.value = pvalInput.value;
+        if (logfcMirror && logfcInput) logfcMirror.value = logfcInput.value;
     }
 
     radios.forEach(r => r.addEventListener('change', applyMethod));
     if (pvalInput) {
         pvalInput.addEventListener('input', () => {
             if (pvalMirror) pvalMirror.value = pvalInput.value;
+        });
+    }
+    if (logfcInput) {
+        logfcInput.addEventListener('input', () => {
+            if (logfcMirror) logfcMirror.value = logfcInput.value;
         });
     }
     applyMethod();
@@ -409,6 +421,63 @@ function setPercentageThreshold(percentage) {
         return filterModeInput.value === 'recommended' ? 'recommended' : 'all';
     }
 
+    /**
+     * Mirror the AOP picker into #volcanoForm so it survives "Update Plot".
+     *
+     * The picker lives in #enrichmentForm, but the threshold controls submit
+     * #volcanoForm — the same split that made the resource checkboxes (#55) and
+     * the confidence select (#60) need mirrors. Without one, /preview re-rendered
+     * the picker empty and the recommended-AOP auto-select below treated that as
+     * "never chosen", silently replacing a manual pick with the demo's AOP on
+     * every threshold change. The label is mirrored too because only the browser
+     * knows it: the server has the AOP id, not its display text.
+     *
+     * Called from every place that mutates the picker rather than on submit,
+     * because the hidden input is set by script and never fires a change event.
+     *
+     * The hidden inputs alone are not enough: anything that sets the picker
+     * without going through those call sites (tour.js's preselectPxrAop, say)
+     * would leave them stale. So the values are also written into the request
+     * at htmx:configRequest below, which is authoritative whoever set them.
+     */
+    function aopMirrorValues() {
+        const values = {
+            aop_selection: hiddenInput.value,
+            aop_label: searchInput.value
+        };
+        if (filterModeInput) values.aop_filter_mode = filterModeInput.value;
+        return values;
+    }
+
+    function syncAopMirror() {
+        const volcanoForm = document.getElementById('volcanoForm');
+        if (!volcanoForm) return;  // not mounted until columns are confirmed
+        volcanoForm.querySelectorAll('input[data-aop-mirror]').forEach(el => el.remove());
+        Object.entries(aopMirrorValues()).forEach(([name, value]) => {
+            const hidden = document.createElement('input');
+            hidden.type = 'hidden';
+            hidden.name = name;
+            hidden.value = value;
+            hidden.setAttribute('data-aop-mirror', '');
+            volcanoForm.appendChild(hidden);
+        });
+    }
+
+    // Authoritative sync: htmx has already gathered the form's parameters by
+    // this point, and mutating evt.detail.parameters is its supported extension
+    // point — so this lands the *current* picker state no matter which code path
+    // set it, and regardless of listener ordering. The hidden inputs above stay
+    // for the non-htmx fallback submit.
+    (function attachAopConfigSync() {
+        const volcanoForm = document.getElementById('volcanoForm');
+        if (!volcanoForm) return;
+        volcanoForm.addEventListener('htmx:configRequest', function (evt) {
+            Object.entries(aopMirrorValues()).forEach(([name, value]) => {
+                evt.detail.parameters[name] = value;
+            });
+        });
+    })();
+
     function applyRecommendedFilter(aops) {
         if (getFilterMode() !== 'recommended' || recommendedAops.length === 0) return aops;
         // Recommended set may include 'NETWORK:kidney' which is not a standard AOP:N id —
@@ -535,6 +604,7 @@ function setPercentageThreshold(percentage) {
                 hiddenInput.value = aop.aop_id;
                 searchInput.value = formatLabel(aop);
                 suggestions.hidden = true;
+                syncAopMirror();
             });
 
             suggestions.appendChild(li);
@@ -608,6 +678,7 @@ function setPercentageThreshold(percentage) {
         filterBtn.addEventListener('click', function () {
             filterModeInput.value = (getFilterMode() === 'all') ? 'recommended' : 'all';
             syncLabel();
+            syncAopMirror();
             // Refresh the dropdown so the new mode applies.
             fetchSuggestions(searchInput.value || '');
         });
@@ -634,10 +705,15 @@ function setPercentageThreshold(percentage) {
                     if (match && !hiddenInput.value) {
                         hiddenInput.value = match.aop_id;
                         searchInput.value = formatLabel(match);
+                        syncAopMirror();
                     }
                 })
                 .catch(function () { /* silent: user can still pick manually */ });
         }
     }
+
+    // Seed the mirror from whatever the server just rendered, so a re-render
+    // that happens before the user touches the picker still carries it forward.
+    syncAopMirror();
 })();
 </script>

--- a/tests/test_flask_routes.py
+++ b/tests/test_flask_routes.py
@@ -788,6 +788,112 @@ class TestDemosPage:
             assert b'<script id="recommended-aops-data"' in response.data
             assert b'AOP:1' in response.data
 
+    def test_preview_echoes_the_chosen_aop_back(self, flask_client):
+        """/preview must re-render the AOP picker with the choice it was given.
+
+        "Update Plot" submits #volcanoForm, but the AOP picker lives in
+        #enrichmentForm, so the choice is mirrored across and posted here. If
+        /preview drops it, the picker re-renders empty — and the recommended-AOP
+        auto-select in _single_analysis_scripts.html reads an empty picker as
+        "never chosen" and overwrites the user's pick with the demo's AOP. That
+        made a manually selected AOP silently revert on every threshold change,
+        which is the whole reason the round-trip exists. Same contract as
+        selected_resources (#55) and min_confidence (#60).
+        """
+        import pandas as pd
+        from unittest.mock import patch
+
+        mock_df = pd.DataFrame({
+            'Gene_Symbol': ['BRCA1', 'TP53', 'EGFR'],
+            'log2FoldChange': [2.5, -1.2, 0.8],
+            'padj': [0.001, 0.05, 0.3],
+        })
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
+             patch('pandas.read_csv', return_value=mock_df):
+            response = flask_client.post('/preview', data={
+                'demo_file': 'GSE90122_TO90137.tsv',
+                'recommended_aops': 'AOP:1',
+                'columns_confirmed': 'true',
+                'id_column': 'Gene_Symbol',
+                'fc_column': 'log2FoldChange',
+                'pval_column': 'padj',
+                # What the mirror posts after the user picks a different AOP
+                # and flips the picker to "all".
+                'aop_selection': 'AOP:37',
+                'aop_label': 'AOP:37: Some other pathway (5 KEs)',
+                'aop_filter_mode': 'all',
+            })
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert 'id="aop_selection"' in body
+        assert 'value="AOP:37"' in body, "chosen AOP was not echoed into the picker"
+        assert 'AOP:37: Some other pathway' in body, "picker label was not echoed back"
+        assert 'id="aop_filter_mode"' in body
+        assert 'value="all"' in body, "filter mode reverted to 'recommended'"
+
+    def test_preview_rejects_a_junk_aop_filter_mode(self, flask_client):
+        """An unrecognised filter mode falls back to 'recommended', never renders raw."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        mock_df = pd.DataFrame({
+            'Gene_Symbol': ['BRCA1', 'TP53', 'EGFR'],
+            'log2FoldChange': [2.5, -1.2, 0.8],
+            'padj': [0.001, 0.05, 0.3],
+        })
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
+             patch('pandas.read_csv', return_value=mock_df):
+            response = flask_client.post('/preview', data={
+                'demo_file': 'GSE90122_TO90137.tsv',
+                'recommended_aops': 'AOP:1',
+                'columns_confirmed': 'true',
+                'id_column': 'Gene_Symbol',
+                'fc_column': 'log2FoldChange',
+                'pval_column': 'padj',
+                'aop_filter_mode': 'nonsense',
+            })
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert 'nonsense' not in body
+        assert 'id="aop_filter_mode"' in body
+        assert 'value="recommended"' in body
+
+    def test_enrichment_form_carries_a_logfc_mirror(self, flask_client):
+        """The log2FC box needs the same hidden mirror the p-value box has.
+
+        The threshold inputs live in #volcanoForm; the Analyse button is in
+        #enrichmentForm. p-value has #pval-mirror kept in sync on input, log2FC
+        had no mirror at all — so typing a custom threshold and pressing "Run
+        Enrichment Analysis" without first pressing "Update Plot" ran the
+        analysis on the previous threshold while the box showed the new one.
+        This asserts the hook the sync attaches to exists.
+        """
+        import pandas as pd
+        from unittest.mock import patch
+
+        mock_df = pd.DataFrame({
+            'Gene_Symbol': ['BRCA1', 'TP53', 'EGFR'],
+            'log2FoldChange': [2.5, -1.2, 0.8],
+            'padj': [0.001, 0.05, 0.3],
+        })
+        with patch('os.path.exists', side_effect=uploaded_file_exists), \
+             patch('pandas.read_csv', return_value=mock_df):
+            response = flask_client.post('/preview', data={
+                'demo_file': 'GSE90122_TO90137.tsv',
+                'columns_confirmed': 'true',
+                'id_column': 'Gene_Symbol',
+                'fc_column': 'log2FoldChange',
+                'pval_column': 'padj',
+            })
+
+        assert response.status_code == 200
+        body = response.data.decode()
+        assert 'id="pval-mirror"' in body     # control: the mirror that already worked
+        assert 'id="logfc-mirror"' in body    # the one that was missing
+        assert "getElementById('logfc-mirror')" in body, "mirror element exists but nothing syncs it"
+
     def test_preview_without_recommended_aops_hides_filter_toggle(self, flask_client):
         """POST /preview WITHOUT recommended_aops (upload-your-own path) hides the toggle (D-07)."""
         import pandas as pd


### PR DESCRIPTION
Two pieces of state on the analysis page did not survive the HTMX swap. Found while reviewing the demo flow ahead of the OpenTox summer school.

## 1. The chosen AOP silently reverted to the demo's

Pick a demo dataset, press **Show all AOPs**, choose something other than the recommended AOP, then click any log2FC quick button or **Update Plot**:

| | before | after |
|---|---|---|
| `aop_selection` | `AOP:464` → `AOP:DEMO` | `AOP:464` holds |
| `aop_filter_mode` | `all` → `recommended` | `all` holds |

The quick buttons auto-submit, so this needed no deliberate action — and the analysis then ran against an AOP the user had not chosen, with no indication on the results page.

**Cause.** The threshold controls submit `#volcanoForm`; the AOP picker lives in `#enrichmentForm`. That split is why the resource checkboxes (#55) and the confidence select (#60) each needed a mirror. `aop_selection` and `aop_filter_mode` never got one, so they were not posted, `/preview` had nothing to echo back, and the picker re-rendered with no value. The recommended-AOP auto-select then read the empty picker as "never chosen" and overwrote the pick — doing precisely what its own comment promised it would not:

```js
// Only kicks in when the picker is empty (so we never clobber a manual selection …)
if (recommendedAops.length === 1 && !hiddenInput.value && !searchInput.value) {
```

The guard was correct in intent and could never hold, because after a swap the picker was always empty.

**Fix.** Mirror the selection, its label and the filter mode into `#volcanoForm`, and round-trip all three through `/preview`. Only the browser knows the display label — the server has the id — so the label rides along.

The mirror is written both as hidden inputs and, authoritatively, into `evt.detail.parameters` on `htmx:configRequest`. Hidden inputs alone were not enough: they are only refreshed at the call sites that mutate the picker, so any other path that sets it — `tour.js`'s `preselectPxrAop`, for one — left them stale. This was caught by testing that path rather than reasoning about it.

## 2. A custom log2FC threshold was ignored unless you pressed Update Plot first

`pval_threshold` had a hidden `#pval-mirror` kept in sync on every keystroke; `logfc_threshold` had no mirror at all. Typing `2.5` into Custom and pressing **Run Enrichment Analysis** ran on the *previous* threshold while the box on screen read `2.5` — wrong numbers, no error. Given the same mirror the p-value box has.

## Verification

Journey replayed in Chromium against both versions; the table above is that run. All three demo entry points then walked end to end:

- single demo dataset → preview → confirm → Analyse → results
- guided tour — all four preview steps, AOP preselected, Analyse → results table
- one-click batch demo → progress → compare page, 2 conditions

Suite: **649 passed**. Three new server-side tests cover the round-trip; two of them confirmed failing against the unfixed code (the third guards the new filter-mode whitelist).

Note the browser check is not in CI — Playwright is not in `requirements-dev`, so the client-side mirror has no automated guard. Worth a follow-up.